### PR TITLE
remove manifest download endpoint from campaign launcher server

### DIFF
--- a/campaign-launcher/server/src/modules/manifest/manifest.controller.ts
+++ b/campaign-launcher/server/src/modules/manifest/manifest.controller.ts
@@ -1,8 +1,7 @@
-import { Body, Controller, Get, Post, Query } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import {
-  ManifestDto,
   ManifestUploadRequestDto,
   ManifestUploadResponseDto,
 } from './manifest.dto';
@@ -23,17 +22,5 @@ export class ManifestController {
   @ApiResponse({ status: 400, description: 'Bad Request' })
   async uploadManifest(@Body() data: ManifestUploadRequestDto) {
     return this.manifestService.uploadManifest(data);
-  }
-
-  @Get('/download')
-  @ApiOperation({ summary: 'Download manifest data' })
-  @ApiResponse({
-    status: 200,
-    description: 'Manifest downloaded',
-    type: ManifestDto,
-  })
-  @ApiResponse({ status: 400, description: 'Bad Request' })
-  async downloadManifest(@Query('hash') hash: string) {
-    return this.manifestService.downloadManifest(hash);
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Removed `/api/campaign/download` endpoint.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->
I removed the controller for the endpoint.

## How to test the changes

<!-- If there are any special testing requirements, add them here -->
Check the swagger doc from preview deployment

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #29 