### PR TITLE
fix manifest https google cloud storage

### DIFF
--- a/campaign-launcher/interface/src/hooks/human-protocol-sdk/escrow.ts
+++ b/campaign-launcher/interface/src/hooks/human-protocol-sdk/escrow.ts
@@ -92,7 +92,7 @@ export const useCampaigns = (chainId: ChainId) => {
               if (campaign.manifestUrl) {
                 // @dev Temporary fix to handle http/https issue
                 const url = campaign.manifestUrl.replace(
-                  'http://storage.googleapis.com',
+                  'http://storage.googleapis.com:80',
                   'https://storage.googleapis.com'
                 );
                 manifest = await fetch(url).then((res) => res.json());

--- a/campaign-launcher/interface/src/hooks/human-protocol-sdk/escrow.ts
+++ b/campaign-launcher/interface/src/hooks/human-protocol-sdk/escrow.ts
@@ -90,9 +90,12 @@ export const useCampaigns = (chainId: ChainId) => {
 
             try {
               if (campaign.manifestUrl) {
-                manifest = await fetch(campaign.manifestUrl).then((res) =>
-                  res.json()
+                // @dev Temporary fix to handle http/https issue
+                const url = campaign.manifestUrl.replace(
+                  'http://storage.googleapis.com',
+                  'https://storage.googleapis.com'
                 );
+                manifest = await fetch(url).then((res) => res.json());
               }
             } catch {
               manifest = undefined;


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
There are some manifest URL that has `http` instead of `https` for the google cloud storage objects. The server was not configured to use SSL, so this insecure URL is generated. It's already on-chain data, so need to replace it with https from front-end.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->
- Added a string replacement from `http://storage.googleapis.com` to `https://storage.googleapis.com`

## How to test the changes

<!-- If there are any special testing requirements, add them here -->
Check if dashboard main page is displayed.

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
