### PR TITLE
[Recording Oracle] feat: add API key protection

### DIFF
--- a/recording-oracle/.env.example
+++ b/recording-oracle/.env.example
@@ -3,6 +3,7 @@ NODE_ENV="development"
 HOST="localhost"
 PORT=5001
 SESSION_SECRET="secret"
+API_KEY="api-key"
 
 # Database
 POSTGRES_HOST="localhost"

--- a/recording-oracle/src/common/config/env-schema.ts
+++ b/recording-oracle/src/common/config/env-schema.ts
@@ -6,6 +6,7 @@ export const envValidator = Joi.object({
   HOST: Joi.string(),
   PORT: Joi.string(),
   SESSION_SECRET: Joi.string(),
+  API_KEY: Joi.string(),
   // Datbase
   POSTGRES_HOST: Joi.string().default('localhost'),
   POSTGRES_USER: Joi.string().default('user'),

--- a/recording-oracle/src/common/config/server-config.service.ts
+++ b/recording-oracle/src/common/config/server-config.service.ts
@@ -16,4 +16,7 @@ export class ServerConfigService {
   get sessionSecret(): string {
     return this.configService.get<string>('SESSION_SECRET', 'session-secret');
   }
+  get apiKey(): string {
+    return this.configService.get<string>('API_KEY', 'api-key');
+  }
 }

--- a/recording-oracle/src/common/guards/api-key.guard.ts
+++ b/recording-oracle/src/common/guards/api-key.guard.ts
@@ -1,0 +1,30 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+
+import { ServerConfigService } from '../config/server-config.service';
+
+@Injectable()
+export class ApiKeyGuard implements CanActivate {
+  constructor(private serverConfigService: ServerConfigService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+
+    const apiKey = request.headers['x-api-key'];
+
+    if (!apiKey) {
+      throw new UnauthorizedException('API key is missing.');
+    }
+
+    // call your env. var the name you want
+    if (apiKey !== this.serverConfigService.apiKey) {
+      throw new UnauthorizedException('Invalid API key.');
+    }
+
+    return true;
+  }
+}

--- a/recording-oracle/src/modules/records/records.controller.ts
+++ b/recording-oracle/src/modules/records/records.controller.ts
@@ -4,8 +4,17 @@ import {
   Body,
   HttpException,
   HttpStatus,
+  UseGuards,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBody, ApiResponse } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBody,
+  ApiResponse,
+  ApiHeader,
+} from '@nestjs/swagger';
+
+import { ApiKeyGuard } from '../../common/guards/api-key.guard';
 
 import { RecordsService } from './records.service';
 import { RequestDto } from './request.dto';
@@ -15,11 +24,16 @@ import { RequestDto } from './request.dto';
 export class RecordsController {
   constructor(private readonly recordsService: RecordsService) {}
 
+  @UseGuards(ApiKeyGuard)
   @Post('calculate-liquidity-score')
   @ApiOperation({
     summary: 'Calculate liquidity score',
     description:
-      'Calculates the liquidity score for a given exchange, symbol, and user based on trades and open orders.',
+      "Calculates the liquidity score for a given exchange, symbol, and user based on trades and open orders.\n\n*This endpoint will be deprecated once it's confirmed that the cron job is running correctly.*",
+  })
+  @ApiHeader({
+    name: 'x-api-key',
+    description: 'API key for authentication',
   })
   @ApiBody({
     description: 'Payload to calculate liquidity score',

--- a/recording-oracle/src/modules/user/user.controller.ts
+++ b/recording-oracle/src/modules/user/user.controller.ts
@@ -1,18 +1,32 @@
-import { Body, Controller, Post } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBody,
+  ApiHeader,
+} from '@nestjs/swagger';
+
+import { ApiKeyGuard } from '../../common/guards/api-key.guard';
 
 import { SignUpUserDto } from './user.dto';
 import { UserService } from './user.service';
 
-@ApiTags('users') // Tags this controller for swagger documentation under "users"
+@ApiTags('users')
 @Controller('users')
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
+  @UseGuards(ApiKeyGuard)
   @Post('signup')
   @ApiOperation({
     summary: 'Sign up a user',
-    description: 'Registers user and associates them with a campaign.',
+    description:
+      'Registers user and associates with a campaign.\n\n*Security Warning: Please provide the **Read-Only** API key and secret for the exchange.*',
+  })
+  @ApiHeader({
+    name: 'x-api-key',
+    description: 'API key for authentication',
   })
   @ApiBody({
     type: SignUpUserDto,
@@ -22,7 +36,7 @@ export class UserController {
     status: 201,
     description: 'User signed up successfully',
     type: Object,
-  }) // Customize the response object as needed
+  })
   @ApiResponse({ status: 400, description: 'Bad request' })
   async signUp(@Body() signUpUserDto: SignUpUserDto) {
     const { userId, walletAddress, exchange, apiKey, secret, campaignAddress } =

--- a/recording-oracle/src/modules/user/user.dto.ts
+++ b/recording-oracle/src/modules/user/user.dto.ts
@@ -3,13 +3,16 @@ import { ApiProperty } from '@nestjs/swagger';
 export class SignUpUserDto {
   @ApiProperty({ example: '1', description: 'UserID' })
   userId: string;
-  @ApiProperty({ description: 'Wallet Address to receive rewards' })
+  @ApiProperty({
+    example: '0x00',
+    description: 'Wallet Address to receive rewards',
+  })
   walletAddress: string;
   @ApiProperty({ example: 'binance', description: 'Exchange name' })
   exchange: string;
   @ApiProperty({ example: 'xxx', description: 'API Key for the Exchange' })
   apiKey: string;
-  @ApiProperty({ example: 'xxx', description: 'API SECRET for the Exchange' })
+  @ApiProperty({ example: 'xxx', description: 'API Secret for the Exchange' })
   secret: string;
   @ApiProperty({
     example: '0x00',


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
- Added `x-api-key` header for authentication.
- Updated swagger doc.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->
From the security perspective, we need to protect the API endpoints, since it'll be used from other services like campaign launcher server / Mr.market.

## How to test the changes

<!-- If there are any special testing requirements, add them here -->
Try API endpoints on Swagger with/without api key.

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #48 