### PR TITLE
feat: add recording oracle endpoint for Mr.Market

### DIFF
--- a/recording-oracle/src/app.module.ts
+++ b/recording-oracle/src/app.module.ts
@@ -18,6 +18,7 @@ import { CampaignModule } from './modules/campaign/campaign.module';
 import { ExchangeModule } from './modules/exchange/exchange.module';
 import { HealthModule } from './modules/health/health.module';
 import { LiquidityScoreModule } from './modules/liquidity-score/liquidity-score.module';
+import { MrMarketModule } from './modules/mr-market/mr-market.module';
 import { RecordsModule } from './modules/records/records.module';
 import { StorageModule } from './modules/storage/storage.module';
 import { UserModule } from './modules/user/user.module';
@@ -57,6 +58,7 @@ import { Web3Module } from './modules/web3/web3.module';
     StorageModule,
     Web3Module,
     LiquidityScoreModule,
+    MrMarketModule,
     ServeStaticModule.forRoot({
       rootPath: join(__dirname, '././modules/', 'node_modules/swagger-ui-dist'),
     }),

--- a/recording-oracle/src/common/constants/errors.ts
+++ b/recording-oracle/src/common/constants/errors.ts
@@ -44,3 +44,10 @@ export enum ErrorCampaign {
   InvalidChainId = 'Invalid chain id',
   InvalidCampaignData = 'Invalid campaign data',
 }
+
+export enum ErrorMrMarket {
+  WalletAlreadyExists = 'Wallet already exists',
+  CampaignAlreadyRegistered = 'Mr.Market already registered for the campaign',
+  ExchangeAPIKeyExists = 'Exchange API key already exists',
+  InvalidCampaign = 'Invalid campaign',
+}

--- a/recording-oracle/src/modules/mr-market/mr-market.controller.ts
+++ b/recording-oracle/src/modules/mr-market/mr-market.controller.ts
@@ -1,0 +1,50 @@
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBody,
+  ApiHeader,
+} from '@nestjs/swagger';
+
+import { ApiKeyGuard } from '../../common/guards/api-key.guard';
+
+import {
+  CampaignRegisterRequestDto,
+  CampaignRegisterResponseDto,
+} from './mr-market.dto';
+import { MrMarketService } from './mr-market.service';
+
+@ApiTags('Mr.Market')
+@Controller('mr-market')
+export class MrMarketController {
+  constructor(private readonly mrMarketService: MrMarketService) {}
+
+  @Post('campaign')
+  @UseGuards(ApiKeyGuard)
+  @ApiHeader({
+    name: 'x-api-key',
+    description: 'API key for authentication',
+  })
+  @ApiOperation({
+    summary: 'Register Mr.Market to the campaign',
+    description:
+      'Registers Mr.Market to the campaign. Exchange API key is required to be registered.',
+  })
+  @ApiBody({
+    type: CampaignRegisterRequestDto,
+    description: 'Wallet address, Campaign details, and Exchange API key.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Registered Mr.Market to the campaign successfully.',
+    type: CampaignRegisterResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Bad request' })
+  public async registerForCampaign(
+    @Body() data: CampaignRegisterRequestDto,
+  ): Promise<CampaignRegisterResponseDto> {
+    await this.mrMarketService.registerToCampaign(data);
+    return { success: true };
+  }
+}

--- a/recording-oracle/src/modules/mr-market/mr-market.dto.ts
+++ b/recording-oracle/src/modules/mr-market/mr-market.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsBoolean,
+  IsEthereumAddress,
+  IsNumber,
+  IsString,
+} from 'class-validator';
+
+export class CampaignRegisterRequestDto {
+  @ApiProperty({
+    name: 'wallet_address',
+    description: 'Address of the wallet',
+  })
+  @IsString()
+  @IsEthereumAddress()
+  public walletAddress: string;
+
+  @ApiProperty({
+    name: 'chain_id',
+    description: 'Chain ID of the campaign',
+  })
+  @IsNumber()
+  public chainId: number;
+
+  @ApiProperty({
+    name: 'address',
+    description: 'Address of the campaign',
+  })
+  @IsString()
+  @IsEthereumAddress()
+  public address: string;
+
+  @ApiProperty({
+    name: 'exchange_name',
+    description: 'Name of the exchange',
+  })
+  @IsString()
+  public exchangeName: string;
+
+  @ApiProperty({
+    name: 'api_key',
+    description: 'Read-only API key for the exchange',
+  })
+  @IsString()
+  public apiKey: string;
+
+  @ApiProperty({
+    name: 'secret',
+    description: 'Read-only API secret for the exchange',
+  })
+  @IsString()
+  public secret: string;
+}
+
+export class CampaignRegisterResponseDto {
+  @ApiProperty({
+    name: 'success',
+    description: 'Whether the registration was successful',
+  })
+  @IsBoolean()
+  public success: boolean;
+}

--- a/recording-oracle/src/modules/mr-market/mr-market.module.ts
+++ b/recording-oracle/src/modules/mr-market/mr-market.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+
+import { CampaignModule } from '../campaign/campaign.module';
+import { UserModule } from '../user/user.module';
+
+import { MrMarketController } from './mr-market.controller';
+import { MrMarketService } from './mr-market.service';
+
+@Module({
+  imports: [CampaignModule, UserModule],
+  providers: [MrMarketService],
+  controllers: [MrMarketController],
+  exports: [MrMarketService],
+})
+export class MrMarketModule {}

--- a/recording-oracle/src/modules/mr-market/mr-market.service.ts
+++ b/recording-oracle/src/modules/mr-market/mr-market.service.ts
@@ -1,0 +1,69 @@
+import { HttpStatus, Injectable, Logger } from '@nestjs/common';
+
+import { ErrorMrMarket, ErrorUser } from '../../common/constants/errors';
+import { ControlledError } from '../../common/errors/controlled';
+import { isCenteralizedExchange } from '../../common/utils/exchange';
+import { UserEntity } from '../../database/entities';
+import { CampaignService } from '../campaign/campaign.service';
+import { UserService } from '../user/user.service';
+
+import { CampaignRegisterRequestDto } from './mr-market.dto';
+
+@Injectable()
+export class MrMarketService {
+  private readonly logger = new Logger(MrMarketService.name);
+
+  constructor(
+    private campaignService: CampaignService,
+    private userService: UserService,
+  ) {}
+
+  public async createOrGetMrMarketUser(address: string): Promise<UserEntity> {
+    try {
+      await this.userService.createWeb3User(address);
+    } catch (e) {
+      if (e.message !== ErrorUser.AlreadyExists) {
+        throw e;
+      }
+    }
+    return await this.userService.getByAddress(address);
+  }
+
+  public async registerToCampaign(data: CampaignRegisterRequestDto) {
+    const user = await this.createOrGetMrMarketUser(data.walletAddress);
+    const campaign = await this.campaignService.createCampaignIfNotExists(data);
+
+    if (user.campaigns?.some((c) => c.id === campaign.id)) {
+      throw new ControlledError(
+        ErrorMrMarket.CampaignAlreadyRegistered,
+        HttpStatus.CONFLICT,
+      );
+    }
+
+    try {
+      await this.userService.createExchangeAPIKey(user, {
+        exchangeName: data.exchangeName,
+        apiKey: data.apiKey,
+        secret: data.secret,
+      });
+    } catch (e) {
+      if (e.message !== ErrorMrMarket.ExchangeAPIKeyExists) {
+        throw e;
+      }
+    }
+
+    if (!isCenteralizedExchange(campaign.exchangeName)) {
+      throw new ControlledError(
+        ErrorMrMarket.InvalidCampaign,
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    if (user.campaigns) {
+      user.campaigns.push(campaign);
+    } else {
+      user.campaigns = [campaign];
+    }
+    await user.save();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal of this pull request. What does it change or fix? -->
Added `/mr-market/campaign` endpoint that is protected by API key.
This allows Mr.Market to join the campaign directly without auth.

## Summary of changes

<!-- At a high level, what parts of the code did you change and why? -->

## How to test the changes

<!-- If there are any special testing requirements, add them here -->

## Related issues
[Keywords for linking issues](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

<!-- Does this close any open issues? -->
Closes #122 