### PR TITLE
[Recording Oracle] feat: initial migration w/ setup

### DIFF
--- a/recording-oracle/package.json
+++ b/recording-oracle/package.json
@@ -13,11 +13,17 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,test}/**/*.ts\" --fix",
+    "migration:create": "yarn typeorm migration:create",
+    "migration:generate": "yarn typeorm migration:generate -d typeorm-migrations-datasource.ts",
+    "migration:revert": "yarn typeorm migration:revert -d typeorm-migrations-datasource.ts",
+    "migration:run": "yarn typeorm migration:run -d typeorm-migrations-datasource.ts",
+    "migration:show": "yarn typeorm migration:show -d typeorm-migrations-datasource.ts",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "typeorm": "typeorm-ts-node-commonjs"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/recording-oracle/src/common/constants/index.ts
+++ b/recording-oracle/src/common/constants/index.ts
@@ -1,0 +1,1 @@
+export const DATABASE_SCHEMA_NAME = 'hu_fi';

--- a/recording-oracle/src/database/migrations/1748865118682-initial-setup.ts
+++ b/recording-oracle/src/database/migrations/1748865118682-initial-setup.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+import { DATABASE_SCHEMA_NAME } from '../../common/constants';
+
+export class InitialSetup1748865118682 implements MigrationInterface {
+  name = 'InitialSetup1748865118682';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createSchema(DATABASE_SCHEMA_NAME, true);
+
+    await queryRunner.query(
+      `CREATE TABLE "hu_fi"."users" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "evm_address" character varying(42) NOT NULL, "nonce" character varying(32) NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL, "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "PK_a3ffb1c0c8416b9fc6f907b7433" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_6009c050ae797d7e13ba0b0759" ON "hu_fi"."users" ("evm_address") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "hu_fi"."refresh_tokens" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "user_id" uuid NOT NULL, "expires_at" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "PK_7d8bee0204106019488c4c50ffa" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_3ddc983c5f7bcf132fd8732c3f" ON "hu_fi"."refresh_tokens" ("user_id") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hu_fi"."refresh_tokens" ADD CONSTRAINT "FK_3ddc983c5f7bcf132fd8732c3f4" FOREIGN KEY ("user_id") REFERENCES "hu_fi"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "hu_fi"."refresh_tokens" DROP CONSTRAINT "FK_3ddc983c5f7bcf132fd8732c3f4"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "hu_fi"."IDX_3ddc983c5f7bcf132fd8732c3f"`,
+    );
+    await queryRunner.query(`DROP TABLE "hu_fi"."refresh_tokens"`);
+    await queryRunner.query(
+      `DROP INDEX "hu_fi"."IDX_6009c050ae797d7e13ba0b0759"`,
+    );
+    await queryRunner.query(`DROP TABLE "hu_fi"."users"`);
+
+    await queryRunner.dropSchema(DATABASE_SCHEMA_NAME);
+  }
+}

--- a/recording-oracle/src/modules/auth/token.entity.ts
+++ b/recording-oracle/src/modules/auth/token.entity.ts
@@ -1,0 +1,26 @@
+import {
+  Column,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+import { DATABASE_SCHEMA_NAME } from '../../common/constants';
+import type { UserEntity } from '../users';
+
+@Entity({ schema: DATABASE_SCHEMA_NAME, name: 'refresh_tokens' })
+@Index(['userId'], { unique: true })
+export class RefreshTokenEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne('UserEntity', { persistence: false, onDelete: 'CASCADE' })
+  user?: UserEntity;
+
+  @Column()
+  userId: string;
+
+  @Column({ type: 'timestamptz' })
+  expiresAt: Date;
+}

--- a/recording-oracle/src/modules/users/index.ts
+++ b/recording-oracle/src/modules/users/index.ts
@@ -1,0 +1,1 @@
+export { UserEntity } from './user.entity';

--- a/recording-oracle/src/modules/users/user.entity.ts
+++ b/recording-oracle/src/modules/users/user.entity.ts
@@ -1,0 +1,22 @@
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+import { DATABASE_SCHEMA_NAME } from '../../common/constants';
+
+@Entity({ schema: DATABASE_SCHEMA_NAME, name: 'users' })
+@Index(['evmAddress'], { unique: true })
+export class UserEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('varchar', { length: 42 })
+  evmAddress: string;
+
+  @Column('varchar', { length: 32 })
+  nonce: string;
+
+  @Column({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @Column({ type: 'timestamptz' })
+  updatedAt: Date;
+}

--- a/recording-oracle/typeorm-migrations-datasource.ts
+++ b/recording-oracle/typeorm-migrations-datasource.ts
@@ -1,0 +1,37 @@
+import * as dotenv from 'dotenv';
+import { DataSource } from 'typeorm';
+import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
+
+import Environment from './src/utils/environment';
+
+dotenv.config({
+  /**
+   * First value wins if "override" option is not set
+   */
+  path: [`.env.${Environment.name}`, '.env'],
+});
+
+const connectionUrl = process.env.POSTGRES_URL;
+
+export default new DataSource({
+  type: 'postgres',
+  useUTC: true,
+  ...(connectionUrl
+    ? {
+        url: connectionUrl,
+      }
+    : {
+        host: process.env.POSTGRES_HOST,
+        port: Number(process.env.POSTGRES_PORT),
+        username: process.env.POSTGRES_USER,
+        password: process.env.POSTGRES_PASSWORD,
+        database: process.env.POSTGRES_DATABASE,
+      }),
+  ssl: process.env.POSTGRES_SSL?.toLowerCase() === 'true',
+  synchronize: false,
+  migrationsRun: true,
+  migrations: ['src/database/migrations/*.ts'],
+  migrationsTableName: 'migrations_typeorm',
+  namingStrategy: new SnakeNamingStrategy(),
+  entities: ['src/modules/**/*.entity.ts'],
+});


### PR DESCRIPTION
## Description
Added setup for typeorm migration & initial migration

## Summary of changes
- added necessary initial entities as per issue description
- added package scripts to work with migrations & migrations setup
- added initial migration

## How to test the changes
Prerequisites:
- have DB running (via `docker compose up -d`
- have `.env.local` (`NODE_ENV=local` is needed before command then; you can use `.env` if want defauls)

Manual tests:
- [x] use `NODE_ENV=local yarn migration:generate initial-migration` to create initial migration
- [x] `NODE_ENV=local yarn migration:run` on local to make sure it creates necessary schema and tables; attempt to create rows via DataGrip to ensure `uuid` auto-generation, column validation and relations
- [x] `NODE_ENV=local yarn migration:show` to check the status of migration
- [x] `NODE_ENV=local yarn migration:revert` to check if it reverts
- [x] check `public/migrations_typeorm` table to ensure proper typeorm migration refs

## Related issues
Closes https://github.com/Hu-Fi/hufi/issues/213
