### PR TITLE
[Campaign-launcher] Fix token info for all campaigns

### DIFF
--- a/campaign-launcher/server/src/modules/campaign/campaign.service.ts
+++ b/campaign-launcher/server/src/modules/campaign/campaign.service.ts
@@ -54,11 +54,11 @@ export class CampaignService {
                 symbol: manifest.token.toLowerCase(),
                 tokenSymbol: await this.web3Service.getTokenSymbol(
                   campaign.token,
-                  chainId,
+                  campaign.chainId,
                 ),
                 tokenDecimals: await this.web3Service.getTokenDecimals(
                   campaign.token,
-                  chainId,
+                  campaign.chainId,
                 ),
               } as CampaignDataDto;
             } catch (err) {


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
When filtering campaigns across all networks, the chainId parameter is set to -1 (representing "ALL"). This caused an error when fetching transactions, because the code was using this -1 value instead of the actual chain ID of each campaign. The fix was to use the campaign’s own chainId property when retrieving transactions, ensuring the correct network is queried for each campaign.

## How has this been tested?
Ran locally

## Potential risks; What to monitor; Rollback plan
None