### PR TITLE
[Recording Oracle] test: campaigns service

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -1,0 +1,28 @@
+name: Unit tests
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Enable corepack
+        run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+          cache-dependency-path: '**/yarn.lock'
+      - name: Install root dependencies
+        run: yarn
+      - name: Run setup
+        run: yarn setup
+      - name: Run test
+        run: yarn test

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "cd scripts && make start",
     "lint": "cd scripts && make lint",
     "lint:fix": "cd scripts && make lint-fix",
-    "format": "cd scripts && make format"
+    "format": "cd scripts && make format",
+    "test": "cd scripts && make test"
   },
   "packageManager": "yarn@4.9.1",
   "devDependencies": {

--- a/recording-oracle/package.json
+++ b/recording-oracle/package.json
@@ -72,6 +72,7 @@
     "eslint-plugin-prettier": "^5.2.2",
     "globals": "^16.2.0",
     "jest": "^29.7.0",
+    "nock": "^14.0.5",
     "pino-pretty": "^13.0.0",
     "prettier": "^3.4.2",
     "supertest": "^7.0.0",

--- a/recording-oracle/src/common/types/index.ts
+++ b/recording-oracle/src/common/types/index.ts
@@ -1,1 +1,2 @@
+export * from './manifest';
 export * from './request';

--- a/recording-oracle/src/common/types/manifest.ts
+++ b/recording-oracle/src/common/types/manifest.ts
@@ -1,0 +1,7 @@
+export type CampaignManifest = {
+  exchange: string;
+  pair: string;
+  fund_token: string;
+  start_date: Date;
+  end_date: Date;
+};

--- a/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
@@ -1,0 +1,243 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+jest.mock('@human-protocol/sdk');
+jest.mock('@/logger');
+
+import { faker } from '@faker-js/faker';
+import { createMock } from '@golevelup/ts-jest';
+import { EscrowClient, EscrowStatus, EscrowUtils } from '@human-protocol/sdk';
+import { Test } from '@nestjs/testing';
+
+import { Web3ConfigService } from '@/config';
+import logger from '@/logger';
+import { ExchangeApiKeysRepository } from '@/modules/exchange-api-keys';
+import { Web3Service } from '@/modules/web3';
+import {
+  generateTestnetChainId,
+  mockWeb3ConfigService,
+} from '@/modules/web3/fixtures';
+import * as manifestUtils from '@/utils/manifest';
+
+import { CampaignNotFoundError, InvalidCampaign } from './campaigns.errors';
+import { CampaignsRepository } from './campaigns.repository';
+import { CampaignsService } from './campaigns.service';
+import { UserCampaignsRepository } from './user-campaigns.repository';
+import { generateCampaignManifest } from './fixtures';
+
+const mockCampaignsRepository = createMock<CampaignsRepository>();
+const mockUserCampaignsRepository = createMock<UserCampaignsRepository>();
+const mockExchangeApiKeysRepository = createMock<ExchangeApiKeysRepository>();
+
+const mockedEscrowClient = jest.mocked(EscrowClient);
+const mockedEscrowUtils = jest.mocked(EscrowUtils);
+
+describe('CampaignsService', () => {
+  let campaignsService: CampaignsService;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        CampaignsService,
+        {
+          provide: CampaignsRepository,
+          useValue: mockCampaignsRepository,
+        },
+        {
+          provide: UserCampaignsRepository,
+          useValue: mockUserCampaignsRepository,
+        },
+        {
+          provide: ExchangeApiKeysRepository,
+          useValue: mockExchangeApiKeysRepository,
+        },
+        {
+          provide: Web3ConfigService,
+          useValue: mockWeb3ConfigService,
+        },
+        Web3Service,
+      ],
+    }).compile();
+
+    campaignsService = moduleRef.get<CampaignsService>(CampaignsService);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(campaignsService).toBeDefined();
+  });
+
+  describe('retrieveCampaignManifest', () => {
+    const mockedGetEscrowStatus = jest.fn();
+
+    let spyOnDownloadCampaignManifest: jest.SpyInstance;
+    let chainId: number;
+    let campaignAddress: string;
+
+    beforeAll(() => {
+      spyOnDownloadCampaignManifest = jest.spyOn(
+        manifestUtils,
+        'downloadCampaignManifest',
+      );
+      spyOnDownloadCampaignManifest.mockImplementation();
+    });
+
+    afterAll(() => {
+      spyOnDownloadCampaignManifest.mockRestore();
+    });
+
+    beforeEach(() => {
+      chainId = generateTestnetChainId();
+      campaignAddress = faker.finance.ethereumAddress();
+
+      mockedEscrowClient.build.mockResolvedValue({
+        getStatus: mockedGetEscrowStatus,
+      } as unknown as EscrowClient);
+    });
+
+    it('should throw when escrow not found', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      mockedEscrowUtils.getEscrow.mockResolvedValueOnce(null as any);
+
+      let thrownError;
+      try {
+        await campaignsService['retrieveCampaignManifest'](
+          chainId,
+          campaignAddress,
+        );
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeInstanceOf(CampaignNotFoundError);
+      expect(thrownError.address).toBe(campaignAddress);
+
+      expect(mockedEscrowUtils.getEscrow).toHaveBeenCalledWith(
+        chainId,
+        campaignAddress,
+      );
+    });
+
+    it('should throw when escrow is for different recording oracle', async () => {
+      const escrowRecordingOracle = faker.finance.ethereumAddress();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      mockedEscrowUtils.getEscrow.mockResolvedValueOnce({
+        recordingOracle: escrowRecordingOracle,
+      } as any);
+
+      let thrownError;
+      try {
+        await campaignsService['retrieveCampaignManifest'](
+          chainId,
+          campaignAddress,
+        );
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeInstanceOf(InvalidCampaign);
+      expect(thrownError.address).toBe(campaignAddress);
+      expect(thrownError.details).toBe(
+        `Invalid recording oracle address: ${escrowRecordingOracle}`,
+      );
+
+      expect(mockedEscrowUtils.getEscrow).toHaveBeenCalledWith(
+        chainId,
+        campaignAddress,
+      );
+    });
+
+    it.each([EscrowStatus.Cancelled, EscrowStatus.Complete])(
+      'should throw when escrow has invalid status [%#]',
+      async (escrowStatus) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        mockedEscrowUtils.getEscrow.mockResolvedValueOnce({
+          recordingOracle: mockWeb3ConfigService.operatorAddress,
+        } as any);
+        mockedGetEscrowStatus.mockResolvedValueOnce(escrowStatus);
+
+        let thrownError;
+        try {
+          await campaignsService['retrieveCampaignManifest'](
+            chainId,
+            campaignAddress,
+          );
+        } catch (error) {
+          thrownError = error;
+        }
+
+        expect(thrownError).toBeInstanceOf(InvalidCampaign);
+        expect(thrownError.address).toBe(campaignAddress);
+        expect(thrownError.details).toBe(
+          `Invalid status: ${EscrowStatus[escrowStatus]}`,
+        );
+
+        expect(mockedEscrowUtils.getEscrow).toHaveBeenCalledWith(
+          chainId,
+          campaignAddress,
+        );
+
+        expect(mockedGetEscrowStatus).toHaveBeenCalledWith(campaignAddress);
+      },
+    );
+
+    it('should log and throw when fails to download manifest', async () => {
+      const manifestUrl = faker.internet.url();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      mockedEscrowUtils.getEscrow.mockResolvedValueOnce({
+        manifestUrl,
+        recordingOracle: mockWeb3ConfigService.operatorAddress,
+      } as any);
+      mockedGetEscrowStatus.mockResolvedValueOnce(EscrowStatus.Pending);
+
+      const syntheticError = new Error(faker.lorem.sentence());
+      spyOnDownloadCampaignManifest.mockRejectedValueOnce(syntheticError);
+
+      let thrownError;
+      try {
+        await campaignsService['retrieveCampaignManifest'](
+          chainId,
+          campaignAddress,
+        );
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeInstanceOf(InvalidCampaign);
+      expect(thrownError.address).toBe(campaignAddress);
+
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledWith(
+        'Failed to download campaign manifest',
+        syntheticError,
+      );
+
+      expect(spyOnDownloadCampaignManifest).toHaveBeenCalledTimes(1);
+      expect(spyOnDownloadCampaignManifest).toHaveBeenCalledWith(manifestUrl);
+    });
+
+    it('should download and return manifest', async () => {
+      const manifestUrl = faker.internet.url();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      mockedEscrowUtils.getEscrow.mockResolvedValueOnce({
+        manifestUrl,
+        recordingOracle: mockWeb3ConfigService.operatorAddress,
+      } as any);
+      mockedGetEscrowStatus.mockResolvedValueOnce(EscrowStatus.Pending);
+
+      const mockedManifest = generateCampaignManifest();
+      spyOnDownloadCampaignManifest.mockResolvedValueOnce(mockedManifest);
+
+      const manifest = await campaignsService['retrieveCampaignManifest'](
+        chainId,
+        campaignAddress,
+      );
+
+      expect(manifest).toEqual(mockedManifest);
+
+      expect(spyOnDownloadCampaignManifest).toHaveBeenCalledTimes(1);
+      expect(spyOnDownloadCampaignManifest).toHaveBeenCalledWith(manifestUrl);
+    });
+  });
+});

--- a/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
@@ -355,7 +355,6 @@ describe('CampaignsService', () => {
       );
       const campaignManifest = generateCampaignManifest();
       spyOnRetrieveCampaignManifest.mockResolvedValueOnce(campaignManifest);
-      spyOnCreateCampaign.mockResolvedValueOnce(campaign);
 
       mockUserCampaignsRepository.checkUserJoinedCampaign.mockResolvedValueOnce(
         false,
@@ -368,9 +367,13 @@ describe('CampaignsService', () => {
       const now = new Date();
       jest.useFakeTimers();
 
-      const id = await campaignsService.join(userId, chainId, campaignAddress);
+      const campaignId = await campaignsService.join(
+        userId,
+        chainId,
+        campaignAddress,
+      );
 
-      expect(id).toBe(campaign.id);
+      expect(isUuidV4(campaignId)).toBe(true);
 
       expect(spyOnRetrieveCampaignManifest).toHaveBeenCalledTimes(1);
       expect(spyOnRetrieveCampaignManifest).toHaveBeenCalledWith(
@@ -388,7 +391,7 @@ describe('CampaignsService', () => {
       expect(mockUserCampaignsRepository.insert).toHaveBeenCalledTimes(1);
       expect(mockUserCampaignsRepository.insert).toHaveBeenCalledWith({
         userId,
-        campaignId: campaign.id,
+        campaignId,
         exchangeApiKeyId: exchangeApiKey.id,
         createdAt: now,
       });

--- a/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
@@ -21,12 +21,13 @@ import {
   mockWeb3ConfigService,
 } from '@/modules/web3/fixtures';
 import * as manifestUtils from '@/utils/manifest';
+import { generateCampaignManifest } from '~/test/fixtures/manifest';
 
 import { CampaignEntity } from './campaign.entity';
 import { CampaignNotFoundError, InvalidCampaign } from './campaigns.errors';
 import { CampaignsRepository } from './campaigns.repository';
 import { CampaignsService } from './campaigns.service';
-import { generateCampaignEntity, generateCampaignManifest } from './fixtures';
+import { generateCampaignEntity } from './fixtures';
 import { UserCampaignsRepository } from './user-campaigns.repository';
 
 const mockCampaignsRepository = createMock<CampaignsRepository>();

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -3,6 +3,7 @@ import crypto from 'crypto';
 import { EscrowClient, EscrowStatus, EscrowUtils } from '@human-protocol/sdk';
 import { Injectable } from '@nestjs/common';
 
+import type { CampaignManifest } from '@/common/types';
 import { Web3ConfigService } from '@/config';
 import logger from '@/logger';
 import {
@@ -15,7 +16,7 @@ import { downloadCampaignManifest } from '@/utils/manifest';
 import { CampaignEntity } from './campaign.entity';
 import { CampaignNotFoundError, InvalidCampaign } from './campaigns.errors';
 import { CampaignsRepository } from './campaigns.repository';
-import { CampaignManifest, CampaignStatus } from './types';
+import { CampaignStatus } from './types';
 import { UserCampaignEntity } from './user-campaign.entity';
 import { UserCampaignsRepository } from './user-campaigns.repository';
 

--- a/recording-oracle/src/modules/campaigns/fixtures/index.ts
+++ b/recording-oracle/src/modules/campaigns/fixtures/index.ts
@@ -1,25 +1,13 @@
 import { faker } from '@faker-js/faker';
 
-import type { CampaignManifest } from '@/common/types';
-import { generateExchangeName } from '@/modules/exchange/fixtures';
 import { generateTestnetChainId } from '@/modules/web3/fixtures';
+import {
+  generateExchangeName,
+  generateTradingPair,
+} from '~/test/fixtures/manifest';
 
 import { CampaignEntity } from '../campaign.entity';
 import { CampaignStatus } from '../types';
-
-function generateTradingPair(): string {
-  return `${faker.finance.currencyCode()}/${faker.finance.currencyCode()}`;
-}
-
-export function generateCampaignManifest(): CampaignManifest {
-  return {
-    exchange: generateExchangeName(),
-    pair: generateTradingPair(),
-    fund_token: 'HMT',
-    start_date: faker.date.recent(),
-    end_date: faker.date.future(),
-  };
-}
 
 export function generateCampaignEntity(): CampaignEntity {
   const startDate = faker.date.soon();

--- a/recording-oracle/src/modules/campaigns/fixtures/index.ts
+++ b/recording-oracle/src/modules/campaigns/fixtures/index.ts
@@ -1,0 +1,14 @@
+import { faker } from '@faker-js/faker';
+
+import { SUPPORTED_EXCHANGE_NAMES } from '@/common/constants';
+import type { CampaignManifest } from '@/common/types';
+
+export function generateCampaignManifest(): CampaignManifest {
+  return {
+    exchange: faker.helpers.arrayElement(SUPPORTED_EXCHANGE_NAMES),
+    pair: `${faker.finance.currencyCode()}/${faker.finance.currencyCode()}`,
+    fund_token: 'HMT',
+    start_date: faker.date.recent(),
+    end_date: faker.date.future(),
+  };
+}

--- a/recording-oracle/src/modules/campaigns/fixtures/index.ts
+++ b/recording-oracle/src/modules/campaigns/fixtures/index.ts
@@ -1,14 +1,40 @@
 import { faker } from '@faker-js/faker';
 
-import { SUPPORTED_EXCHANGE_NAMES } from '@/common/constants';
 import type { CampaignManifest } from '@/common/types';
+import { generateExchangeName } from '@/modules/exchange/fixtures';
+import { generateTestnetChainId } from '@/modules/web3/fixtures';
+
+import { CampaignEntity } from '../campaign.entity';
+import { CampaignStatus } from '../types';
+
+function generateTradingPair(): string {
+  return `${faker.finance.currencyCode()}/${faker.finance.currencyCode()}`;
+}
 
 export function generateCampaignManifest(): CampaignManifest {
   return {
-    exchange: faker.helpers.arrayElement(SUPPORTED_EXCHANGE_NAMES),
-    pair: `${faker.finance.currencyCode()}/${faker.finance.currencyCode()}`,
+    exchange: generateExchangeName(),
+    pair: generateTradingPair(),
     fund_token: 'HMT',
     start_date: faker.date.recent(),
     end_date: faker.date.future(),
   };
+}
+
+export function generateCampaignEntity(): CampaignEntity {
+  const startDate = faker.date.soon();
+  const campaign = {
+    id: faker.string.uuid(),
+    chainId: generateTestnetChainId(),
+    address: faker.finance.ethereumAddress(),
+    pair: generateTradingPair(),
+    exchangeName: generateExchangeName(),
+    startDate: faker.date.soon(),
+    endDate: faker.date.soon({ refDate: startDate }),
+    status: CampaignStatus.ACTIVE,
+    createdAt: faker.date.recent(),
+    updatedAt: new Date(),
+  };
+
+  return campaign as CampaignEntity;
 }

--- a/recording-oracle/src/modules/campaigns/index.ts
+++ b/recording-oracle/src/modules/campaigns/index.ts
@@ -2,5 +2,3 @@ export { CampaignEntity } from './campaign.entity';
 export { UserCampaignEntity } from './user-campaign.entity';
 
 export { CampaignsModule } from './campaigns.module';
-
-export type { CampaignManifest } from './types';

--- a/recording-oracle/src/modules/campaigns/types.ts
+++ b/recording-oracle/src/modules/campaigns/types.ts
@@ -1,6 +1,6 @@
 /*
-    Internal status of the campaign in recording oracle database.
-    Used to simplify queries for results calculation and cancellation.
+  Internal status of the campaign in recording oracle database.
+  Used to simplify queries for results calculation and cancellation.
 */
 export enum CampaignStatus {
   ACTIVE = 'active',
@@ -8,11 +8,3 @@ export enum CampaignStatus {
   CANCELLED = 'cancelled',
   COMPLETED = 'completed',
 }
-
-export type CampaignManifest = {
-  exchange: string;
-  pair: string;
-  fund_token: string;
-  start_date: Date;
-  end_date: Date;
-};

--- a/recording-oracle/src/modules/exchange-api-keys/fixtures/index.ts
+++ b/recording-oracle/src/modules/exchange-api-keys/fixtures/index.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 
-import { generateExchangeName } from '@/modules/exchange/fixtures';
+import { generateExchangeName } from '~/test/fixtures/manifest';
 
 import { ExchangeApiKeyEntity } from '../exchange-api-key.entity';
 

--- a/recording-oracle/src/modules/exchange-api-keys/fixtures/index.ts
+++ b/recording-oracle/src/modules/exchange-api-keys/fixtures/index.ts
@@ -2,6 +2,8 @@ import { faker } from '@faker-js/faker';
 
 import { generateExchangeName } from '@/modules/exchange/fixtures';
 
+import { ExchangeApiKeyEntity } from '../exchange-api-key.entity';
+
 export function generateExchangeApiKeysData() {
   return {
     userId: faker.string.uuid(),
@@ -9,4 +11,15 @@ export function generateExchangeApiKeysData() {
     apiKey: faker.string.sample(),
     secretKey: faker.string.sample(),
   };
+}
+
+export function generateExchangeApiKey(): ExchangeApiKeyEntity {
+  const entity = {
+    id: faker.string.uuid(),
+    ...generateExchangeApiKeysData(),
+    createdAt: faker.date.recent(),
+    updatedAt: new Date(),
+  };
+
+  return entity as ExchangeApiKeyEntity;
 }

--- a/recording-oracle/src/modules/exchange/ccxt-exchange-client.spec.ts
+++ b/recording-oracle/src/modules/exchange/ccxt-exchange-client.spec.ts
@@ -27,10 +27,10 @@ import * as ccxt from 'ccxt';
 import type { Exchange } from 'ccxt';
 
 import logger from '@/logger';
+import { generateExchangeName } from '~/test/fixtures/manifest';
 
 import { CcxtExchangeClient } from './ccxt-exchange-client';
 import { ExchangeApiClientError } from './errors';
-import { generateExchangeName } from './fixtures';
 
 const mockedCcxt = jest.mocked(ccxt);
 const mockedExchange = createMock<Exchange>();

--- a/recording-oracle/src/modules/exchange/fixtures/index.ts
+++ b/recording-oracle/src/modules/exchange/fixtures/index.ts
@@ -1,7 +1,0 @@
-import { faker } from '@faker-js/faker';
-
-import { SUPPORTED_EXCHANGE_NAMES } from '@/common/constants';
-
-export function generateExchangeName() {
-  return faker.helpers.arrayElement(SUPPORTED_EXCHANGE_NAMES);
-}

--- a/recording-oracle/src/modules/web3/fixtures/index.ts
+++ b/recording-oracle/src/modules/web3/fixtures/index.ts
@@ -1,0 +1,18 @@
+import { faker } from '@faker-js/faker';
+
+import { ChainIds } from '@/common/constants';
+import { Web3ConfigService } from '@/config/web3-config.service';
+import { generateEthWallet } from '~/test/fixtures/web3';
+
+const testWallet = generateEthWallet();
+
+export function generateTestnetChainId() {
+  return faker.helpers.arrayElement(ChainIds);
+}
+
+export const mockWeb3ConfigService: Omit<Web3ConfigService, 'configService'> = {
+  privateKey: testWallet.privateKey,
+  operatorAddress: testWallet.address,
+  gasPriceMultiplier: faker.number.int({ min: 1, max: 42 }),
+  getRpcUrlByChainId: () => faker.internet.url(),
+};

--- a/recording-oracle/src/modules/web3/fixtures/index.ts
+++ b/recording-oracle/src/modules/web3/fixtures/index.ts
@@ -1,13 +1,17 @@
 import { faker } from '@faker-js/faker';
 
-import { ChainIds } from '@/common/constants';
+import { DevelopmentChainId } from '@/common/constants';
 import { Web3ConfigService } from '@/config/web3-config.service';
 import { generateEthWallet } from '~/test/fixtures/web3';
 
 const testWallet = generateEthWallet();
 
+const testnetChainIds = Object.values(DevelopmentChainId).filter(
+  (v) => typeof v === 'number',
+);
+
 export function generateTestnetChainId() {
-  return faker.helpers.arrayElement(ChainIds);
+  return faker.helpers.arrayElement(testnetChainIds);
 }
 
 export const mockWeb3ConfigService: Omit<Web3ConfigService, 'configService'> = {

--- a/recording-oracle/src/modules/web3/web3.service.spec.ts
+++ b/recording-oracle/src/modules/web3/web3.service.spec.ts
@@ -1,0 +1,105 @@
+import { faker } from '@faker-js/faker';
+import { createMock } from '@golevelup/ts-jest';
+import { Test } from '@nestjs/testing';
+import { FeeData, JsonRpcProvider, Provider } from 'ethers';
+
+import { generateTestnetChainId, mockWeb3ConfigService } from './fixtures';
+import type { WalletWithProvider } from './types';
+import { Web3Service } from './web3.service';
+import { Web3ConfigService } from '../../config';
+
+describe('Web3Service', () => {
+  let web3Service: Web3Service;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        {
+          provide: Web3ConfigService,
+          useValue: mockWeb3ConfigService,
+        },
+        Web3Service,
+      ],
+    }).compile();
+
+    web3Service = moduleRef.get<Web3Service>(Web3Service);
+  });
+
+  it('should succesfully create service instance', () => {
+    /**
+     * Constructor throws if configuration is invalid,
+     * so check for an instance as litmus test
+     */
+    expect(web3Service).toBeDefined();
+  });
+
+  describe('getSigner', () => {
+    it('should return correct signer for a valid chainId on testnet', () => {
+      const validChainId = generateTestnetChainId();
+
+      const signer = web3Service.getSigner(validChainId);
+      expect(signer).toBeDefined();
+      expect(signer.address).toEqual(mockWeb3ConfigService.operatorAddress);
+      expect(signer.privateKey).toEqual(mockWeb3ConfigService.privateKey);
+      expect(signer.provider).toBeInstanceOf(JsonRpcProvider);
+    });
+
+    it('should throw if invalid chain id provided', () => {
+      const invalidChainId = -42;
+
+      expect(() => web3Service.getSigner(invalidChainId)).toThrow(
+        `No signer for provided chain id: ${invalidChainId}`,
+      );
+    });
+  });
+
+  describe('calculateGasPrice', () => {
+    const mockProvider = createMock<Provider>();
+    let spyOnGetSigner: jest.SpyInstance;
+
+    beforeAll(() => {
+      spyOnGetSigner = jest.spyOn(web3Service, 'getSigner').mockImplementation(
+        () =>
+          ({
+            provider: mockProvider,
+          }) as unknown as WalletWithProvider,
+      );
+    });
+
+    afterAll(() => {
+      spyOnGetSigner.mockRestore();
+    });
+
+    afterEach(() => {
+      mockProvider.getFeeData.mockReset();
+    });
+
+    it('should use multiplier for gas price', async () => {
+      const testChainId = generateTestnetChainId();
+
+      const randomGasPrice = faker.number.bigInt({ min: 1n });
+
+      mockProvider.getFeeData.mockResolvedValueOnce({
+        gasPrice: randomGasPrice,
+      } as FeeData);
+
+      const gasPrice = await web3Service.calculateGasPrice(testChainId);
+
+      const expectedGasPrice =
+        randomGasPrice * BigInt(mockWeb3ConfigService.gasPriceMultiplier);
+      expect(gasPrice).toEqual(expectedGasPrice);
+    });
+
+    it('should throw if no gas price from provider', async () => {
+      const testChainId = generateTestnetChainId();
+
+      mockProvider.getFeeData.mockResolvedValueOnce({
+        gasPrice: null,
+      } as FeeData);
+
+      await expect(web3Service.calculateGasPrice(testChainId)).rejects.toThrow(
+        `No gas price data for chain id: ${testChainId}`,
+      );
+    });
+  });
+});

--- a/recording-oracle/src/utils/manifest.ts
+++ b/recording-oracle/src/utils/manifest.ts
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
 import { SUPPORTED_EXCHANGE_NAMES } from '@/common/constants';
-import type { CampaignManifest } from '@/modules/campaigns';
+import type { CampaignManifest } from '@/common/types';
 
 const manifestSchema = Joi.object({
   exchange: Joi.string()

--- a/recording-oracle/src/utils/manifest.ts
+++ b/recording-oracle/src/utils/manifest.ts
@@ -7,23 +7,32 @@ const manifestSchema = Joi.object({
   exchange: Joi.string()
     .valid(...SUPPORTED_EXCHANGE_NAMES)
     .required(),
-  pair: Joi.string().required(),
-  fund_token: Joi.string().required(),
+  pair: Joi.string()
+    .pattern(/^[A-Z]{3,10}\/[A-Z]{3,10}$/)
+    .required(),
+  fund_token: Joi.string()
+    .pattern(/^[A-Z]{3,10}$/)
+    .required(),
   start_date: Joi.date().iso(),
   end_date: Joi.date().iso().greater(Joi.ref('start_date')).required(),
-}).unknown();
+}).options({ allowUnknown: true, stripUnknown: true });
 
 export async function downloadCampaignManifest(
   url: string,
 ): Promise<CampaignManifest> {
   const response = await fetch(url);
-  const manifestJson = await response.json();
 
-  const validationResult = manifestSchema.validate(manifestJson);
-
-  if (validationResult.error) {
-    throw new Error(`Invalid manifest schema`);
+  if (!response.ok) {
+    throw new Error('Failed to load manifest');
   }
 
-  return validationResult.value;
+  try {
+    const manifestJson = await response.json();
+
+    const validatedManifest = Joi.attempt(manifestJson, manifestSchema);
+
+    return validatedManifest;
+  } catch {
+    throw new Error(`Invalid manifest schema`);
+  }
 }

--- a/recording-oracle/test/fixtures/manifest.ts
+++ b/recording-oracle/test/fixtures/manifest.ts
@@ -1,0 +1,22 @@
+import { faker } from '@faker-js/faker';
+
+import { SUPPORTED_EXCHANGE_NAMES } from '@/common/constants';
+import { CampaignManifest } from '@/common/types';
+
+export function generateTradingPair(): string {
+  return `${faker.finance.currencyCode()}/${faker.finance.currencyCode()}`;
+}
+
+export function generateExchangeName() {
+  return faker.helpers.arrayElement(SUPPORTED_EXCHANGE_NAMES);
+}
+
+export function generateCampaignManifest(): CampaignManifest {
+  return {
+    exchange: generateExchangeName(),
+    pair: generateTradingPair(),
+    fund_token: 'HMT',
+    start_date: faker.date.recent(),
+    end_date: faker.date.future(),
+  };
+}

--- a/recording-oracle/yarn.lock
+++ b/recording-oracle/yarn.lock
@@ -1474,6 +1474,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mswjs/interceptors@npm:^0.38.7":
+  version: 0.38.7
+  resolution: "@mswjs/interceptors@npm:0.38.7"
+  dependencies:
+    "@open-draft/deferred-promise": "npm:^2.2.0"
+    "@open-draft/logger": "npm:^0.3.0"
+    "@open-draft/until": "npm:^2.0.0"
+    is-node-process: "npm:^1.2.0"
+    outvariant: "npm:^1.4.3"
+    strict-event-emitter: "npm:^0.5.1"
+  checksum: 10c0/89b0065921ce5c68656ef472e3beca8e9dee473c556facc5ff2a8c2da1f45f901a66ae5ff2a1e7c32d6fc8e677f75d2cd793d22ca4451a17d256e8771a77b589
+  languageName: node
+  linkType: hard
+
 "@napi-rs/wasm-runtime@npm:^0.2.10":
   version: 0.2.10
   resolution: "@napi-rs/wasm-runtime@npm:0.2.10"
@@ -1852,6 +1866,30 @@ __metadata:
   bin:
     opencollective: bin/opencollective.js
   checksum: 10c0/ef2835d8635d2928152eff8b5a1ec42c145e2ab00cb02ff4bb61f0a6f5528afc9b169c06c32308c783779fe26855ebc67419743046caa80e582e814cff73187d
+  languageName: node
+  linkType: hard
+
+"@open-draft/deferred-promise@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@open-draft/deferred-promise@npm:2.2.0"
+  checksum: 10c0/eafc1b1d0fc8edb5e1c753c5e0f3293410b40dde2f92688211a54806d4136887051f39b98c1950370be258483deac9dfd17cf8b96557553765198ef2547e4549
+  languageName: node
+  linkType: hard
+
+"@open-draft/logger@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@open-draft/logger@npm:0.3.0"
+  dependencies:
+    is-node-process: "npm:^1.2.0"
+    outvariant: "npm:^1.4.0"
+  checksum: 10c0/90010647b22e9693c16258f4f9adb034824d1771d3baa313057b9a37797f571181005bc50415a934eaf7c891d90ff71dcd7a9d5048b0b6bb438f31bef2c7c5c1
+  languageName: node
+  linkType: hard
+
+"@open-draft/until@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "@open-draft/until@npm:2.1.0"
+  checksum: 10c0/61d3f99718dd86bb393fee2d7a785f961dcaf12f2055f0c693b27f4d0cd5f7a03d498a6d9289773b117590d794a43cd129366fd8e99222e4832f67b1653d54cf
   languageName: node
   linkType: hard
 
@@ -6300,6 +6338,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-node-process@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "is-node-process@npm:1.2.0"
+  checksum: 10c0/5b24fda6776d00e42431d7bcd86bce81cb0b6cabeb944142fe7b077a54ada2e155066ad06dbe790abdb397884bdc3151e04a9707b8cd185099efbc79780573ed
+  languageName: node
+  linkType: hard
+
 "is-number-object@npm:^1.1.1":
   version: 1.1.1
   resolution: "is-number-object@npm:1.1.1"
@@ -7123,6 +7168,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-stringify-safe@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "json-stringify-safe@npm:5.0.1"
+  checksum: 10c0/7dbf35cd0411d1d648dceb6d59ce5857ec939e52e4afc37601aa3da611f0987d5cee5b38d58329ceddf3ed48bd7215229c8d52059ab01f2444a338bf24ed0f37
+  languageName: node
+  linkType: hard
+
 "json5@npm:^1.0.2":
   version: 1.0.2
   resolution: "json5@npm:1.0.2"
@@ -7803,6 +7855,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nock@npm:^14.0.5":
+  version: 14.0.5
+  resolution: "nock@npm:14.0.5"
+  dependencies:
+    "@mswjs/interceptors": "npm:^0.38.7"
+    json-stringify-safe: "npm:^5.0.1"
+    propagate: "npm:^2.0.0"
+  checksum: 10c0/3221abf0bbd84243b4d151abecdecffb22eba896e3a9c7e711b9bd1adc32f2273eb1c3c36f340e53d1c229ea99362364f418dd23017e11416c54e09b1babf219
+  languageName: node
+  linkType: hard
+
 "node-abort-controller@npm:^3.0.1":
   version: 3.1.1
   resolution: "node-abort-controller@npm:3.1.1"
@@ -8069,6 +8132,13 @@ __metadata:
   version: 1.0.2
   resolution: "os-tmpdir@npm:1.0.2"
   checksum: 10c0/f438450224f8e2687605a8dd318f0db694b6293c5d835ae509a69e97c8de38b6994645337e5577f5001115470414638978cc49da1cdcc25106dad8738dc69990
+  languageName: node
+  linkType: hard
+
+"outvariant@npm:^1.4.0, outvariant@npm:^1.4.3":
+  version: 1.4.3
+  resolution: "outvariant@npm:1.4.3"
+  checksum: 10c0/5976ca7740349cb8c71bd3382e2a762b1aeca6f33dc984d9d896acdf3c61f78c3afcf1bfe9cc633a7b3c4b295ec94d292048f83ea2b2594fae4496656eba992c
   languageName: node
   linkType: hard
 
@@ -8655,6 +8725,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"propagate@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "propagate@npm:2.0.1"
+  checksum: 10c0/01e1023b60ae4050d1a2783f976d7db702022dbdb70dba797cceedad8cfc01b3939c41e77032f8c32aa9d93192fe937ebba1345e8604e5ce61fd3b62ee3003b8
+  languageName: node
+  linkType: hard
+
 "proxy-addr@npm:^2.0.7":
   version: 2.0.7
   resolution: "proxy-addr@npm:2.0.7"
@@ -8846,6 +8923,7 @@ __metadata:
     helmet: "npm:^8.1.0"
     jest: "npm:^29.7.0"
     joi: "npm:^17.13.3"
+    nock: "npm:^14.0.5"
     passport: "npm:^0.7.0"
     passport-jwt: "npm:^4.0.1"
     pg: "npm:^8.16.0"
@@ -9612,6 +9690,13 @@ __metadata:
   version: 1.1.0
   resolution: "streamsearch@npm:1.1.0"
   checksum: 10c0/fbd9aecc2621364384d157f7e59426f4bfd385e8b424b5aaa79c83a6f5a1c8fd2e4e3289e95de1eb3511cb96bb333d6281a9919fafce760e4edb35b2cd2facab
+  languageName: node
+  linkType: hard
+
+"strict-event-emitter@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "strict-event-emitter@npm:0.5.1"
+  checksum: 10c0/f5228a6e6b6393c57f52f62e673cfe3be3294b35d6f7842fc24b172ae0a6e6c209fa83241d0e433fc267c503bc2f4ffdbe41a9990ff8ffd5ac425ec0489417f7
   languageName: node
   linkType: hard
 

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -146,3 +146,12 @@ lint-fix:
 	$(MAKE) lint-fix-recording-oracle
 	$(MAKE) lint-fix-reputation-oracle
 	@echo "Finished fixing lint issues"
+
+test-recording-oracle:
+	cd $(PROJECT_ROOT)/recording-oracle && yarn test
+
+.PHONY: test
+test:
+	@echo "Run unit tests..."
+	$(MAKE) test-recording-oracle
+	@echo "Finished unit tests"


### PR DESCRIPTION
## Issue tracking
Part of #236 

## Context behind the change
- added unit tests for campaigns service and web3 service as well
- moved `CampaignManifest` type to `common` folder in order to avoid potential circular dependency in the future + it's not part of the campaign module itself, it's something general atm because we also have manifest utils
- enabled unit tests in CI

## How has this been tested?
- [x] `yarn test`
- [x] CI tests pass 

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No