### PR TITLE
Display Campaign's Network Icon

### DIFF
--- a/campaign-launcher/interfaceV2/src/components/CampaignInfo/index.tsx
+++ b/campaign-launcher/interfaceV2/src/components/CampaignInfo/index.tsx
@@ -1,10 +1,10 @@
 import { FC } from 'react';
 
-import { Box, CircularProgress, Typography } from '@mui/material';
+import { Box, CircularProgress, Tooltip, Typography } from '@mui/material';
 
 import { CampaignDataDto } from '../../api/client';
 import { CalendarIcon } from '../../icons';
-import { getChainIcon } from '../../utils';
+import { getChainIcon, getNetworkName } from '../../utils';
 import JoinCampaign from '../JoinCampaign';
 
 const formatDate = (block: number): string => {
@@ -61,9 +61,11 @@ const CampaignInfo: FC<Props> = ({ campaign, isCampaignLoading }) => {
           </>
         )}
       </Box>
-      <Box ml={2}>
-        {getChainIcon(campaign.chainId)}
-      </Box>
+      <Tooltip title={getNetworkName(campaign.chainId) || "Unknown Network"}>
+        <Box ml={2}>
+          {getChainIcon(campaign.chainId)}
+        </Box>
+      </Tooltip>
       <JoinCampaign campaign={campaign} />
     </>
   );

--- a/campaign-launcher/interfaceV2/src/components/CampaignInfo/index.tsx
+++ b/campaign-launcher/interfaceV2/src/components/CampaignInfo/index.tsx
@@ -1,8 +1,10 @@
 import { FC } from 'react';
 
+import { ChainId } from '@human-protocol/sdk';
 import { Box, CircularProgress, Typography } from '@mui/material';
 
 import { CampaignDataDto } from '../../api/client';
+import { CHAIN_ICONS } from '../../constants/chainIcons';
 import { CalendarIcon } from '../../icons';
 import JoinCampaign from '../JoinCampaign';
 
@@ -12,6 +14,11 @@ const formatDate = (block: number): string => {
   const month = date.toLocaleString('en-US', { month: 'short' });
   const year = date.getFullYear();
   return `${day} ${month} ${year}`;
+};
+
+const getChainIcon = (id?: number) => {
+  if (!id) return null;
+  return CHAIN_ICONS[id as ChainId] || null;
 };
 
 type Props = {
@@ -60,7 +67,10 @@ const CampaignInfo: FC<Props> = ({ campaign, isCampaignLoading }) => {
           </>
         )}
       </Box>
-      <JoinCampaign campaign={campaign}  />
+      <Box ml={2}>
+        {getChainIcon(campaign.chainId)}
+      </Box>
+      <JoinCampaign campaign={campaign} />
     </>
   );
 };

--- a/campaign-launcher/interfaceV2/src/components/CampaignInfo/index.tsx
+++ b/campaign-launcher/interfaceV2/src/components/CampaignInfo/index.tsx
@@ -1,11 +1,10 @@
 import { FC } from 'react';
 
-import { ChainId } from '@human-protocol/sdk';
 import { Box, CircularProgress, Typography } from '@mui/material';
 
 import { CampaignDataDto } from '../../api/client';
-import { CHAIN_ICONS } from '../../constants/chainIcons';
 import { CalendarIcon } from '../../icons';
+import { getChainIcon } from '../../utils';
 import JoinCampaign from '../JoinCampaign';
 
 const formatDate = (block: number): string => {
@@ -14,11 +13,6 @@ const formatDate = (block: number): string => {
   const month = date.toLocaleString('en-US', { month: 'short' });
   const year = date.getFullYear();
   return `${day} ${month} ${year}`;
-};
-
-const getChainIcon = (id?: number) => {
-  if (!id) return null;
-  return CHAIN_ICONS[id as ChainId] || null;
 };
 
 type Props = {

--- a/campaign-launcher/interfaceV2/src/components/CampaignsTable/index.tsx
+++ b/campaign-launcher/interfaceV2/src/components/CampaignsTable/index.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAccount } from 'wagmi';
 
 import { CampaignDataDto } from '../../api/client';
+import { CHAIN_ICONS } from '../../constants/chainIcons';
 import { useIsXlDesktop, useIsLgDesktop } from '../../hooks/useBreakpoints';
 import { OpenInNewIcon } from '../../icons';
 import { useExchangesContext } from '../../providers/ExchangesProvider';
@@ -44,6 +45,11 @@ const formatDate = (block: number) => {
   const month = date.toLocaleString('en-US', { month: 'long' });
   const year = date.getFullYear();
   return `${day}${getSuffix(day)} ${month} ${year}`;
+};
+
+const getChainIcon = (id?: number) => {
+  if (!id) return null;
+  return CHAIN_ICONS[id as ChainId] || null;
 };
 
 const MyCampaignsNoRows: FC = () => {
@@ -221,6 +227,15 @@ const CampaignsTable: FC<Props> = ({
             </IconButton>
           </Typography>
         );
+      },
+    },
+    {
+      field: 'network',
+      headerName: 'Network',
+      flex: 1,
+      minWidth: 100,
+      renderCell: (params) => {
+        return <Typography variant="subtitle2">{getChainIcon(params.row.chainId)}</Typography>;
       },
     },
     {

--- a/campaign-launcher/interfaceV2/src/components/CampaignsTable/index.tsx
+++ b/campaign-launcher/interfaceV2/src/components/CampaignsTable/index.tsx
@@ -7,11 +7,10 @@ import { useNavigate } from 'react-router-dom';
 import { useAccount } from 'wagmi';
 
 import { CampaignDataDto } from '../../api/client';
-import { CHAIN_ICONS } from '../../constants/chainIcons';
 import { useIsXlDesktop, useIsLgDesktop } from '../../hooks/useBreakpoints';
 import { OpenInNewIcon } from '../../icons';
 import { useExchangesContext } from '../../providers/ExchangesProvider';
-import { formatAddress, getExplorerUrl, formatTokenAmount } from '../../utils';
+import { formatAddress, getExplorerUrl, formatTokenAmount, getChainIcon } from '../../utils';
 import ConnectWallet from '../ConnectWallet';
 import { CryptoPairEntity } from '../CryptoPairEntity';
 import LaunchCampaign from '../LaunchCampaign';
@@ -45,11 +44,6 @@ const formatDate = (block: number) => {
   const month = date.toLocaleString('en-US', { month: 'long' });
   const year = date.getFullYear();
   return `${day}${getSuffix(day)} ${month} ${year}`;
-};
-
-const getChainIcon = (id?: number) => {
-  if (!id) return null;
-  return CHAIN_ICONS[id as ChainId] || null;
 };
 
 const MyCampaignsNoRows: FC = () => {

--- a/campaign-launcher/interfaceV2/src/components/CampaignsTable/index.tsx
+++ b/campaign-launcher/interfaceV2/src/components/CampaignsTable/index.tsx
@@ -1,7 +1,7 @@
 import { FC, MouseEvent } from 'react';
 
 import { ChainId } from '@human-protocol/sdk';
-import { Button, IconButton, Typography, Box } from '@mui/material';
+import { Button, IconButton, Typography, Box, Tooltip } from '@mui/material';
 import { DataGrid, GridColDef, GridPagination } from '@mui/x-data-grid';
 import { useNavigate } from 'react-router-dom';
 import { useAccount } from 'wagmi';
@@ -10,7 +10,7 @@ import { CampaignDataDto } from '../../api/client';
 import { useIsXlDesktop, useIsLgDesktop } from '../../hooks/useBreakpoints';
 import { OpenInNewIcon } from '../../icons';
 import { useExchangesContext } from '../../providers/ExchangesProvider';
-import { formatAddress, getExplorerUrl, formatTokenAmount, getChainIcon } from '../../utils';
+import { formatAddress, getExplorerUrl, formatTokenAmount, getChainIcon, getNetworkName } from '../../utils';
 import ConnectWallet from '../ConnectWallet';
 import { CryptoPairEntity } from '../CryptoPairEntity';
 import LaunchCampaign from '../LaunchCampaign';
@@ -229,7 +229,14 @@ const CampaignsTable: FC<Props> = ({
       flex: 1,
       minWidth: 100,
       renderCell: (params) => {
-        return <Typography variant="subtitle2">{getChainIcon(params.row.chainId)}</Typography>;
+        const networkName = getNetworkName(params.row.chainId);
+        return (
+          <Tooltip title={networkName || "Unknown Network"}>
+            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+              {getChainIcon(params.row.chainId)}
+            </Box>
+          </Tooltip>
+        );
       },
     },
     {

--- a/campaign-launcher/interfaceV2/src/components/NetworkSwitcher/index.tsx
+++ b/campaign-launcher/interfaceV2/src/components/NetworkSwitcher/index.tsx
@@ -4,14 +4,8 @@ import { ChainId } from '@human-protocol/sdk';
 import { Button, Menu, MenuItem, Typography } from '@mui/material';
 import { useAccount, useSwitchChain, useConfig } from 'wagmi';
 
-import { CHAIN_ICONS } from '../../constants/chainIcons';
 import { ChevronIcon } from '../../icons';
-import { getSupportedChainIds } from '../../utils';
-
-const getChainIcon = (id?: number) => {
-  if (!id) return null;
-  return CHAIN_ICONS[id as ChainId] || null;
-};
+import { getChainIcon, getSupportedChainIds } from '../../utils';
 
 const NetworkSwitcher: FC = () => {
   const { chain, isConnected } = useAccount();
@@ -60,7 +54,7 @@ const NetworkSwitcher: FC = () => {
         }}
       >
         <Typography variant="body2" fontWeight={600}>
-          {getChainIcon(chain?.id)}
+          {getChainIcon(chain?.id as ChainId)}
           {chain?.name ? null : 'Select Network'}
         </Typography>
       </Button>

--- a/campaign-launcher/interfaceV2/src/utils/index.ts
+++ b/campaign-launcher/interfaceV2/src/utils/index.ts
@@ -67,3 +67,8 @@ export const getChainIcon = (id?: ChainId) => {
   if (!id) return null;
   return CHAIN_ICONS[id] || null;
 };
+
+export const getNetworkName = (chainId?: ChainId): string | undefined => {
+  if (!chainId) return undefined;
+  return NETWORKS[chainId]?.title;
+};

--- a/campaign-launcher/interfaceV2/src/utils/index.ts
+++ b/campaign-launcher/interfaceV2/src/utils/index.ts
@@ -6,6 +6,7 @@ import {
   TESTNET_CHAIN_IDS,
   LOCALHOST_CHAIN_IDS,
 } from '../constants';
+import { CHAIN_ICONS } from '../constants/chainIcons';
 
 export const formatAddress = (address?: string) => {
   if (!address) return '';
@@ -60,4 +61,9 @@ export const formatTokenAmount = (amount: string | number, decimals = 18): strin
   } else {
     return parseFloat(formattedAmount.toFixed(3));
   }
+};
+
+export const getChainIcon = (id?: ChainId) => {
+  if (!id) return null;
+  return CHAIN_ICONS[id] || null;
 };


### PR DESCRIPTION
## Issue tracking
Not ticketed

## Context behind the change
We want to indicate a campaign's network

![img](https://github.com/user-attachments/assets/0d48ce96-a500-4736-bd69-4280c976ec70)

![img](https://github.com/user-attachments/assets/4bb2536b-57f2-46d3-a0ab-ec6878e60ad3)


## How has this been tested?
locally on both pages

## Release plan
regular plan

## Potential risks; What to monitor; Rollback plan
no risks