### PR TITLE
[Recording Oracle] feat: total volume stats

### DIFF
--- a/recording-oracle/package.json
+++ b/recording-oracle/package.json
@@ -47,6 +47,7 @@
     "helmet": "^8.1.0",
     "joi": "^17.13.3",
     "lodash": "^4.17.21",
+    "lru-cache": "^11.1.0",
     "minio": "^7.1.3",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",

--- a/recording-oracle/src/app.module.ts
+++ b/recording-oracle/src/app.module.ts
@@ -15,6 +15,7 @@ import { AuthModule } from './modules/auth';
 import { CampaignsModule } from './modules/campaigns';
 import { ExchangeApiKeysModule } from './modules/exchange-api-keys';
 import { HealthModule } from './modules/health';
+import { StatisticsModule } from './modules/statistics';
 import { UsersModule } from './modules/users';
 
 @Module({
@@ -63,6 +64,7 @@ import { UsersModule } from './modules/users';
     ExchangeApiKeysModule,
     HealthModule,
     UsersModule,
+    StatisticsModule,
   ],
   controllers: [AppController],
 })

--- a/recording-oracle/src/common/interceptors/transform.ts
+++ b/recording-oracle/src/common/interceptors/transform.ts
@@ -21,11 +21,17 @@ export class TransformInterceptor implements NestInterceptor {
 
     if (request.query) {
       const transformedQuery = this.transformRequestData(request.query);
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      for (const key of Object.keys(request.query)) {
-        delete request.query[key];
-      }
-      Object.assign(request.query, transformedQuery);
+      /**
+       * Starting from express v5 'req.query' is not writable property anymore
+       * (https://expressjs.com/en/guide/migrating-5.html#req.query), so we have
+       * to monkey patch it in order to transform it.
+       */
+      Object.defineProperty(request, 'query', {
+        value: transformedQuery,
+        configurable: true,
+        enumerable: true,
+        writable: true,
+      });
     }
 
     if (request.params) {

--- a/recording-oracle/src/database/database.module.ts
+++ b/recording-oracle/src/database/database.module.ts
@@ -6,7 +6,11 @@ import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 import Environment from '@/common/utils/environment';
 import { DatabaseConfigService } from '@/config';
 import { RefreshTokenEntity } from '@/modules/auth';
-import { CampaignEntity, UserCampaignEntity } from '@/modules/campaigns';
+import {
+  CampaignEntity,
+  UserCampaignEntity,
+  VolumeStatEntity,
+} from '@/modules/campaigns';
 import { ExchangeApiKeyEntity } from '@/modules/exchange-api-keys';
 import { UserEntity } from '@/modules/users';
 
@@ -50,6 +54,7 @@ import { UserEntity } from '@/modules/users';
             RefreshTokenEntity,
             UserCampaignEntity,
             UserEntity,
+            VolumeStatEntity,
           ],
 
           logging: shouldEnableLogging

--- a/recording-oracle/src/database/migrations/1752851913318-volume-stats.ts
+++ b/recording-oracle/src/database/migrations/1752851913318-volume-stats.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class VolumeStats1752851913318 implements MigrationInterface {
+  name = 'VolumeStats1752851913318';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "hu_fi"."volume_stats" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "campaign_address" character varying(42) NOT NULL, "exchange_name" character varying(20) NOT NULL, "volume" numeric(20,2) NOT NULL, "period_start" TIMESTAMP WITH TIME ZONE NOT NULL, "period_end" TIMESTAMP WITH TIME ZONE NOT NULL, "recorded_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "PK_cb48bf745e9c4fc42bf2d8c567e" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_7ec2d9f22efc25135dc0e7731d" ON "hu_fi"."volume_stats" ("exchange_name", "campaign_address", "period_start") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "hu_fi"."IDX_7ec2d9f22efc25135dc0e7731d"`,
+    );
+    await queryRunner.query(`DROP TABLE "hu_fi"."volume_stats"`);
+  }
+}

--- a/recording-oracle/src/main.ts
+++ b/recording-oracle/src/main.ts
@@ -1,5 +1,6 @@
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
+import type { NestExpressApplication } from '@nestjs/platform-express';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import helmet from 'helmet';
 
@@ -8,7 +9,7 @@ import { ServerConfigService } from './config';
 import logger, { nestLoggerOverride } from './logger';
 
 async function bootstrap(): Promise<void> {
-  const app = await NestFactory.create(AppModule, {
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     cors: true,
     logger: nestLoggerOverride,
   });

--- a/recording-oracle/src/modules/campaigns/campaigns.module.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.module.ts
@@ -11,6 +11,7 @@ import { CampaignsRepository } from './campaigns.repository';
 import { CampaignsService } from './campaigns.service';
 import { MarketMakingResultsChecker } from './progress-checkers';
 import { UserCampaignsRepository } from './user-campaigns.repository';
+import { VolumeStatsRepository } from './volume-stats.repository';
 
 @Module({
   imports: [ExchangeModule, ExchangeApiKeysModule, StorageModule, Web3Module],
@@ -18,10 +19,11 @@ import { UserCampaignsRepository } from './user-campaigns.repository';
     CampaignsRepository,
     CampaignsService,
     UserCampaignsRepository,
+    VolumeStatsRepository,
     MarketMakingResultsChecker,
     PgAdvisoryLock,
   ],
   controllers: [CampaignsController],
-  exports: [],
+  exports: [VolumeStatsRepository],
 })
 export class CampaignsModule {}

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -69,8 +69,8 @@ export class CampaignsService {
     private readonly volumeStatsRepository: VolumeStatsRepository,
     private readonly web3Service: Web3Service,
     private readonly web3ConfigService: Web3ConfigService,
-    private readonly moduleRef: ModuleRef,
     private readonly pgAdvisoryLock: PgAdvisoryLock,
+    private readonly moduleRef: ModuleRef,
   ) {}
 
   async join(

--- a/recording-oracle/src/modules/campaigns/index.ts
+++ b/recording-oracle/src/modules/campaigns/index.ts
@@ -1,4 +1,7 @@
 export { CampaignEntity } from './campaign.entity';
 export { UserCampaignEntity } from './user-campaign.entity';
+export { VolumeStatEntity } from './volume-stat.entity';
+
+export { VolumeStatsRepository } from './volume-stats.repository';
 
 export { CampaignsModule } from './campaigns.module';

--- a/recording-oracle/src/modules/campaigns/volume-stat.entity.ts
+++ b/recording-oracle/src/modules/campaigns/volume-stat.entity.ts
@@ -1,0 +1,31 @@
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+import { DATABASE_SCHEMA_NAME } from '@/common/constants';
+
+@Entity({ schema: DATABASE_SCHEMA_NAME, name: 'volume_stats' })
+@Index(['exchangeName', 'campaignAddress', 'periodStart'], { unique: true })
+export class VolumeStatEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('varchar', { length: 42 })
+  campaignAddress: string;
+
+  @Column('varchar', { length: 20 })
+  exchangeName: string;
+
+  @Column({ type: 'decimal', precision: 20, scale: 2 })
+  volume: number;
+
+  @Column({ type: 'timestamptz' })
+  periodStart: Date;
+
+  @Column({ type: 'timestamptz' })
+  periodEnd: Date;
+
+  @Column({
+    type: 'timestamptz',
+    default: () => 'now()',
+  })
+  recordedAt: Date;
+}

--- a/recording-oracle/src/modules/campaigns/volume-stats.repository.ts
+++ b/recording-oracle/src/modules/campaigns/volume-stats.repository.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+
+import { VolumeStatEntity } from './volume-stat.entity';
+
+@Injectable()
+export class VolumeStatsRepository extends Repository<VolumeStatEntity> {
+  constructor(dataSource: DataSource) {
+    super(VolumeStatEntity, dataSource.createEntityManager());
+  }
+
+  async calculateTotalVolume(exchangeName?: string): Promise<number> {
+    const totalSumQuery = this.createQueryBuilder('stat').select(
+      'COALESCE(SUM(stat.volume), 0)',
+      'totalVolume',
+    );
+
+    if (exchangeName) {
+      totalSumQuery.where('stat.exchange_name = :exchangeName', {
+        exchangeName,
+      });
+    }
+
+    const queryResult = await totalSumQuery.getRawOne();
+
+    return Number(queryResult.totalVolume);
+  }
+}

--- a/recording-oracle/src/modules/statistics/index.ts
+++ b/recording-oracle/src/modules/statistics/index.ts
@@ -1,0 +1,2 @@
+export { StatisticsModule } from './statistics.module';
+export { StatisticsService } from './statistics.service';

--- a/recording-oracle/src/modules/statistics/statistics.controller.ts
+++ b/recording-oracle/src/modules/statistics/statistics.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import { Public } from '@/common/decorators';
+
+import { StatisticsService } from './statistics.service';
+
+@Public()
+@ApiTags('Statistics')
+@Controller('/stats')
+export class StatisticsController {
+  constructor(private readonly statisticsService: StatisticsService) {}
+
+  @Get('/total-volume')
+  @ApiOperation({
+    summary: 'Get total generated volume',
+    description:
+      'Returns total volume generated in all campaigns by all participants',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Total volume returned successfully',
+  })
+  async getTotalVolume(): Promise<unknown> {
+    const totalVolume = await this.statisticsService.getTotalVolume();
+
+    return { totalVolume };
+  }
+}

--- a/recording-oracle/src/modules/statistics/statistics.controller.ts
+++ b/recording-oracle/src/modules/statistics/statistics.controller.ts
@@ -1,9 +1,25 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Query } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { LRUCache } from 'lru-cache';
 
 import { Public } from '@/common/decorators';
 
+import {
+  GetTotalVolumeQueryDto,
+  GetTotalVolumeResponseDto,
+} from './statistics.dto';
 import { StatisticsService } from './statistics.service';
+
+const statsCache = new LRUCache({
+  ttl: 1000 * 60 * 1,
+  max: 4200,
+  ttlAutopurge: false,
+  allowStale: false,
+  noDeleteOnStaleGet: false,
+  noUpdateTTL: false,
+  updateAgeOnGet: false,
+  updateAgeOnHas: false,
+});
 
 @Public()
 @ApiTags('Statistics')
@@ -20,10 +36,22 @@ export class StatisticsController {
   @ApiResponse({
     status: 200,
     description: 'Total volume returned successfully',
+    type: GetTotalVolumeResponseDto,
   })
-  async getTotalVolume(): Promise<unknown> {
-    const totalVolume = await this.statisticsService.getTotalVolume();
+  async getTotalVolume(
+    @Query() { exchangeName }: GetTotalVolumeQueryDto,
+  ): Promise<GetTotalVolumeResponseDto> {
+    const cacheKey = `get-total-volume-for-${exchangeName || 'all'}`;
 
-    return { totalVolume };
+    if (!statsCache.has(cacheKey)) {
+      const totalVolume =
+        await this.statisticsService.getTotalVolume(exchangeName);
+
+      statsCache.set(cacheKey, totalVolume);
+    }
+
+    return {
+      totalVolume: statsCache.get(cacheKey) as number,
+    };
   }
 }

--- a/recording-oracle/src/modules/statistics/statistics.dto.ts
+++ b/recording-oracle/src/modules/statistics/statistics.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, Validate } from 'class-validator';
+
+import { SUPPORTED_EXCHANGE_NAMES } from '@/common/constants';
+import { ExchangeNameValidator } from '@/common/validators';
+
+export class GetTotalVolumeQueryDto {
+  @ApiPropertyOptional({
+    name: 'exchange_name',
+    enum: SUPPORTED_EXCHANGE_NAMES,
+  })
+  @IsOptional()
+  @Validate(ExchangeNameValidator)
+  exchangeName?: string;
+}
+
+export class GetTotalVolumeResponseDto {
+  @ApiProperty()
+  totalVolume: number;
+}

--- a/recording-oracle/src/modules/statistics/statistics.module.ts
+++ b/recording-oracle/src/modules/statistics/statistics.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+
+import { CampaignsModule } from '@/modules/campaigns';
+
+import { StatisticsController } from './statistics.controller';
+import { StatisticsService } from './statistics.service';
+
+@Module({
+  imports: [CampaignsModule],
+  providers: [StatisticsService],
+  controllers: [StatisticsController],
+  exports: [],
+})
+export class StatisticsModule {}

--- a/recording-oracle/src/modules/statistics/statistics.service.ts
+++ b/recording-oracle/src/modules/statistics/statistics.service.ts
@@ -2,16 +2,37 @@ import { Injectable } from '@nestjs/common';
 
 import { VolumeStatsRepository } from '@/modules/campaigns';
 
+const inFlightPromisesCache = new Map<string, Promise<unknown>>();
+
 @Injectable()
 export class StatisticsService {
   constructor(private readonly volumeStatsRepository: VolumeStatsRepository) {}
 
-  async getTotalVolume() {
-    /**
-     * TODO: add in-memory caching
-     */
-    const totalVolume = await this.volumeStatsRepository.calculateTotalVolume();
+  async getTotalVolume(exchangeName?: string): Promise<number> {
+    const cacheKey = `get-total-volume-${exchangeName || 'all'}`;
 
-    return totalVolume;
+    try {
+      if (!inFlightPromisesCache.has(cacheKey)) {
+        const totalVolumeQuery = this.volumeStatsRepository
+          .createQueryBuilder('stat')
+          .select('COALESCE(SUM(stat.volume), 0)', 'totalVolume');
+
+        if (exchangeName) {
+          totalVolumeQuery.where('stat.exchange_name = :exchangeName', {
+            exchangeName,
+          });
+        }
+
+        inFlightPromisesCache.set(cacheKey, totalVolumeQuery.getRawOne());
+      }
+
+      const queryResult = (await inFlightPromisesCache.get(cacheKey)) as {
+        totalVolume: string;
+      };
+
+      return Number(queryResult.totalVolume);
+    } finally {
+      inFlightPromisesCache.delete(cacheKey);
+    }
   }
 }

--- a/recording-oracle/src/modules/statistics/statistics.service.ts
+++ b/recording-oracle/src/modules/statistics/statistics.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+
+import { VolumeStatsRepository } from '@/modules/campaigns';
+
+@Injectable()
+export class StatisticsService {
+  constructor(private readonly volumeStatsRepository: VolumeStatsRepository) {}
+
+  async getTotalVolume() {
+    /**
+     * TODO: add in-memory caching
+     */
+    const totalVolume = await this.volumeStatsRepository.calculateTotalVolume();
+
+    return totalVolume;
+  }
+}

--- a/recording-oracle/yarn.lock
+++ b/recording-oracle/yarn.lock
@@ -7475,7 +7475,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^11.0.0":
+"lru-cache@npm:^11.0.0, lru-cache@npm:^11.1.0":
   version: 11.1.0
   resolution: "lru-cache@npm:11.1.0"
   checksum: 10c0/85c312f7113f65fae6a62de7985348649937eb34fb3d212811acbf6704dc322a421788aca253b62838f1f07049a84cc513d88f494e373d3756514ad263670a64
@@ -8983,6 +8983,7 @@ __metadata:
     jest: "npm:^29.7.0"
     joi: "npm:^17.13.3"
     lodash: "npm:^4.17.21"
+    lru-cache: "npm:^11.1.0"
     minio: "npm:^7.1.3"
     nock: "npm:^14.0.5"
     passport: "npm:^0.7.0"


### PR DESCRIPTION
## Issue tracking
Closes #271

## Context behind the change
Unfortunately we can't get daily stats because we get generated volume for different periods in different campaigns, so recording actual stats would be an overhead for now.

Taking into account that this endpoint is public and that volume data is not updated frequently, apply caching on controller level and also avoid multiple identical queries running in parallel.

## How has this been tested?
- [x] unit tests
- [x] e2e locally: call `/stats/total-volume` w/o `exchange_name`, make sure correct total is returned
- [x] e2e locally: call `/stats/total-volume` w/ `exchange_name`, make sure correct total is returned
- [x] e2e locally: verify that cache is used for subsequent calls
- [x] e2e locally: verify that only one DB query runs at a time for specific exchange (or `all`) by simulating long-running query

## Release plan
Just merge PR.
For local dev - `yarn install & yarn migration: run` after merge.

## Potential risks; What to monitor; Rollback plan
No.