### PR TITLE
[Recording Oracle] feat: change logout flow

### DIFF
--- a/recording-oracle/src/modules/auth/refresh-tokens.repository.ts
+++ b/recording-oracle/src/modules/auth/refresh-tokens.repository.ts
@@ -35,7 +35,7 @@ export class RefreshTokensRepository extends Repository<RefreshTokenEntity> {
     });
   }
 
-  async deleteByUserId(userId: string): Promise<void> {
-    await this.delete({ userId });
+  async deleteById(id: string): Promise<void> {
+    await this.delete({ id });
   }
 }


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Atm if user's access token is expired, they are not able to logout, which is not very convenient for UI implementation. Changing logout to handle refresh token invalidation by passing the exact refresh token.

## How has this been tested?
- [x] locally e2e: auth with latest nonce, refresh tokens and then logout

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No