### PR TITLE
[v2] feat: campaign statuses mapping; change supported exchanges

### DIFF
--- a/campaign-launcher/server/.env.example
+++ b/campaign-launcher/server/.env.example
@@ -9,6 +9,7 @@ RPC_URL_POLYGON_AMOY=replace-me-if-needed
 RPC_URL_AURORA_TESTNET=replace-me-if-needed
 RPC_URL_LOCALHOST=replace-me-if-needed
 
+EXCHANGE_ORACLE=replace-me
 RECORDING_ORACLE=replace-me
 REPUTATION_ORACLE=replace-me
 

--- a/campaign-launcher/server/src/common/constants/index.ts
+++ b/campaign-launcher/server/src/common/constants/index.ts
@@ -1,6 +1,19 @@
-import * as ccxt from 'ccxt';
-
-export const SUPPORTED_EXCHANGE_NAMES = [...ccxt.exchanges] as const;
+export const SUPPORTED_EXCHANGE_NAMES = [
+  'bigone',
+  'binance',
+  'bitget',
+  'bybit',
+  'coinbaseexchange',
+  'gate',
+  'htx',
+  'kraken',
+  'kucoin',
+  'mexc',
+  'okx',
+  'upbit',
+  'xt',
+] as const;
+export type SupportedExchange = (typeof SUPPORTED_EXCHANGE_NAMES)[number];
 
 export const EVM_ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/;
 

--- a/campaign-launcher/server/src/common/validators/web3.ts
+++ b/campaign-launcher/server/src/common/validators/web3.ts
@@ -7,11 +7,17 @@ import {
   ValidatorConstraintInterface,
 } from 'class-validator';
 
-import { ChainIds, SUPPORTED_EXCHANGE_NAMES } from '@/common/constants';
+import {
+  ChainIds,
+  SUPPORTED_EXCHANGE_NAMES,
+  type SupportedExchange,
+} from '@/common/constants';
 
-const validExchangeNameSet = new Set(SUPPORTED_EXCHANGE_NAMES);
-export function isValidExchangeName(input: string): boolean {
-  return validExchangeNameSet.has(input);
+const validExchangeNameSet = new Set<SupportedExchange>(
+  SUPPORTED_EXCHANGE_NAMES,
+);
+export function isValidExchangeName(input: string): input is SupportedExchange {
+  return validExchangeNameSet.has(input as SupportedExchange);
 }
 
 @ValidatorConstraint({ name: 'ExchangeName', async: false })

--- a/campaign-launcher/server/src/config/env-schema.ts
+++ b/campaign-launcher/server/src/config/env-schema.ts
@@ -26,6 +26,7 @@ export const envValidator = Joi.object({
     .allow(''),
   RPC_URL_LOCALHOST: Joi.string(),
 
+  EXCHANGE_ORACLE: Joi.string().pattern(EVM_ADDRESS_REGEX).required(),
   RECORDING_ORACLE: Joi.string().pattern(EVM_ADDRESS_REGEX).required(),
   REPUTATION_ORACLE: Joi.string().pattern(EVM_ADDRESS_REGEX).required(),
 });

--- a/campaign-launcher/server/src/config/web3-config.service.ts
+++ b/campaign-launcher/server/src/config/web3-config.service.ts
@@ -32,4 +32,8 @@ export class Web3ConfigService {
   get reputationOracle(): string {
     return this.configService.getOrThrow<string>('REPUTATION_ORACLE');
   }
+
+  get exchangeOracle(): string {
+    return this.configService.getOrThrow<string>('EXCHANGE_ORACLE');
+  }
 }

--- a/campaign-launcher/server/src/modules/campaigns/campaigns.dto.ts
+++ b/campaign-launcher/server/src/modules/campaigns/campaigns.dto.ts
@@ -15,6 +15,7 @@ import {
   ChainIds,
   SUPPORTED_EXCHANGE_NAMES,
   DEFAULT_PAGINATION_LIMIT,
+  type ReadableEscrowStatus,
 } from '@/common/constants';
 import { ExchangeNameValidator, IsChainId } from '@/common/validators';
 
@@ -128,6 +129,9 @@ export class CampaignData {
 
   @ApiProperty()
   status: CampaignStatus;
+
+  @ApiProperty({ name: 'escrow_status' })
+  escrowStatus: ReadableEscrowStatus;
 
   @ApiProperty()
   launcher: string;

--- a/campaign-launcher/server/src/modules/campaigns/campaigns.dto.ts
+++ b/campaign-launcher/server/src/modules/campaigns/campaigns.dto.ts
@@ -1,8 +1,8 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import {
+  IsEnum,
   IsEthereumAddress,
-  IsIn,
   IsNumber,
   IsOptional,
   IsPositive,
@@ -13,12 +13,12 @@ import {
 import {
   type ChainId,
   ChainIds,
-  type ReadableEscrowStatus,
-  READABLE_ESCROW_STATUSES,
   SUPPORTED_EXCHANGE_NAMES,
   DEFAULT_PAGINATION_LIMIT,
 } from '@/common/constants';
 import { ExchangeNameValidator, IsChainId } from '@/common/validators';
+
+import { CampaignStatus } from './types';
 
 export class GetCampaignsQueryDto {
   @ApiProperty({
@@ -45,11 +45,11 @@ export class GetCampaignsQueryDto {
 
   @ApiPropertyOptional({
     description: 'Status of campaign escrow',
-    enum: READABLE_ESCROW_STATUSES,
+    enum: CampaignStatus,
   })
   @IsOptional()
-  @IsIn(READABLE_ESCROW_STATUSES)
-  status?: ReadableEscrowStatus;
+  @IsEnum(CampaignStatus)
+  status?: CampaignStatus;
 
   @ApiPropertyOptional({
     default: DEFAULT_PAGINATION_LIMIT,
@@ -127,7 +127,7 @@ export class CampaignData {
   fundTokenDecimals: number;
 
   @ApiProperty()
-  status: ReadableEscrowStatus;
+  status: CampaignStatus;
 
   @ApiProperty()
   launcher: string;

--- a/campaign-launcher/server/src/modules/campaigns/campaigns.dto.ts
+++ b/campaign-launcher/server/src/modules/campaigns/campaigns.dto.ts
@@ -135,6 +135,15 @@ export class CampaignData {
 
   @ApiProperty()
   launcher: string;
+
+  @ApiProperty({ name: 'exchange_oracle' })
+  exchangeOracle: string;
+
+  @ApiProperty({ name: 'recording_oracle' })
+  recordingOracle: string;
+
+  @ApiProperty({ name: 'reputation_oracle' })
+  reputationOracle: string;
 }
 
 export class GetCampaignsResponseDto {

--- a/campaign-launcher/server/src/modules/campaigns/campaigns.service.ts
+++ b/campaign-launcher/server/src/modules/campaigns/campaigns.service.ts
@@ -63,6 +63,7 @@ export class CampaignsService {
     }
     const campaignEscrows = await EscrowUtils.getEscrows({
       chainId: chainId as number,
+      exchangeOracle: this.web3ConfigService.exchangeOracle,
       recordingOracle: this.web3ConfigService.recordingOracle,
       reputationOracle: this.web3ConfigService.reputationOracle,
       launcher: filters?.launcherAddress,
@@ -112,6 +113,9 @@ export class CampaignsService {
         status: ESCROW_TO_CAMPAIGN_STATUS[campaignEscrow.status],
         escrowStatus: campaignEscrow.status as ReadableEscrowStatus,
         launcher: ethers.getAddress(campaignEscrow.launcher),
+        exchangeOracle: campaignEscrow.exchangeOracle as string,
+        recordingOracle: campaignEscrow.recordingOracle as string,
+        reputationOracle: campaignEscrow.reputationOracle as string,
       });
     }
 
@@ -202,6 +206,9 @@ export class CampaignsService {
         amount: amount.toString(),
       })),
       launcher: ethers.getAddress(campaignEscrow.launcher),
+      exchangeOracle: campaignEscrow.exchangeOracle as string,
+      recordingOracle: campaignEscrow.recordingOracle as string,
+      reputationOracle: campaignEscrow.reputationOracle as string,
     };
   }
 

--- a/campaign-launcher/server/src/modules/campaigns/campaigns.service.ts
+++ b/campaign-launcher/server/src/modules/campaigns/campaigns.service.ts
@@ -7,7 +7,7 @@ import { Injectable } from '@nestjs/common';
 import dayjs from 'dayjs';
 import { ethers } from 'ethers';
 
-import { ChainId } from '@/common/constants';
+import { ChainId, ReadableEscrowStatus } from '@/common/constants';
 import * as httpUtils from '@/common/utils/http';
 import { Web3ConfigService } from '@/config';
 import logger from '@/logger';
@@ -110,6 +110,7 @@ export class CampaignsService {
         fundTokenSymbol: campaignTokenSymbol,
         fundTokenDecimals: campaignTokenDecimals,
         status: ESCROW_TO_CAMPAIGN_STATUS[campaignEscrow.status],
+        escrowStatus: campaignEscrow.status as ReadableEscrowStatus,
         launcher: ethers.getAddress(campaignEscrow.launcher),
       });
     }
@@ -193,6 +194,7 @@ export class CampaignsService {
       fundTokenSymbol: campaignTokenSymbol,
       fundTokenDecimals: campaignTokenDecimals,
       status: ESCROW_TO_CAMPAIGN_STATUS[campaignEscrow.status],
+      escrowStatus: campaignEscrow.status as ReadableEscrowStatus,
       // details
       amountPaid: campaignEscrow.amountPaid,
       dailyPaidAmounts: Object.entries(amountsPerDay).map(([date, amount]) => ({

--- a/campaign-launcher/server/src/modules/campaigns/campaigns.service.ts
+++ b/campaign-launcher/server/src/modules/campaigns/campaigns.service.ts
@@ -18,18 +18,21 @@ import { InvalidCampaignManifestError } from './campaigns.errors';
 import * as manifestUtils from './manifest.utils';
 import { CampaignManifest, CampaignStatus } from './types';
 
-const CAMPAIGN_TO_ESCROW_STATUSES: Record<CampaignStatus, EscrowStatus[]> = {
+const CAMPAIGN_STATUS_TO_ESCROW_STATUSES: Record<
+  CampaignStatus,
+  EscrowStatus[]
+> = {
   [CampaignStatus.ACTIVE]: [EscrowStatus.Pending, EscrowStatus.Partial],
   [CampaignStatus.CANCELLED]: [EscrowStatus.Cancelled],
   [CampaignStatus.COMPLETED]: [EscrowStatus.Complete],
 };
 
-const ESCROW_TO_CAMPAIGN_STATUS: Record<string, CampaignStatus> = {};
+const ESCROW_STATUS_TO_CAMPAIGN_STATUS: Record<string, CampaignStatus> = {};
 for (const [campaignStatus, escrowStatuses] of Object.entries(
-  CAMPAIGN_TO_ESCROW_STATUSES,
+  CAMPAIGN_STATUS_TO_ESCROW_STATUSES,
 )) {
   for (const escrowStatus of escrowStatuses) {
-    ESCROW_TO_CAMPAIGN_STATUS[EscrowStatus[escrowStatus]] =
+    ESCROW_STATUS_TO_CAMPAIGN_STATUS[EscrowStatus[escrowStatus]] =
       campaignStatus as CampaignStatus;
   }
 }
@@ -59,7 +62,7 @@ export class CampaignsService {
 
     let statuses: EscrowStatus[] | undefined;
     if (filters?.status) {
-      statuses = CAMPAIGN_TO_ESCROW_STATUSES[filters.status];
+      statuses = CAMPAIGN_STATUS_TO_ESCROW_STATUSES[filters.status];
     }
     const campaignEscrows = await EscrowUtils.getEscrows({
       chainId: chainId as number,
@@ -110,7 +113,7 @@ export class CampaignsService {
         fundToken: ethers.getAddress(campaignEscrow.token),
         fundTokenSymbol: campaignTokenSymbol,
         fundTokenDecimals: campaignTokenDecimals,
-        status: ESCROW_TO_CAMPAIGN_STATUS[campaignEscrow.status],
+        status: ESCROW_STATUS_TO_CAMPAIGN_STATUS[campaignEscrow.status],
         escrowStatus: campaignEscrow.status as ReadableEscrowStatus,
         launcher: ethers.getAddress(campaignEscrow.launcher),
         exchangeOracle: campaignEscrow.exchangeOracle as string,
@@ -197,7 +200,7 @@ export class CampaignsService {
       fundToken: ethers.getAddress(campaignEscrow.token),
       fundTokenSymbol: campaignTokenSymbol,
       fundTokenDecimals: campaignTokenDecimals,
-      status: ESCROW_TO_CAMPAIGN_STATUS[campaignEscrow.status],
+      status: ESCROW_STATUS_TO_CAMPAIGN_STATUS[campaignEscrow.status],
       escrowStatus: campaignEscrow.status as ReadableEscrowStatus,
       // details
       amountPaid: campaignEscrow.amountPaid,

--- a/campaign-launcher/server/src/modules/campaigns/types.ts
+++ b/campaign-launcher/server/src/modules/campaigns/types.ts
@@ -7,3 +7,9 @@ export type CampaignManifest = {
   start_date: Date;
   end_date: Date;
 };
+
+export enum CampaignStatus {
+  ACTIVE = 'active',
+  CANCELLED = 'cancelled',
+  COMPLETED = 'completed',
+}

--- a/recording-oracle/.env.example
+++ b/recording-oracle/.env.example
@@ -43,5 +43,7 @@ RPC_URL_POLYGON_AMOY=replace-me-if-needed
 RPC_URL_AURORA_TESTNET=replace-me-if-needed
 RPC_URL_LOCALHOST=replace-me-if-needed
 
+ALCHEMY_API_KEY=replace-me
+
 # Subgraph (Needed for accessing subgraph data)
 SUBGRAPH_API_KEY=replace-me

--- a/recording-oracle/package.json
+++ b/recording-oracle/package.json
@@ -39,6 +39,7 @@
     "@nestjs/swagger": "^11.2.0",
     "@nestjs/terminus": "^11.0.0",
     "@nestjs/typeorm": "^11.0.0",
+    "alchemy-sdk": "^3.6.2",
     "ccxt": "^4.4.88",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",

--- a/recording-oracle/src/common/constants/index.ts
+++ b/recording-oracle/src/common/constants/index.ts
@@ -1,11 +1,24 @@
-import * as ccxt from 'ccxt';
-
 export const DATABASE_SCHEMA_NAME = 'hu_fi';
 // Used for the first user authentication
 export const DEFAULT_NONCE = 'signup';
 export const JWT_STRATEGY_NAME = 'jwt-http';
 
-export const SUPPORTED_EXCHANGE_NAMES = [...ccxt.exchanges] as const;
+export const SUPPORTED_EXCHANGE_NAMES = [
+  'bigone',
+  'binance',
+  'bitget',
+  'bybit',
+  'coinbaseexchange',
+  'gate',
+  'htx',
+  'kraken',
+  'kucoin',
+  'mexc',
+  'okx',
+  'upbit',
+  'xt',
+] as const;
+export type SupportedExchange = (typeof SUPPORTED_EXCHANGE_NAMES)[number];
 
 export const EVM_SIGNATURE_REGEX = /^0x[0-9a-fA-F]{130}$/;
 

--- a/recording-oracle/src/common/validators/web3.ts
+++ b/recording-oracle/src/common/validators/web3.ts
@@ -4,11 +4,16 @@ import {
   ValidatorConstraintInterface,
 } from 'class-validator';
 
-import { SUPPORTED_EXCHANGE_NAMES } from '@/common/constants';
+import {
+  SUPPORTED_EXCHANGE_NAMES,
+  type SupportedExchange,
+} from '@/common/constants';
 
-const validExchangeNameSet = new Set(SUPPORTED_EXCHANGE_NAMES);
-export function isValidExchangeName(input: string): boolean {
-  return validExchangeNameSet.has(input);
+const validExchangeNameSet = new Set<SupportedExchange>(
+  SUPPORTED_EXCHANGE_NAMES,
+);
+export function isValidExchangeName(input: string): input is SupportedExchange {
+  return validExchangeNameSet.has(input as SupportedExchange);
 }
 
 @ValidatorConstraint({ name: 'ExchangeName', async: false })

--- a/recording-oracle/src/config/env-schema.ts
+++ b/recording-oracle/src/config/env-schema.ts
@@ -51,6 +51,7 @@ export const envValidator = Joi.object({
     .uri({ scheme: ['http', 'https'] })
     .allow(''),
   RPC_URL_LOCALHOST: Joi.string(),
+  ALCHEMY_API_KEY: Joi.string(),
   // S3
   S3_ENDPOINT: Joi.string(),
   S3_PORT: Joi.number().integer(),

--- a/recording-oracle/src/config/web3-config.service.ts
+++ b/recording-oracle/src/config/web3-config.service.ts
@@ -46,4 +46,8 @@ export class Web3ConfigService {
 
     return rpcUrlsByChainId[chainId];
   }
+
+  get alchemyApiKey(): string {
+    return this.configService.getOrThrow('ALCHEMY_API_KEY');
+  }
 }

--- a/recording-oracle/src/database/migrations/1753973381832-initial-migration.ts
+++ b/recording-oracle/src/database/migrations/1753973381832-initial-migration.ts
@@ -2,8 +2,8 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 
 import { DATABASE_SCHEMA_NAME } from '@/common/constants';
 
-export class InitialMigration1753720799709 implements MigrationInterface {
-  name = 'InitialMigration1753720799709';
+export class InitialMigration1753973381832 implements MigrationInterface {
+  name = 'InitialMigration1753973381832';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.createSchema(DATABASE_SCHEMA_NAME, true);
@@ -24,6 +24,15 @@ export class InitialMigration1753720799709 implements MigrationInterface {
       `CREATE UNIQUE INDEX "IDX_7ec2d9f22efc25135dc0e7731d" ON "hu_fi"."volume_stats" ("exchange_name", "campaign_address", "period_start") `,
     );
     await queryRunner.query(
+      `CREATE TYPE "hu_fi"."campaigns_status_enum" AS ENUM('active', 'pending_cancellation', 'cancelled', 'pending_completion', 'completed')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "hu_fi"."campaigns" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "chain_id" integer NOT NULL, "address" character varying(42) NOT NULL, "type" character varying(40) NOT NULL, "daily_volume_target" numeric(20,8) NOT NULL, "exchange_name" character varying(20) NOT NULL, "pair" character varying(20) NOT NULL, "start_date" TIMESTAMP WITH TIME ZONE NOT NULL, "end_date" TIMESTAMP WITH TIME ZONE NOT NULL, "fund_amount" numeric(30,18) NOT NULL, "fund_token" character varying(20) NOT NULL, "last_results_at" TIMESTAMP WITH TIME ZONE, "status" "hu_fi"."campaigns_status_enum" NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL, "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "PK_831e3fcd4fc45b4e4c3f57a9ee4" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_0130ea9fe1114c6f88f6ed6315" ON "hu_fi"."campaigns" ("chain_id", "address") `,
+    );
+    await queryRunner.query(
       `CREATE TABLE "hu_fi"."user_campaigns" ("user_id" uuid NOT NULL, "campaign_id" uuid NOT NULL, "exchange_api_key_id" uuid NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "PK_8ccc7f91e6aa94ef3e1c672f000" PRIMARY KEY ("user_id", "campaign_id"))`,
     );
     await queryRunner.query(
@@ -31,15 +40,6 @@ export class InitialMigration1753720799709 implements MigrationInterface {
     );
     await queryRunner.query(
       `CREATE TABLE "hu_fi"."refresh_tokens" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "user_id" uuid NOT NULL, "expires_at" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "REL_3ddc983c5f7bcf132fd8732c3f" UNIQUE ("user_id"), CONSTRAINT "PK_7d8bee0204106019488c4c50ffa" PRIMARY KEY ("id"))`,
-    );
-    await queryRunner.query(
-      `CREATE TYPE "hu_fi"."campaigns_status_enum" AS ENUM('active', 'pending_cancellation', 'cancelled', 'completed')`,
-    );
-    await queryRunner.query(
-      `CREATE TABLE "hu_fi"."campaigns" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "chain_id" integer NOT NULL, "address" character varying(42) NOT NULL, "type" character varying(40) NOT NULL, "daily_volume_target" numeric(20,8) NOT NULL, "exchange_name" character varying(20) NOT NULL, "pair" character varying(20) NOT NULL, "start_date" TIMESTAMP WITH TIME ZONE NOT NULL, "end_date" TIMESTAMP WITH TIME ZONE NOT NULL, "fund_amount" numeric(30,18) NOT NULL, "fund_token" character varying(20) NOT NULL, "last_results_at" TIMESTAMP WITH TIME ZONE, "status" "hu_fi"."campaigns_status_enum" NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL, "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "PK_831e3fcd4fc45b4e4c3f57a9ee4" PRIMARY KEY ("id"))`,
-    );
-    await queryRunner.query(
-      `CREATE UNIQUE INDEX "IDX_0130ea9fe1114c6f88f6ed6315" ON "hu_fi"."campaigns" ("chain_id", "address") `,
     );
     await queryRunner.query(
       `ALTER TABLE "hu_fi"."exchange_api_keys" ADD CONSTRAINT "FK_96ee74195b058a1b55afc49f673" FOREIGN KEY ("user_id") REFERENCES "hu_fi"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
@@ -74,16 +74,16 @@ export class InitialMigration1753720799709 implements MigrationInterface {
     await queryRunner.query(
       `ALTER TABLE "hu_fi"."exchange_api_keys" DROP CONSTRAINT "FK_96ee74195b058a1b55afc49f673"`,
     );
-    await queryRunner.query(
-      `DROP INDEX "hu_fi"."IDX_0130ea9fe1114c6f88f6ed6315"`,
-    );
-    await queryRunner.query(`DROP TABLE "hu_fi"."campaigns"`);
-    await queryRunner.query(`DROP TYPE "hu_fi"."campaigns_status_enum"`);
     await queryRunner.query(`DROP TABLE "hu_fi"."refresh_tokens"`);
     await queryRunner.query(
       `DROP INDEX "hu_fi"."idx_users_campaigns_campaign_id"`,
     );
     await queryRunner.query(`DROP TABLE "hu_fi"."user_campaigns"`);
+    await queryRunner.query(
+      `DROP INDEX "hu_fi"."IDX_0130ea9fe1114c6f88f6ed6315"`,
+    );
+    await queryRunner.query(`DROP TABLE "hu_fi"."campaigns"`);
+    await queryRunner.query(`DROP TYPE "hu_fi"."campaigns_status_enum"`);
     await queryRunner.query(
       `DROP INDEX "hu_fi"."IDX_7ec2d9f22efc25135dc0e7731d"`,
     );

--- a/recording-oracle/src/database/migrations/1754303207946-initial-migration.ts
+++ b/recording-oracle/src/database/migrations/1754303207946-initial-migration.ts
@@ -2,8 +2,8 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 
 import { DATABASE_SCHEMA_NAME } from '@/common/constants';
 
-export class InitialMigration1753973381832 implements MigrationInterface {
-  name = 'InitialMigration1753973381832';
+export class InitialMigration1754303207946 implements MigrationInterface {
+  name = 'InitialMigration1754303207946';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.createSchema(DATABASE_SCHEMA_NAME, true);
@@ -18,10 +18,13 @@ export class InitialMigration1753973381832 implements MigrationInterface {
       `CREATE UNIQUE INDEX "IDX_8dcd9d18790ca62ebf1fb40cd3" ON "hu_fi"."exchange_api_keys" ("user_id", "exchange_name") `,
     );
     await queryRunner.query(
-      `CREATE TABLE "hu_fi"."volume_stats" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "campaign_address" character varying(42) NOT NULL, "exchange_name" character varying(20) NOT NULL, "volume" numeric(20,2) NOT NULL, "period_start" TIMESTAMP WITH TIME ZONE NOT NULL, "period_end" TIMESTAMP WITH TIME ZONE NOT NULL, "recorded_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "PK_cb48bf745e9c4fc42bf2d8c567e" PRIMARY KEY ("id"))`,
+      `CREATE TABLE "hu_fi"."volume_stats" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "campaign_address" character varying(42) NOT NULL, "exchange_name" character varying(20) NOT NULL, "volume" numeric(20,2) NOT NULL, "volume_usd" numeric(20,2) NOT NULL, "period_start" TIMESTAMP WITH TIME ZONE NOT NULL, "period_end" TIMESTAMP WITH TIME ZONE NOT NULL, "recorded_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "PK_cb48bf745e9c4fc42bf2d8c567e" PRIMARY KEY ("id"))`,
     );
     await queryRunner.query(
       `CREATE UNIQUE INDEX "IDX_7ec2d9f22efc25135dc0e7731d" ON "hu_fi"."volume_stats" ("exchange_name", "campaign_address", "period_start") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "hu_fi"."refresh_tokens" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "user_id" uuid NOT NULL, "expires_at" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "REL_3ddc983c5f7bcf132fd8732c3f" UNIQUE ("user_id"), CONSTRAINT "PK_7d8bee0204106019488c4c50ffa" PRIMARY KEY ("id"))`,
     );
     await queryRunner.query(
       `CREATE TYPE "hu_fi"."campaigns_status_enum" AS ENUM('active', 'pending_cancellation', 'cancelled', 'pending_completion', 'completed')`,
@@ -39,10 +42,10 @@ export class InitialMigration1753973381832 implements MigrationInterface {
       `CREATE INDEX "idx_users_campaigns_campaign_id" ON "hu_fi"."user_campaigns" ("campaign_id") `,
     );
     await queryRunner.query(
-      `CREATE TABLE "hu_fi"."refresh_tokens" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "user_id" uuid NOT NULL, "expires_at" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "REL_3ddc983c5f7bcf132fd8732c3f" UNIQUE ("user_id"), CONSTRAINT "PK_7d8bee0204106019488c4c50ffa" PRIMARY KEY ("id"))`,
+      `ALTER TABLE "hu_fi"."exchange_api_keys" ADD CONSTRAINT "FK_96ee74195b058a1b55afc49f673" FOREIGN KEY ("user_id") REFERENCES "hu_fi"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
     );
     await queryRunner.query(
-      `ALTER TABLE "hu_fi"."exchange_api_keys" ADD CONSTRAINT "FK_96ee74195b058a1b55afc49f673" FOREIGN KEY ("user_id") REFERENCES "hu_fi"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+      `ALTER TABLE "hu_fi"."refresh_tokens" ADD CONSTRAINT "FK_3ddc983c5f7bcf132fd8732c3f4" FOREIGN KEY ("user_id") REFERENCES "hu_fi"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
     );
     await queryRunner.query(
       `ALTER TABLE "hu_fi"."user_campaigns" ADD CONSTRAINT "FK_4deae32968a6a500078abf381a1" FOREIGN KEY ("user_id") REFERENCES "hu_fi"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
@@ -53,15 +56,9 @@ export class InitialMigration1753973381832 implements MigrationInterface {
     await queryRunner.query(
       `ALTER TABLE "hu_fi"."user_campaigns" ADD CONSTRAINT "FK_9a1811aa669af54d7809c049525" FOREIGN KEY ("exchange_api_key_id") REFERENCES "hu_fi"."exchange_api_keys"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
     );
-    await queryRunner.query(
-      `ALTER TABLE "hu_fi"."refresh_tokens" ADD CONSTRAINT "FK_3ddc983c5f7bcf132fd8732c3f4" FOREIGN KEY ("user_id") REFERENCES "hu_fi"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
-    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(
-      `ALTER TABLE "hu_fi"."refresh_tokens" DROP CONSTRAINT "FK_3ddc983c5f7bcf132fd8732c3f4"`,
-    );
     await queryRunner.query(
       `ALTER TABLE "hu_fi"."user_campaigns" DROP CONSTRAINT "FK_9a1811aa669af54d7809c049525"`,
     );
@@ -72,9 +69,11 @@ export class InitialMigration1753973381832 implements MigrationInterface {
       `ALTER TABLE "hu_fi"."user_campaigns" DROP CONSTRAINT "FK_4deae32968a6a500078abf381a1"`,
     );
     await queryRunner.query(
+      `ALTER TABLE "hu_fi"."refresh_tokens" DROP CONSTRAINT "FK_3ddc983c5f7bcf132fd8732c3f4"`,
+    );
+    await queryRunner.query(
       `ALTER TABLE "hu_fi"."exchange_api_keys" DROP CONSTRAINT "FK_96ee74195b058a1b55afc49f673"`,
     );
-    await queryRunner.query(`DROP TABLE "hu_fi"."refresh_tokens"`);
     await queryRunner.query(
       `DROP INDEX "hu_fi"."idx_users_campaigns_campaign_id"`,
     );
@@ -84,6 +83,7 @@ export class InitialMigration1753973381832 implements MigrationInterface {
     );
     await queryRunner.query(`DROP TABLE "hu_fi"."campaigns"`);
     await queryRunner.query(`DROP TYPE "hu_fi"."campaigns_status_enum"`);
+    await queryRunner.query(`DROP TABLE "hu_fi"."refresh_tokens"`);
     await queryRunner.query(
       `DROP INDEX "hu_fi"."IDX_7ec2d9f22efc25135dc0e7731d"`,
     );

--- a/recording-oracle/src/modules/campaigns/campaigns.controller.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.controller.ts
@@ -26,10 +26,10 @@ import {
 } from './campaigns.dto';
 import { CampaignsControllerErrorsFilter } from './campaigns.error-filter';
 import { CampaignsService } from './campaigns.service';
-import { ExposedCampaignStatus, CampaignStatus } from './types';
+import { ReturnedCampaignStatus, CampaignStatus } from './types';
 
-const EXPOSED_TO_CAMPAIGN_STATUSES: Record<
-  ExposedCampaignStatus,
+const RETURNED_STATUS_TO_CAMPAIGN_STATUSES: Record<
+  ReturnedCampaignStatus,
   CampaignStatus[]
 > = {
   [CampaignStatus.ACTIVE]: [
@@ -41,13 +41,16 @@ const EXPOSED_TO_CAMPAIGN_STATUSES: Record<
   [CampaignStatus.COMPLETED]: [CampaignStatus.COMPLETED],
 };
 
-const CAMPAIGN_TO_EXPOSED_STATUS: Record<string, ExposedCampaignStatus> = {};
-for (const [exposedCampaignStatus, campaignStatuses] of Object.entries(
-  EXPOSED_TO_CAMPAIGN_STATUSES,
+const CAMPAIGN_STATUS_TO_RETURNED_STATUS: Record<
+  string,
+  ReturnedCampaignStatus
+> = {};
+for (const [returnedCampaignStatus, campaignStatuses] of Object.entries(
+  RETURNED_STATUS_TO_CAMPAIGN_STATUSES,
 )) {
   for (const campaignStatus of campaignStatuses) {
-    CAMPAIGN_TO_EXPOSED_STATUS[campaignStatus] =
-      exposedCampaignStatus as ExposedCampaignStatus;
+    CAMPAIGN_STATUS_TO_RETURNED_STATUS[campaignStatus] =
+      returnedCampaignStatus as ReturnedCampaignStatus;
   }
 }
 
@@ -101,7 +104,7 @@ export class CampaignsController {
     const limit = query.limit;
 
     const statuses: CampaignStatus[] = query.status
-      ? EXPOSED_TO_CAMPAIGN_STATUSES[query.status]
+      ? RETURNED_STATUS_TO_CAMPAIGN_STATUSES[query.status]
       : [];
 
     const campaigns = await this.campaignsService.getJoined(request.user.id, {
@@ -116,7 +119,7 @@ export class CampaignsController {
         .map((campaign) => ({
           chainId: campaign.chainId,
           address: campaign.address,
-          status: CAMPAIGN_TO_EXPOSED_STATUS[campaign.status],
+          status: CAMPAIGN_STATUS_TO_RETURNED_STATUS[campaign.status],
           processingStatus: campaign.status,
           exchangeName: campaign.exchangeName,
           tradingPair: campaign.pair,

--- a/recording-oracle/src/modules/campaigns/campaigns.dto.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.dto.ts
@@ -14,7 +14,7 @@ import {
   type ChainId,
 } from '@/common/constants';
 
-import { ExposedCampaignStatus } from './types';
+import { ReturnedCampaignStatus } from './types';
 
 export class JoinCampaignDto {
   @ApiProperty({ name: 'chain_id', enum: ChainIds })
@@ -65,11 +65,11 @@ export class JoinedCampaignDto {
 
 export class ListJoinedCampaignsQueryDto {
   @ApiPropertyOptional({
-    enum: ExposedCampaignStatus,
+    enum: ReturnedCampaignStatus,
   })
   @IsOptional()
-  @IsEnum(ExposedCampaignStatus)
-  status?: ExposedCampaignStatus;
+  @IsEnum(ReturnedCampaignStatus)
+  status?: ReturnedCampaignStatus;
 
   @ApiPropertyOptional({
     default: DEFAULT_PAGINATION_LIMIT,

--- a/recording-oracle/src/modules/campaigns/campaigns.dto.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.dto.ts
@@ -3,7 +3,6 @@ import { Transform } from 'class-transformer';
 import {
   IsEnum,
   IsEthereumAddress,
-  IsIn,
   IsNumber,
   IsOptional,
   IsPositive,
@@ -15,7 +14,7 @@ import {
   type ChainId,
 } from '@/common/constants';
 
-import { CampaignStatus } from './types';
+import { ExposedCampaignStatus } from './types';
 
 export class JoinCampaignDto {
   @ApiProperty({ name: 'chain_id', enum: ChainIds })
@@ -32,7 +31,7 @@ export class JoinCampaignSuccessDto {
   id: string;
 }
 
-class JoinedCampaignDto {
+export class JoinedCampaignDto {
   @ApiProperty({ name: 'chain_id' })
   chainId: number;
 
@@ -41,6 +40,9 @@ class JoinedCampaignDto {
 
   @ApiProperty()
   status: string;
+
+  @ApiProperty({ name: 'processing_status' })
+  processingStatus: string;
 
   @ApiProperty({ name: 'exchange_name' })
   exchangeName: string;
@@ -61,18 +63,13 @@ class JoinedCampaignDto {
   fundToken: string;
 }
 
-const VALID_CAMPAIGN_FILTER_STATUSES = [
-  CampaignStatus.ACTIVE,
-  CampaignStatus.COMPLETED,
-];
-
 export class ListJoinedCampaignsQueryDto {
   @ApiPropertyOptional({
-    enum: VALID_CAMPAIGN_FILTER_STATUSES,
+    enum: ExposedCampaignStatus,
   })
   @IsOptional()
-  @IsIn(VALID_CAMPAIGN_FILTER_STATUSES)
-  status?: CampaignStatus;
+  @IsEnum(ExposedCampaignStatus)
+  status?: ExposedCampaignStatus;
 
   @ApiPropertyOptional({
     default: DEFAULT_PAGINATION_LIMIT,

--- a/recording-oracle/src/modules/campaigns/campaigns.repository.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.repository.ts
@@ -42,4 +42,12 @@ export class CampaignsRepository extends Repository<CampaignEntity> {
 
     return results;
   }
+
+  async findForCompletionTracking(): Promise<CampaignEntity[]> {
+    return this.find({
+      where: {
+        status: CampaignStatus.PENDING_COMPLETION,
+      },
+    });
+  }
 }

--- a/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
@@ -1304,7 +1304,7 @@ describe('CampaignsService', () => {
       );
     });
 
-    it('should not complete campaign if not ended yet', async () => {
+    it('should not move campaign to "pending_completion" if not ended yet', async () => {
       const now = new Date();
       jest.useFakeTimers({ now });
 
@@ -1328,7 +1328,7 @@ describe('CampaignsService', () => {
       });
     });
 
-    it('should not complete campaign if reached its end date but not all results calculated', async () => {
+    it('should not move campaign to "pending_completion" if reached its end date but not all results calculated', async () => {
       const now = new Date();
       campaign.endDate = new Date(now.valueOf() - 1);
 
@@ -1361,7 +1361,7 @@ describe('CampaignsService', () => {
       });
     });
 
-    it('should complete campaign when reached its end date and all results calculated', async () => {
+    it('should move campaign to "pending_completion" when reached its end date and all results calculated', async () => {
       const now = new Date();
       campaign.endDate = new Date(now.valueOf() - 1);
 
@@ -1394,12 +1394,12 @@ describe('CampaignsService', () => {
       expect(mockCampaignsRepository.save).toHaveBeenCalledTimes(1);
       expect(mockCampaignsRepository.save).toHaveBeenCalledWith({
         ...campaign,
-        status: 'completed',
+        status: 'pending_completion',
         lastResultsAt: now,
       });
     });
 
-    it('should complete campaign if recording period dates overlap', async () => {
+    it('should move campaign to "pending_completion" campaign if recording period dates overlap', async () => {
       campaign.endDate = dayjs().subtract(1, 'day').toDate();
 
       campaign.startDate = dayjs(campaign.endDate).subtract(1, 'day').toDate();
@@ -1426,7 +1426,7 @@ describe('CampaignsService', () => {
       expect(mockCampaignsRepository.save).toHaveBeenCalledTimes(1);
       expect(mockCampaignsRepository.save).toHaveBeenCalledWith({
         ...campaign,
-        status: 'completed',
+        status: 'pending_completion',
         lastResultsAt: now,
       });
 

--- a/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
@@ -721,7 +721,7 @@ describe('CampaignsService', () => {
       const testSkip = faker.number.int();
 
       const campaigns = await campaignsService.getJoined(userId, {
-        status: testStatus as CampaignStatus,
+        statuses: [testStatus as CampaignStatus],
         limit: testLimit,
         skip: testSkip,
       });
@@ -731,7 +731,7 @@ describe('CampaignsService', () => {
       expect(mockUserCampaignsRepository.findByUserId).toHaveBeenCalledWith(
         userId,
         {
-          status: testStatus,
+          statuses: [testStatus],
           limit: testLimit,
           skip: testSkip,
         },

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -162,12 +162,16 @@ export class CampaignsService {
 
   async getJoined(
     userId: string,
-    options?: Partial<{ status?: CampaignStatus; limit: number; skip: number }>,
+    options?: Partial<{
+      statuses?: CampaignStatus[];
+      limit: number;
+      skip: number;
+    }>,
   ): Promise<CampaignEntity[]> {
     const userCampaigns = await this.userCampaignsRepository.findByUserId(
       userId,
       {
-        status: options?.status,
+        statuses: options?.statuses,
         limit: options?.limit,
         skip: options?.skip,
       },

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -565,6 +565,17 @@ export class CampaignsService {
     intermediateResult: IntermediateResult,
   ): Promise<void> {
     try {
+      const [_baseTokenSymbol, quoteTokenSymbol] = campaign.pair.split('/');
+
+      const quoteTokenPriceUsd =
+        await this.web3Service.getTokenPriceUsd(quoteTokenSymbol);
+
+      if (!quoteTokenPriceUsd) {
+        return;
+      }
+
+      const volumeUsd = intermediateResult.total_volume * quoteTokenPriceUsd;
+
       await this.volumeStatsRepository.upsert(
         {
           exchangeName: campaign.exchangeName,
@@ -572,6 +583,7 @@ export class CampaignsService {
           periodStart: new Date(intermediateResult.from),
           periodEnd: new Date(intermediateResult.to),
           volume: intermediateResult.total_volume.toString(),
+          volumeUsd: volumeUsd.toString(),
         },
         ['exchangeName', 'campaignAddress', 'periodStart'],
       );

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -13,13 +13,14 @@ import dayjs from 'dayjs';
 import { ethers } from 'ethers';
 import _ from 'lodash';
 
-import { SUPPORTED_EXCHANGE_NAMES } from '@/common/constants';
 import { ContentType } from '@/common/enums';
 import Environment from '@/common/utils/environment';
 import * as httpUtils from '@/common/utils/http';
 import { PgAdvisoryLock } from '@/common/utils/pg-advisory-lock';
+import { isValidExchangeName } from '@/common/validators';
 import { Web3ConfigService } from '@/config';
 import logger from '@/logger';
+import { ExchangeApiClientFactory } from '@/modules/exchange';
 import { ExchangeApiKeysService } from '@/modules/exchange-api-keys';
 import { StorageService } from '@/modules/storage';
 import type { UserEntity } from '@/modules/users';
@@ -52,7 +53,6 @@ import {
 import { UserCampaignEntity } from './user-campaign.entity';
 import { UserCampaignsRepository } from './user-campaigns.repository';
 import { VolumeStatsRepository } from './volume-stats.repository';
-import { ExchangeApiClientFactory } from '../exchange';
 
 const PROGRESS_RECORDING_SCHEDULE = Environment.isDevelopment()
   ? CronExpression.EVERY_MINUTE
@@ -248,7 +248,7 @@ export class CampaignsService {
     /*
      * Not including this into Joi schema to send meaningful errors
      */
-    if (!SUPPORTED_EXCHANGE_NAMES.includes(manifest.exchange)) {
+    if (!isValidExchangeName(manifest.exchange)) {
       throw new InvalidCampaign(
         campaignAddress,
         `Exchange not supported: ${manifest.exchange}`,

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -356,13 +356,14 @@ export class CampaignsService {
             /**
              * This can happen only in situations when:
              * - by some reason we lost data about campaign from DB, then re-added it
-             * - by some reason campaign was 'completed', but status changed to 'active'
+             * - by some reason campaign was 'pending_completion'/'completed', but status changed to 'active'
+             *
              * and then attempted to record it's progress but it must be
              * already finished and start-end dates overlap indicates that,
-             * so just mark it as completed, otherwise it leads to invalid intermediate results.
+             * so just mark it as pending_completion, otherwise it leads to invalid intermediate results.
              */
             logger.warn('Campaign progress period dates overlap');
-            campaign.status = CampaignStatus.COMPLETED;
+            campaign.status = CampaignStatus.PENDING_COMPLETION;
             campaign.lastResultsAt = new Date();
             await this.campaignsRepository.save(campaign);
             return;
@@ -399,11 +400,11 @@ export class CampaignsService {
           /**
            * There might be situations when due to delays/failures in processing
            * we reach campaign end date but still have periods to process,
-           * so mark campaign as completed only if results recorded for all periods,
+           * so mark campaign as pending completion only if results recorded for all periods,
            * otherwise keep it as is to wait for all periods to be recorded.
            */
           if (endDate.valueOf() === campaign.endDate.valueOf()) {
-            campaign.status = CampaignStatus.COMPLETED;
+            campaign.status = CampaignStatus.PENDING_COMPLETION;
           }
 
           campaign.lastResultsAt = new Date();

--- a/recording-oracle/src/modules/campaigns/fixtures/campaign.ts
+++ b/recording-oracle/src/modules/campaigns/fixtures/campaign.ts
@@ -18,7 +18,9 @@ import {
   IntermediateResultsData,
 } from '../types';
 
-export function generateCampaignEntity(): CampaignEntity {
+export function generateCampaignEntity(
+  overrides: Partial<CampaignEntity> = {},
+): CampaignEntity {
   const startDate = new Date();
   const durationInDays = faker.number.int({ min: 2, max: 7 });
 
@@ -35,6 +37,8 @@ export function generateCampaignEntity(): CampaignEntity {
     createdAt: faker.date.recent(),
     updatedAt: new Date(),
   };
+
+  Object.assign(campaign, overrides);
 
   return campaign as CampaignEntity;
 }

--- a/recording-oracle/src/modules/campaigns/types.ts
+++ b/recording-oracle/src/modules/campaigns/types.ts
@@ -10,7 +10,7 @@ export enum CampaignStatus {
   COMPLETED = 'completed',
 }
 
-export enum ExposedCampaignStatus {
+export enum ReturnedCampaignStatus {
   ACTIVE = 'active',
   CANCELLED = 'cancelled',
   COMPLETED = 'completed',

--- a/recording-oracle/src/modules/campaigns/types.ts
+++ b/recording-oracle/src/modules/campaigns/types.ts
@@ -10,6 +10,12 @@ export enum CampaignStatus {
   COMPLETED = 'completed',
 }
 
+export enum ExposedCampaignStatus {
+  ACTIVE = 'active',
+  CANCELLED = 'cancelled',
+  COMPLETED = 'completed',
+}
+
 export enum CampaignType {
   MARKET_MAKING = 'MARKET_MAKING',
 }

--- a/recording-oracle/src/modules/campaigns/types.ts
+++ b/recording-oracle/src/modules/campaigns/types.ts
@@ -6,6 +6,7 @@ export enum CampaignStatus {
   ACTIVE = 'active',
   PENDING_CANCELLATION = 'pending_cancellation',
   CANCELLED = 'cancelled',
+  PENDING_COMPLETION = 'pending_completion',
   COMPLETED = 'completed',
 }
 

--- a/recording-oracle/src/modules/campaigns/user-campaigns.repository.ts
+++ b/recording-oracle/src/modules/campaigns/user-campaigns.repository.ts
@@ -7,12 +7,6 @@ import type { CampaignEntity } from './campaign.entity';
 import { CampaignStatus } from './types';
 import { UserCampaignEntity } from './user-campaign.entity';
 
-type FindOptions = {
-  status?: CampaignStatus;
-  limit?: number;
-  skip?: number;
-};
-
 @Injectable()
 export class UserCampaignsRepository extends Repository<UserCampaignEntity> {
   constructor(dataSource: DataSource) {
@@ -21,14 +15,20 @@ export class UserCampaignsRepository extends Repository<UserCampaignEntity> {
 
   async findByUserId(
     userId: string,
-    options: FindOptions = {},
+    options: {
+      statuses?: CampaignStatus[];
+      limit?: number;
+      skip?: number;
+    } = {},
   ): Promise<CampaignEntity[]> {
     const query = this.createQueryBuilder('userCampaign')
       .leftJoinAndSelect('userCampaign.campaign', 'campaign')
       .where('userCampaign.userId = :userId', { userId });
 
-    if (options.status) {
-      query.andWhere('campaign.status = :status', { status: options.status });
+    if (options.statuses?.length) {
+      query.andWhere('campaign.status IN (:...statuses)', {
+        statuses: options.statuses,
+      });
     }
 
     query.orderBy('campaign.startDate').skip(options.skip).limit(options.limit);

--- a/recording-oracle/src/modules/campaigns/volume-stat.entity.ts
+++ b/recording-oracle/src/modules/campaigns/volume-stat.entity.ts
@@ -17,6 +17,9 @@ export class VolumeStatEntity {
   @Column({ type: 'decimal', precision: 20, scale: 2 })
   volume: string;
 
+  @Column({ type: 'decimal', precision: 20, scale: 2 })
+  volumeUsd: string;
+
   @Column({ type: 'timestamptz' })
   periodStart: Date;
 

--- a/recording-oracle/src/modules/statistics/statistics.dto.ts
+++ b/recording-oracle/src/modules/statistics/statistics.dto.ts
@@ -15,6 +15,6 @@ export class GetTotalVolumeQueryDto {
 }
 
 export class GetTotalVolumeResponseDto {
-  @ApiProperty()
+  @ApiProperty({ name: 'total_volume' })
   totalVolume: number;
 }

--- a/recording-oracle/src/modules/statistics/statistics.service.ts
+++ b/recording-oracle/src/modules/statistics/statistics.service.ts
@@ -15,7 +15,7 @@ export class StatisticsService {
       if (!inFlightPromisesCache.has(cacheKey)) {
         const totalVolumeQuery = this.volumeStatsRepository
           .createQueryBuilder('stat')
-          .select('COALESCE(SUM(stat.volume), 0)', 'totalVolume');
+          .select('COALESCE(SUM(stat.volume_usd), 0)', 'totalVolume');
 
         if (exchangeName) {
           totalVolumeQuery.where('stat.exchange_name = :exchangeName', {

--- a/recording-oracle/src/modules/web3/web3.service.spec.ts
+++ b/recording-oracle/src/modules/web3/web3.service.spec.ts
@@ -1,9 +1,13 @@
+jest.mock('@/logger');
+
 import { faker } from '@faker-js/faker';
 import { createMock } from '@golevelup/ts-jest';
 import { Test } from '@nestjs/testing';
+import { Alchemy } from 'alchemy-sdk';
 import { FeeData, JsonRpcProvider, Provider } from 'ethers';
 
 import { Web3ConfigService } from '@/config';
+import logger from '@/logger';
 
 import { generateTestnetChainId, mockWeb3ConfigService } from './fixtures';
 import type { WalletWithProvider } from './types';
@@ -102,5 +106,213 @@ describe('Web3Service', () => {
         `No gas price data for chain id: ${testChainId}`,
       );
     });
+  });
+
+  describe('getTokenPriceUsd', () => {
+    const testTokenSymbol = faker.finance.currencySymbol();
+
+    const mockTokenPriceCache = new Map();
+    const mockAlchemySdk = {
+      prices: createMock<Alchemy['prices']>(),
+    };
+
+    let replacedTokenPriceCacheRef: jest.ReplaceProperty<'tokenPriceCache'>;
+    let replacedAlchemySdkRef: jest.ReplaceProperty<'alchemySdk'>;
+
+    beforeAll(() => {
+      replacedTokenPriceCacheRef = jest.replaceProperty(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        web3Service as any,
+        'tokenPriceCache',
+        mockTokenPriceCache,
+      );
+      replacedAlchemySdkRef = jest.replaceProperty(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        web3Service as any,
+        'alchemySdk',
+        mockAlchemySdk,
+      );
+    });
+
+    afterAll(() => {
+      replacedTokenPriceCacheRef.restore();
+      replacedAlchemySdkRef.restore();
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+
+      mockTokenPriceCache.clear();
+    });
+
+    it('should log a warn if alchemy operation fails and throw', async () => {
+      const testError = new Error(faker.lorem.sentence());
+
+      mockAlchemySdk.prices.getTokenPriceBySymbol.mockRejectedValueOnce(
+        testError,
+      );
+
+      let thrownError;
+      try {
+        await web3Service.getTokenPriceUsd(testTokenSymbol);
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeInstanceOf(Error);
+      expect(thrownError.message).toBe('Failed to get token price');
+
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledWith(
+        'Error while getting token price',
+        {
+          symbol: testTokenSymbol,
+          error: testError,
+        },
+      );
+    });
+
+    it('should cache and return price if available', async () => {
+      const price = faker.number.float();
+      mockAlchemySdk.prices.getTokenPriceBySymbol.mockResolvedValueOnce({
+        data: [
+          {
+            symbol: testTokenSymbol,
+            prices: [
+              {
+                currency: 'usd',
+                value: price.toString(),
+                lastUpdatedAt: faker.date.recent().toISOString(),
+              },
+            ],
+            error: null,
+          },
+        ],
+      });
+
+      /**
+       * First call just to cache value
+       */
+      await web3Service.getTokenPriceUsd(testTokenSymbol);
+      /**
+       * Second call to retrieve cached
+       */
+      const result = await web3Service.getTokenPriceUsd(testTokenSymbol);
+
+      expect(result).toBe(price);
+      expect(mockAlchemySdk.prices.getTokenPriceBySymbol).toHaveBeenCalledTimes(
+        1,
+      );
+    });
+
+    it('should not cache and return price if available for different symbols', async () => {
+      const token1 = faker.finance.currencySymbol();
+      const price1 = faker.number.float();
+      mockAlchemySdk.prices.getTokenPriceBySymbol.mockResolvedValueOnce({
+        data: [
+          {
+            symbol: token1,
+            prices: [
+              {
+                currency: 'usd',
+                value: price1.toString(),
+                lastUpdatedAt: faker.date.recent().toISOString(),
+              },
+            ],
+            error: null,
+          },
+        ],
+      });
+      const token2 = faker.finance.currencySymbol();
+      const price2 = faker.number.float();
+      mockAlchemySdk.prices.getTokenPriceBySymbol.mockResolvedValueOnce({
+        data: [
+          {
+            symbol: token2,
+            prices: [
+              {
+                currency: 'usd',
+                value: price2.toString(),
+                lastUpdatedAt: faker.date.recent().toISOString(),
+              },
+            ],
+            error: null,
+          },
+        ],
+      });
+
+      const result1 = await web3Service.getTokenPriceUsd(token1);
+
+      expect(result1).toBe(price1);
+      expect(mockAlchemySdk.prices.getTokenPriceBySymbol).toHaveBeenCalledTimes(
+        1,
+      );
+
+      const result2 = await web3Service.getTokenPriceUsd(token2);
+
+      expect(result2).toBe(price2);
+      expect(mockAlchemySdk.prices.getTokenPriceBySymbol).toHaveBeenCalledTimes(
+        2,
+      );
+    });
+
+    it.each([
+      {
+        data: [
+          {
+            symbol: testTokenSymbol,
+            prices: [
+              {
+                currency: faker.string.sample(),
+                value: faker.number.float().toString(),
+                lastUpdatedAt: faker.date.recent().toISOString(),
+              },
+            ],
+            error: null,
+          },
+        ],
+      },
+      {
+        data: [
+          {
+            symbol: testTokenSymbol,
+            prices: [],
+            error: {
+              message: 'Token not found',
+            },
+          },
+        ],
+      },
+    ])(
+      'should cache and return null if price is not available [%#]',
+      async (apiResponse) => {
+        mockAlchemySdk.prices.getTokenPriceBySymbol.mockResolvedValueOnce(
+          apiResponse,
+        );
+
+        /**
+         * First call just to cache value
+         */
+        await web3Service.getTokenPriceUsd(testTokenSymbol);
+        /**
+         * Second call to retrieve cached
+         */
+        const result = await web3Service.getTokenPriceUsd(testTokenSymbol);
+
+        expect(result).toBe(null);
+        expect(
+          mockAlchemySdk.prices.getTokenPriceBySymbol,
+        ).toHaveBeenCalledTimes(1);
+
+        expect(logger.warn).toHaveBeenCalledTimes(1);
+        expect(logger.warn).toHaveBeenCalledWith(
+          'Token price in USD is not available',
+          {
+            symbol: testTokenSymbol,
+            apiResult: apiResponse.data[0],
+          },
+        );
+      },
+    );
   });
 });

--- a/recording-oracle/yarn.lock
+++ b/recording-oracle/yarn.lock
@@ -428,6 +428,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.25.0":
+  version: 7.28.2
+  resolution: "@babel/runtime@npm:7.28.2"
+  checksum: 10c0/c20afe253629d53a405a610b12a62ac74d341a2c1e0fb202bbef0c118f6b5c84f94bf16039f58fd0483dd256901259930a43976845bdeb180cab1f882c21b6e0
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.27.2, @babel/template@npm:^7.3.3":
   version: 7.27.2
   resolution: "@babel/template@npm:7.27.2"
@@ -780,6 +787,394 @@ __metadata:
     "@eslint/core": "npm:^0.14.0"
     levn: "npm:^0.4.1"
   checksum: 10c0/a75f0b5d38430318a551b83e27bee570747eb50beeb76b03f64b0e78c2c27ef3d284cfda3443134df028db3251719bc0850c105f778122f6ad762d5270ec8063
+  languageName: node
+  linkType: hard
+
+"@ethersproject/abi@npm:^5.7.0, @ethersproject/abi@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/abi@npm:5.8.0"
+  dependencies:
+    "@ethersproject/address": "npm:^5.8.0"
+    "@ethersproject/bignumber": "npm:^5.8.0"
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/constants": "npm:^5.8.0"
+    "@ethersproject/hash": "npm:^5.8.0"
+    "@ethersproject/keccak256": "npm:^5.8.0"
+    "@ethersproject/logger": "npm:^5.8.0"
+    "@ethersproject/properties": "npm:^5.8.0"
+    "@ethersproject/strings": "npm:^5.8.0"
+  checksum: 10c0/6b759247a2f43ecc1548647d0447d08de1e946dfc7e71bfb014fa2f749c1b76b742a1d37394660ebab02ff8565674b3593fdfa011e16a5adcfc87ca4d85af39c
+  languageName: node
+  linkType: hard
+
+"@ethersproject/abstract-provider@npm:^5.7.0, @ethersproject/abstract-provider@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/abstract-provider@npm:5.8.0"
+  dependencies:
+    "@ethersproject/bignumber": "npm:^5.8.0"
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/logger": "npm:^5.8.0"
+    "@ethersproject/networks": "npm:^5.8.0"
+    "@ethersproject/properties": "npm:^5.8.0"
+    "@ethersproject/transactions": "npm:^5.8.0"
+    "@ethersproject/web": "npm:^5.8.0"
+  checksum: 10c0/9c183da1d037b272ff2b03002c3d801088d0534f88985f4983efc5f3ebd59b05f04bc05db97792fe29ddf87eeba3c73416e5699615f183126f85f877ea6c8637
+  languageName: node
+  linkType: hard
+
+"@ethersproject/abstract-signer@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/abstract-signer@npm:5.8.0"
+  dependencies:
+    "@ethersproject/abstract-provider": "npm:^5.8.0"
+    "@ethersproject/bignumber": "npm:^5.8.0"
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/logger": "npm:^5.8.0"
+    "@ethersproject/properties": "npm:^5.8.0"
+  checksum: 10c0/143f32d7cb0bc7064e45674d4a9dffdb90d6171425d20e8de9dc95765be960534bae7246ead400e6f52346624b66569d9585d790eedd34b0b6b7f481ec331cc2
+  languageName: node
+  linkType: hard
+
+"@ethersproject/address@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/address@npm:5.8.0"
+  dependencies:
+    "@ethersproject/bignumber": "npm:^5.8.0"
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/keccak256": "npm:^5.8.0"
+    "@ethersproject/logger": "npm:^5.8.0"
+    "@ethersproject/rlp": "npm:^5.8.0"
+  checksum: 10c0/8bac8a4b567c75c1abc00eeca08c200de1a2d5cf76d595dc04fa4d7bff9ffa5530b2cdfc5e8656cfa8f6fa046de54be47620a092fb429830a8ddde410b9d50bc
+  languageName: node
+  linkType: hard
+
+"@ethersproject/base64@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/base64@npm:5.8.0"
+  dependencies:
+    "@ethersproject/bytes": "npm:^5.8.0"
+  checksum: 10c0/60ae6d1e2367d70f4090b717852efe62075442ae59aeac9bb1054fe8306a2de8ef0b0561e7fb4666ecb1f8efa1655d683dd240675c3a25d6fa867245525a63ca
+  languageName: node
+  linkType: hard
+
+"@ethersproject/basex@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/basex@npm:5.8.0"
+  dependencies:
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/properties": "npm:^5.8.0"
+  checksum: 10c0/46a94ba9678fc458ab0bee4a0af9f659f1d3f5df5bb98485924fe8ecbd46eda37d81f95f882243d56f0f5efe051b0749163f5056e48ff836c5fba648754d4956
+  languageName: node
+  linkType: hard
+
+"@ethersproject/bignumber@npm:^5.7.0, @ethersproject/bignumber@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/bignumber@npm:5.8.0"
+  dependencies:
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/logger": "npm:^5.8.0"
+    bn.js: "npm:^5.2.1"
+  checksum: 10c0/8e87fa96999d59d0ab4c814c79e3a8354d2ba914dfa78cf9ee688f53110473cec0df0db2aaf9d447e84ab2dbbfca39979abac4f2dac69fef4d080f4cc3e29613
+  languageName: node
+  linkType: hard
+
+"@ethersproject/bytes@npm:^5.7.0, @ethersproject/bytes@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/bytes@npm:5.8.0"
+  dependencies:
+    "@ethersproject/logger": "npm:^5.8.0"
+  checksum: 10c0/47ef798f3ab43b95dc74097b2c92365c919308ecabc3e34d9f8bf7f886fa4b99837ba5cf4dc8921baaaafe6899982f96b0e723b3fc49132c061f83d1ca3fed8b
+  languageName: node
+  linkType: hard
+
+"@ethersproject/constants@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/constants@npm:5.8.0"
+  dependencies:
+    "@ethersproject/bignumber": "npm:^5.8.0"
+  checksum: 10c0/374b3c2c6da24f8fef62e2316eae96faa462826c0774ef588cd7313ae7ddac8eb1bb85a28dad80123148be2ba0821c217c14ecfc18e2e683c72adc734b6248c9
+  languageName: node
+  linkType: hard
+
+"@ethersproject/contracts@npm:^5.7.0":
+  version: 5.8.0
+  resolution: "@ethersproject/contracts@npm:5.8.0"
+  dependencies:
+    "@ethersproject/abi": "npm:^5.8.0"
+    "@ethersproject/abstract-provider": "npm:^5.8.0"
+    "@ethersproject/abstract-signer": "npm:^5.8.0"
+    "@ethersproject/address": "npm:^5.8.0"
+    "@ethersproject/bignumber": "npm:^5.8.0"
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/constants": "npm:^5.8.0"
+    "@ethersproject/logger": "npm:^5.8.0"
+    "@ethersproject/properties": "npm:^5.8.0"
+    "@ethersproject/transactions": "npm:^5.8.0"
+  checksum: 10c0/49961b92334c4f2fab5f4da8f3119e97c1dc39cc8695e3043931757968213f5e732c00bf896193cf0186dcb33101dcd6efb70690dee0dd2cfbfd3843f55485aa
+  languageName: node
+  linkType: hard
+
+"@ethersproject/hash@npm:^5.7.0, @ethersproject/hash@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/hash@npm:5.8.0"
+  dependencies:
+    "@ethersproject/abstract-signer": "npm:^5.8.0"
+    "@ethersproject/address": "npm:^5.8.0"
+    "@ethersproject/base64": "npm:^5.8.0"
+    "@ethersproject/bignumber": "npm:^5.8.0"
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/keccak256": "npm:^5.8.0"
+    "@ethersproject/logger": "npm:^5.8.0"
+    "@ethersproject/properties": "npm:^5.8.0"
+    "@ethersproject/strings": "npm:^5.8.0"
+  checksum: 10c0/72a287d4d70fae716827587339ffb449b8c23ef8728db6f8a661f359f7cb1e5ffba5b693c55e09d4e7162bf56af4a0e98a334784e0706d98102d1a5786241537
+  languageName: node
+  linkType: hard
+
+"@ethersproject/hdnode@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/hdnode@npm:5.8.0"
+  dependencies:
+    "@ethersproject/abstract-signer": "npm:^5.8.0"
+    "@ethersproject/basex": "npm:^5.8.0"
+    "@ethersproject/bignumber": "npm:^5.8.0"
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/logger": "npm:^5.8.0"
+    "@ethersproject/pbkdf2": "npm:^5.8.0"
+    "@ethersproject/properties": "npm:^5.8.0"
+    "@ethersproject/sha2": "npm:^5.8.0"
+    "@ethersproject/signing-key": "npm:^5.8.0"
+    "@ethersproject/strings": "npm:^5.8.0"
+    "@ethersproject/transactions": "npm:^5.8.0"
+    "@ethersproject/wordlists": "npm:^5.8.0"
+  checksum: 10c0/da0ac7d60e76a76471be1f4f3bba3f28a24165dc3b63c6930a9ec24481e9f8b23936e5fc96363b3591cdfda4381d4623f25b06898b89bf5530b158cb5ea58fdd
+  languageName: node
+  linkType: hard
+
+"@ethersproject/json-wallets@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/json-wallets@npm:5.8.0"
+  dependencies:
+    "@ethersproject/abstract-signer": "npm:^5.8.0"
+    "@ethersproject/address": "npm:^5.8.0"
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/hdnode": "npm:^5.8.0"
+    "@ethersproject/keccak256": "npm:^5.8.0"
+    "@ethersproject/logger": "npm:^5.8.0"
+    "@ethersproject/pbkdf2": "npm:^5.8.0"
+    "@ethersproject/properties": "npm:^5.8.0"
+    "@ethersproject/random": "npm:^5.8.0"
+    "@ethersproject/strings": "npm:^5.8.0"
+    "@ethersproject/transactions": "npm:^5.8.0"
+    aes-js: "npm:3.0.0"
+    scrypt-js: "npm:3.0.1"
+  checksum: 10c0/6c5cac87bdfac9ac47bf6ac25168a85865dc02e398e97f83820568c568a8cb27cf13a3a5d482f71a2534c7d704a3faa46023bb7ebe8737872b376bec1b66c67b
+  languageName: node
+  linkType: hard
+
+"@ethersproject/keccak256@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/keccak256@npm:5.8.0"
+  dependencies:
+    "@ethersproject/bytes": "npm:^5.8.0"
+    js-sha3: "npm:0.8.0"
+  checksum: 10c0/cd93ac6a5baf842313cde7de5e6e2c41feeea800db9e82955f96e7f3462d2ac6a6a29282b1c9e93b84ce7c91eec02347043c249fd037d6051214275bfc7fe99f
+  languageName: node
+  linkType: hard
+
+"@ethersproject/logger@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/logger@npm:5.8.0"
+  checksum: 10c0/7f39f33e8f254ee681d4778bb71ce3c5de248e1547666f85c43bfbc1c18996c49a31f969f056b66d23012f2420f2d39173107284bc41eb98d0482ace1d06403e
+  languageName: node
+  linkType: hard
+
+"@ethersproject/networks@npm:^5.7.0, @ethersproject/networks@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/networks@npm:5.8.0"
+  dependencies:
+    "@ethersproject/logger": "npm:^5.8.0"
+  checksum: 10c0/3f23bcc4c3843cc9b7e4b9f34df0a1f230b24dc87d51cdad84552302159a84d7899cd80c8a3d2cf8007b09ac373a5b10407007adde23d4c4881a4d6ee6bc4b9c
+  languageName: node
+  linkType: hard
+
+"@ethersproject/pbkdf2@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/pbkdf2@npm:5.8.0"
+  dependencies:
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/sha2": "npm:^5.8.0"
+  checksum: 10c0/0397cf5370cfd568743c3e46ac431f1bd425239baa2691689f1430997d44d310cef5051ea9ee53fabe444f96aced8d6324b41da698e8d7021389dce36251e7e9
+  languageName: node
+  linkType: hard
+
+"@ethersproject/properties@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/properties@npm:5.8.0"
+  dependencies:
+    "@ethersproject/logger": "npm:^5.8.0"
+  checksum: 10c0/20256d7eed65478a38dabdea4c3980c6591b7b75f8c45089722b032ceb0e1cd3dd6dd60c436cfe259337e6909c28d99528c172d06fc74bbd61be8eb9e68be2e6
+  languageName: node
+  linkType: hard
+
+"@ethersproject/providers@npm:^5.7.0":
+  version: 5.8.0
+  resolution: "@ethersproject/providers@npm:5.8.0"
+  dependencies:
+    "@ethersproject/abstract-provider": "npm:^5.8.0"
+    "@ethersproject/abstract-signer": "npm:^5.8.0"
+    "@ethersproject/address": "npm:^5.8.0"
+    "@ethersproject/base64": "npm:^5.8.0"
+    "@ethersproject/basex": "npm:^5.8.0"
+    "@ethersproject/bignumber": "npm:^5.8.0"
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/constants": "npm:^5.8.0"
+    "@ethersproject/hash": "npm:^5.8.0"
+    "@ethersproject/logger": "npm:^5.8.0"
+    "@ethersproject/networks": "npm:^5.8.0"
+    "@ethersproject/properties": "npm:^5.8.0"
+    "@ethersproject/random": "npm:^5.8.0"
+    "@ethersproject/rlp": "npm:^5.8.0"
+    "@ethersproject/sha2": "npm:^5.8.0"
+    "@ethersproject/strings": "npm:^5.8.0"
+    "@ethersproject/transactions": "npm:^5.8.0"
+    "@ethersproject/web": "npm:^5.8.0"
+    bech32: "npm:1.1.4"
+    ws: "npm:8.18.0"
+  checksum: 10c0/893dba429443bbf0a3eadef850e772ad1c706cf17ae6ae48b73467a23b614a3f461e9004850e24439b5c73d30e9259bc983f0f90a911ba11af749e6384fd355a
+  languageName: node
+  linkType: hard
+
+"@ethersproject/random@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/random@npm:5.8.0"
+  dependencies:
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/logger": "npm:^5.8.0"
+  checksum: 10c0/e44c010715668fc29383141ae16cd2ec00c34a434d47e23338e740b8c97372515d95d3b809b969eab2055c19e92b985ca591d326fbb71270c26333215f9925d1
+  languageName: node
+  linkType: hard
+
+"@ethersproject/rlp@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/rlp@npm:5.8.0"
+  dependencies:
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/logger": "npm:^5.8.0"
+  checksum: 10c0/db742ec9c1566d6441242cc2c2ae34c1e5304d48e1fe62bc4e53b1791f219df211e330d2de331e0e4f74482664e205c2e4220e76138bd71f1ec07884e7f5221b
+  languageName: node
+  linkType: hard
+
+"@ethersproject/sha2@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/sha2@npm:5.8.0"
+  dependencies:
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/logger": "npm:^5.8.0"
+    hash.js: "npm:1.1.7"
+  checksum: 10c0/eab941907b7d40ee8436acaaedee32306ed4de2cb9ab37543bc89b1dd2a78f28c8da21efd848525fa1b04a78575be426cfca28f5392f4d28ce6c84e7c26a9421
+  languageName: node
+  linkType: hard
+
+"@ethersproject/signing-key@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/signing-key@npm:5.8.0"
+  dependencies:
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/logger": "npm:^5.8.0"
+    "@ethersproject/properties": "npm:^5.8.0"
+    bn.js: "npm:^5.2.1"
+    elliptic: "npm:6.6.1"
+    hash.js: "npm:1.1.7"
+  checksum: 10c0/a7ff6cd344b0609737a496b6d5b902cf5528ed5a7ce2c0db5e7b69dc491d1810d1d0cd51dddf9dc74dd562ab4961d76e982f1750359b834c53c202e85e4c8502
+  languageName: node
+  linkType: hard
+
+"@ethersproject/strings@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/strings@npm:5.8.0"
+  dependencies:
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/constants": "npm:^5.8.0"
+    "@ethersproject/logger": "npm:^5.8.0"
+  checksum: 10c0/6db39503c4be130110612b6d593a381c62657e41eebf4f553247ebe394fda32cdf74ff645daee7b7860d209fd02c7e909a95b1f39a2f001c662669b9dfe81d00
+  languageName: node
+  linkType: hard
+
+"@ethersproject/transactions@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/transactions@npm:5.8.0"
+  dependencies:
+    "@ethersproject/address": "npm:^5.8.0"
+    "@ethersproject/bignumber": "npm:^5.8.0"
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/constants": "npm:^5.8.0"
+    "@ethersproject/keccak256": "npm:^5.8.0"
+    "@ethersproject/logger": "npm:^5.8.0"
+    "@ethersproject/properties": "npm:^5.8.0"
+    "@ethersproject/rlp": "npm:^5.8.0"
+    "@ethersproject/signing-key": "npm:^5.8.0"
+  checksum: 10c0/dd32f090df5945313aafa8430ce76834479750d6655cb786c3b65ec841c94596b14d3c8c59ee93eed7b4f32f27d321a9b8b43bc6bb51f7e1c6694f82639ffe68
+  languageName: node
+  linkType: hard
+
+"@ethersproject/units@npm:^5.7.0":
+  version: 5.8.0
+  resolution: "@ethersproject/units@npm:5.8.0"
+  dependencies:
+    "@ethersproject/bignumber": "npm:^5.8.0"
+    "@ethersproject/constants": "npm:^5.8.0"
+    "@ethersproject/logger": "npm:^5.8.0"
+  checksum: 10c0/5f92b8379a58024078fce6a4cbf7323cfd79bc41ef8f0a7bbf8be9c816ce18783140ab0d5c8d34ed615639aef7fc3a2ed255e92809e3558a510c4f0d49e27309
+  languageName: node
+  linkType: hard
+
+"@ethersproject/wallet@npm:^5.7.0":
+  version: 5.8.0
+  resolution: "@ethersproject/wallet@npm:5.8.0"
+  dependencies:
+    "@ethersproject/abstract-provider": "npm:^5.8.0"
+    "@ethersproject/abstract-signer": "npm:^5.8.0"
+    "@ethersproject/address": "npm:^5.8.0"
+    "@ethersproject/bignumber": "npm:^5.8.0"
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/hash": "npm:^5.8.0"
+    "@ethersproject/hdnode": "npm:^5.8.0"
+    "@ethersproject/json-wallets": "npm:^5.8.0"
+    "@ethersproject/keccak256": "npm:^5.8.0"
+    "@ethersproject/logger": "npm:^5.8.0"
+    "@ethersproject/properties": "npm:^5.8.0"
+    "@ethersproject/random": "npm:^5.8.0"
+    "@ethersproject/signing-key": "npm:^5.8.0"
+    "@ethersproject/transactions": "npm:^5.8.0"
+    "@ethersproject/wordlists": "npm:^5.8.0"
+  checksum: 10c0/6da450872dda3d9008bad3ccf8467816a63429241e51c66627647123c0fe5625494c4f6c306e098eb8419cc5702ac017d41f5161af5ff670a41fe5d199883c09
+  languageName: node
+  linkType: hard
+
+"@ethersproject/web@npm:^5.7.0, @ethersproject/web@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/web@npm:5.8.0"
+  dependencies:
+    "@ethersproject/base64": "npm:^5.8.0"
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/logger": "npm:^5.8.0"
+    "@ethersproject/properties": "npm:^5.8.0"
+    "@ethersproject/strings": "npm:^5.8.0"
+  checksum: 10c0/e3cd547225638db6e94fcd890001c778d77adb0d4f11a7f8c447e961041678f3fbfaffe77a962c7aa3f6597504232442e7015f2335b1788508a108708a30308a
+  languageName: node
+  linkType: hard
+
+"@ethersproject/wordlists@npm:^5.8.0":
+  version: 5.8.0
+  resolution: "@ethersproject/wordlists@npm:5.8.0"
+  dependencies:
+    "@ethersproject/bytes": "npm:^5.8.0"
+    "@ethersproject/hash": "npm:^5.8.0"
+    "@ethersproject/logger": "npm:^5.8.0"
+    "@ethersproject/properties": "npm:^5.8.0"
+    "@ethersproject/strings": "npm:^5.8.0"
+  checksum: 10c0/e230a2ba075006bc3a2538e096003e43ef9ba453317f37a4d99638720487ec447c1fa61a592c80483f8a8ad6466511cf4cf5c49cf84464a1679999171ce311f4
   languageName: node
   linkType: hard
 
@@ -1829,6 +2224,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/curves@npm:^1.4.2":
+  version: 1.9.6
+  resolution: "@noble/curves@npm:1.9.6"
+  dependencies:
+    "@noble/hashes": "npm:1.8.0"
+  checksum: 10c0/e462875ad752d2cdffc3c7b27b6de3adcff5fae0731e94138bd9e452c5f9b7aaf4c01ea6c62d3c0544b4e7419662535bb2ef1103311de48d51885c053206e118
+  languageName: node
+  linkType: hard
+
 "@noble/hashes@npm:1.3.2":
   version: 1.3.2
   resolution: "@noble/hashes@npm:1.3.2"
@@ -1836,7 +2240,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:^1.1.5":
+"@noble/hashes@npm:1.8.0, @noble/hashes@npm:^1.1.5, @noble/hashes@npm:^1.4.0":
   version: 1.8.0
   resolution: "@noble/hashes@npm:1.8.0"
   checksum: 10c0/06a0b52c81a6fa7f04d67762e08b2c476a00285858150caeaaff4037356dd5e119f45b2a530f638b77a5eeca013168ec1b655db41bae3236cb2e9d511484fc77
@@ -2152,10 +2556,88 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/buffer-layout@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@solana/buffer-layout@npm:4.0.1"
+  dependencies:
+    buffer: "npm:~6.0.3"
+  checksum: 10c0/6535f3908cf6dfc405b665795f0c2eaa0482a8c6b1811403945cf7b450e7eb7b40acce3e8af046f2fcc3eea1a15e61d48c418315d813bee4b720d56b00053305
+  languageName: node
+  linkType: hard
+
+"@solana/codecs-core@npm:2.3.0":
+  version: 2.3.0
+  resolution: "@solana/codecs-core@npm:2.3.0"
+  dependencies:
+    "@solana/errors": "npm:2.3.0"
+  peerDependencies:
+    typescript: ">=5.3.3"
+  checksum: 10c0/efef080b94fe572bcfeac9f1c0b222700203bd2b45c9590e77445b35335d0ed2582d1cc4e533003d2090c385c06eb93dfa05388f9766182aa60ce85eacfd8042
+  languageName: node
+  linkType: hard
+
+"@solana/codecs-numbers@npm:^2.1.0":
+  version: 2.3.0
+  resolution: "@solana/codecs-numbers@npm:2.3.0"
+  dependencies:
+    "@solana/codecs-core": "npm:2.3.0"
+    "@solana/errors": "npm:2.3.0"
+  peerDependencies:
+    typescript: ">=5.3.3"
+  checksum: 10c0/0780d60771e451cfe22ea614315fed2f37507aa62f83cddb900186f88d4d4532eea298d74796d1dbc8c34321a570b5d9ada25e8f4a5aeadd57aa4e688b4465f5
+  languageName: node
+  linkType: hard
+
+"@solana/errors@npm:2.3.0":
+  version: 2.3.0
+  resolution: "@solana/errors@npm:2.3.0"
+  dependencies:
+    chalk: "npm:^5.4.1"
+    commander: "npm:^14.0.0"
+  peerDependencies:
+    typescript: ">=5.3.3"
+  bin:
+    errors: bin/cli.mjs
+  checksum: 10c0/55bef8828b4a6bb5222d3dbfe27162684906ba90753126b9cfd1e8e39c6c29209c0f4f331cfb1d3d1cf43fd456022af92337b4234a145d8de292588197c12c71
+  languageName: node
+  linkType: hard
+
+"@solana/web3.js@npm:^1.87.6":
+  version: 1.98.4
+  resolution: "@solana/web3.js@npm:1.98.4"
+  dependencies:
+    "@babel/runtime": "npm:^7.25.0"
+    "@noble/curves": "npm:^1.4.2"
+    "@noble/hashes": "npm:^1.4.0"
+    "@solana/buffer-layout": "npm:^4.0.1"
+    "@solana/codecs-numbers": "npm:^2.1.0"
+    agentkeepalive: "npm:^4.5.0"
+    bn.js: "npm:^5.2.1"
+    borsh: "npm:^0.7.0"
+    bs58: "npm:^4.0.1"
+    buffer: "npm:6.0.3"
+    fast-stable-stringify: "npm:^1.0.0"
+    jayson: "npm:^4.1.1"
+    node-fetch: "npm:^2.7.0"
+    rpc-websockets: "npm:^9.0.2"
+    superstruct: "npm:^2.0.2"
+  checksum: 10c0/73bf7b6b5b65c7f264587182bbfd65327775b4f3e4831750de6356f58858e57d49213098eec671650940bb7a9bbaa1f352e0710c4075f126d903d72ddddcbdbc
+  languageName: node
+  linkType: hard
+
 "@sqltools/formatter@npm:^1.2.5":
   version: 1.2.5
   resolution: "@sqltools/formatter@npm:1.2.5"
   checksum: 10c0/4b4fa62b8cd4880784b71cc5edd4a13da04fda0a915c14282765a8ec1a900a495e69b322704413e2052d221b5646d9fb0e20e87911f9a8f438f33180eecb11a4
+  languageName: node
+  linkType: hard
+
+"@swc/helpers@npm:^0.5.11":
+  version: 0.5.17
+  resolution: "@swc/helpers@npm:0.5.17"
+  dependencies:
+    tslib: "npm:^2.8.0"
+  checksum: 10c0/fe1f33ebb968558c5a0c595e54f2e479e4609bff844f9ca9a2d1ffd8dd8504c26f862a11b031f48f75c95b0381c2966c3dd156e25942f90089badd24341e7dbb
   languageName: node
   linkType: hard
 
@@ -2274,7 +2756,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/connect@npm:*":
+"@types/connect@npm:*, @types/connect@npm:^3.4.33":
   version: 3.4.38
   resolution: "@types/connect@npm:3.4.38"
   dependencies:
@@ -2491,6 +2973,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^12.12.54":
+  version: 12.20.55
+  resolution: "@types/node@npm:12.20.55"
+  checksum: 10c0/3b190bb0410047d489c49bbaab592d2e6630de6a50f00ba3d7d513d59401d279972a8f5a598b5bb8ddc1702f8a2f4ec57a65d93852f9c329639738e7053637d1
+  languageName: node
+  linkType: hard
+
 "@types/passport-jwt@npm:^4":
   version: 4.0.1
   resolution: "@types/passport-jwt@npm:4.0.1"
@@ -2604,10 +3093,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/uuid@npm:^8.3.4":
+  version: 8.3.4
+  resolution: "@types/uuid@npm:8.3.4"
+  checksum: 10c0/b9ac98f82fcf35962317ef7dc44d9ac9e0f6fdb68121d384c88fe12ea318487d5585d3480fa003cf28be86a3bbe213ca688ba786601dce4a97724765eb5b1cf2
+  languageName: node
+  linkType: hard
+
 "@types/validator@npm:^13.11.8":
   version: 13.15.1
   resolution: "@types/validator@npm:13.15.1"
   checksum: 10c0/4d13ee084bd6736e22fcec421fc01f2b4436e6c7290f29e271e67dca5852368989b46377bc2858554f56c5b33498a4e647d6ae2cb2ef1c3143def89e8be56210
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^7.4.4":
+  version: 7.4.7
+  resolution: "@types/ws@npm:7.4.7"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/f1f53febd8623a85cef2652949acd19d83967e350ea15a851593e3033501750a1e04f418552e487db90a3d48611a1cff3ffcf139b94190c10f2fd1e1dc95ff10
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8.2.2":
+  version: 8.18.1
+  resolution: "@types/ws@npm:8.18.1"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/61aff1129143fcc4312f083bc9e9e168aa3026b7dd6e70796276dcfb2c8211c4292603f9c4864fae702f2ed86e4abd4d38aa421831c2fd7f856c931a481afbab
   languageName: node
   linkType: hard
 
@@ -3181,6 +3695,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aes-js@npm:3.0.0":
+  version: 3.0.0
+  resolution: "aes-js@npm:3.0.0"
+  checksum: 10c0/87dd5b2363534b867db7cef8bc85a90c355460783744877b2db7c8be09740aac5750714f9e00902822f692662bda74cdf40e03fbb5214ffec75c2666666288b8
+  languageName: node
+  linkType: hard
+
 "aes-js@npm:4.0.0-beta.5":
   version: 4.0.0-beta.5
   resolution: "aes-js@npm:4.0.0-beta.5"
@@ -3192,6 +3713,15 @@ __metadata:
   version: 7.1.3
   resolution: "agent-base@npm:7.1.3"
   checksum: 10c0/6192b580c5b1d8fb399b9c62bf8343d76654c2dd62afcb9a52b2cf44a8b6ace1e3b704d3fe3547d91555c857d3df02603341ff2cb961b9cfe2b12f9f3c38ee11
+  languageName: node
+  linkType: hard
+
+"agentkeepalive@npm:^4.5.0":
+  version: 4.6.0
+  resolution: "agentkeepalive@npm:4.6.0"
+  dependencies:
+    humanize-ms: "npm:^1.2.1"
+  checksum: 10c0/235c182432f75046835b05f239708107138a40103deee23b6a08caee5136873709155753b394ec212e49e60e94a378189562cb01347765515cff61b692c69187
   languageName: node
   linkType: hard
 
@@ -3264,6 +3794,29 @@ __metadata:
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
   checksum: 10c0/41e23642cbe545889245b9d2a45854ebba51cda6c778ebced9649420d9205f2efb39cb43dbc41e358409223b1ea43303ae4839db682c848b891e4811da1a5a71
+  languageName: node
+  linkType: hard
+
+"alchemy-sdk@npm:^3.6.2":
+  version: 3.6.2
+  resolution: "alchemy-sdk@npm:3.6.2"
+  dependencies:
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/abstract-provider": "npm:^5.7.0"
+    "@ethersproject/bignumber": "npm:^5.7.0"
+    "@ethersproject/bytes": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/hash": "npm:^5.7.0"
+    "@ethersproject/networks": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@ethersproject/units": "npm:^5.7.0"
+    "@ethersproject/wallet": "npm:^5.7.0"
+    "@ethersproject/web": "npm:^5.7.0"
+    "@solana/web3.js": "npm:^1.87.6"
+    axios: "npm:^1.7.4"
+    sturdy-websocket: "npm:^0.2.1"
+    websocket: "npm:^1.0.34"
+  checksum: 10c0/749947850c978b5adf508da96ddbe4e4b44debfdfcd87c2d5221a2cca072ccdec714221a22e2bbeb0869f937543028261cfc365622b33d565ad68337ec55897c
   languageName: node
   linkType: hard
 
@@ -3542,6 +4095,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:^1.7.4":
+  version: 1.11.0
+  resolution: "axios@npm:1.11.0"
+  dependencies:
+    follow-redirects: "npm:^1.15.6"
+    form-data: "npm:^4.0.4"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/5de273d33d43058610e4d252f0963cc4f10714da0bfe872e8ef2cbc23c2c999acc300fd357b6bce0fc84a2ca9bd45740fa6bb28199ce2c1266c8b1a393f2b36e
+  languageName: node
+  linkType: hard
+
 "babel-jest@npm:^29.7.0":
   version: 29.7.0
   resolution: "babel-jest@npm:29.7.0"
@@ -3628,10 +4192,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base-x@npm:^3.0.2":
+  version: 3.0.11
+  resolution: "base-x@npm:3.0.11"
+  dependencies:
+    safe-buffer: "npm:^5.0.1"
+  checksum: 10c0/4c5b8cd9cef285973b0460934be4fc890eedfd22a8aca527fac3527f041c5d1c912f7b9a6816f19e43e69dc7c29a5deabfa326bd3d6a57ee46af0ad46e3991d5
+  languageName: node
+  linkType: hard
+
 "base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 10c0/f23823513b63173a001030fae4f2dabe283b99a9d324ade3ad3d148e218134676f1ee8568c877cd79ec1c53158dcf2d2ba527a97c606618928ba99dd930102bf
+  languageName: node
+  linkType: hard
+
+"bech32@npm:1.1.4":
+  version: 1.1.4
+  resolution: "bech32@npm:1.1.4"
+  checksum: 10c0/5f62ca47b8df99ace9c0e0d8deb36a919d91bf40066700aaa9920a45f86bb10eb56d537d559416fd8703aa0fb60dddb642e58f049701e7291df678b2033e5ee5
   languageName: node
   linkType: hard
 
@@ -3662,6 +4242,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bn.js@npm:^5.2.0, bn.js@npm:^5.2.1":
+  version: 5.2.2
+  resolution: "bn.js@npm:5.2.2"
+  checksum: 10c0/cb97827d476aab1a0194df33cd84624952480d92da46e6b4a19c32964aa01553a4a613502396712704da2ec8f831cf98d02e74ca03398404bd78a037ba93f2ab
+  languageName: node
+  linkType: hard
+
 "body-parser@npm:^2.2.0":
   version: 2.2.0
   resolution: "body-parser@npm:2.2.0"
@@ -3676,6 +4263,17 @@ __metadata:
     raw-body: "npm:^3.0.0"
     type-is: "npm:^2.0.0"
   checksum: 10c0/a9ded39e71ac9668e2211afa72e82ff86cc5ef94de1250b7d1ba9cc299e4150408aaa5f1e8b03dd4578472a3ce6d1caa2a23b27a6c18e526e48b4595174c116c
+  languageName: node
+  linkType: hard
+
+"borsh@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "borsh@npm:0.7.0"
+  dependencies:
+    bn.js: "npm:^5.2.0"
+    bs58: "npm:^4.0.0"
+    text-encoding-utf-8: "npm:^1.0.2"
+  checksum: 10c0/513b3e51823d2bf5be77cec27742419d2b0427504825dd7ceb00dedb820f246a4762f04b83d5e3aa39c8e075b3cbaeb7ca3c90bd1cbeecccb4a510575be8c581
   languageName: node
   linkType: hard
 
@@ -3760,6 +4358,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bs58@npm:^4.0.0, bs58@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "bs58@npm:4.0.1"
+  dependencies:
+    base-x: "npm:^3.0.2"
+  checksum: 10c0/613a1b1441e754279a0e3f44d1faeb8c8e838feef81e550efe174ff021dd2e08a4c9ae5805b52dfdde79f97b5c0918c78dd24a0eb726c4a94365f0984a0ffc65
+  languageName: node
+  linkType: hard
+
 "bser@npm:2.1.1":
   version: 2.1.1
   resolution: "bser@npm:2.1.1"
@@ -3790,6 +4397,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer@npm:6.0.3, buffer@npm:^6.0.3, buffer@npm:~6.0.3":
+  version: 6.0.3
+  resolution: "buffer@npm:6.0.3"
+  dependencies:
+    base64-js: "npm:^1.3.1"
+    ieee754: "npm:^1.2.1"
+  checksum: 10c0/2a905fbbcde73cc5d8bd18d1caa23715d5f83a5935867c2329f0ac06104204ba7947be098fe1317fbd8830e26090ff8e764f08cd14fefc977bb248c3487bcbd0
+  languageName: node
+  linkType: hard
+
 "buffer@npm:^5.5.0":
   version: 5.7.1
   resolution: "buffer@npm:5.7.1"
@@ -3800,13 +4417,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer@npm:^6.0.3":
-  version: 6.0.3
-  resolution: "buffer@npm:6.0.3"
+"bufferutil@npm:^4.0.1":
+  version: 4.0.9
+  resolution: "bufferutil@npm:4.0.9"
   dependencies:
-    base64-js: "npm:^1.3.1"
-    ieee754: "npm:^1.2.1"
-  checksum: 10c0/2a905fbbcde73cc5d8bd18d1caa23715d5f83a5935867c2329f0ac06104204ba7947be098fe1317fbd8830e26090ff8e764f08cd14fefc977bb248c3487bcbd0
+    node-gyp: "npm:latest"
+    node-gyp-build: "npm:^4.3.0"
+  checksum: 10c0/f8a93279fc9bdcf32b42eba97edc672b39ca0fe5c55a8596099886cffc76ea9dd78e0f6f51ecee3b5ee06d2d564aa587036b5d4ea39b8b5ac797262a363cdf7d
   languageName: node
   linkType: hard
 
@@ -3944,6 +4561,13 @@ __metadata:
     ansi-styles: "npm:^4.1.0"
     supports-color: "npm:^7.1.0"
   checksum: 10c0/4a3fef5cc34975c898ffe77141450f679721df9dde00f6c304353fa9c8b571929123b26a0e4617bde5018977eb655b31970c297b91b63ee83bb82aeb04666880
+  languageName: node
+  linkType: hard
+
+"chalk@npm:^5.4.1":
+  version: 5.5.0
+  resolution: "chalk@npm:5.5.0"
+  checksum: 10c0/23063b544f7c2fe57d25ff814807de561f8adfff72e4f0051051eaa606f772586470507ccd38d89166300eeaadb0164acde8bb8a0716a0f2d56ccdf3761d5e4f
   languageName: node
   linkType: hard
 
@@ -4144,7 +4768,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^2.20.0":
+"commander@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "commander@npm:14.0.0"
+  checksum: 10c0/73c4babfa558077868d84522b11ef56834165d472b9e86a634cd4c3ae7fc72d59af6377d8878e06bd570fe8f3161eced3cbe383c38f7093272bb65bd242b595b
+  languageName: node
+  linkType: hard
+
+"commander@npm:^2.20.0, commander@npm:^2.20.3":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: 10c0/74c781a5248c2402a0a3e966a0a2bba3c054aad144f5c023364be83265e796b20565aa9feff624132ff629aa64e16999fa40a743c10c12f7c61e96a794b99288
@@ -4329,6 +4960,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d@npm:1, d@npm:^1.0.1, d@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "d@npm:1.0.2"
+  dependencies:
+    es5-ext: "npm:^0.10.64"
+    type: "npm:^2.7.2"
+  checksum: 10c0/3e6ede10cd3b77586c47da48423b62bed161bf1a48bdbcc94d87263522e22f5dfb0e678a6dba5323fdc14c5d8612b7f7eb9e7d9e37b2e2d67a7bf9f116dabe5a
+  languageName: node
+  linkType: hard
+
 "data-view-buffer@npm:^1.0.2":
   version: 1.0.2
   resolution: "data-view-buffer@npm:1.0.2"
@@ -4385,6 +5026,15 @@ __metadata:
     supports-color:
       optional: true
   checksum: 10c0/d2b44bc1afd912b49bb7ebb0d50a860dc93a4dd7d946e8de94abc957bb63726b7dd5aa48c18c2386c379ec024c46692e15ed3ed97d481729f929201e671fcd55
+  languageName: node
+  linkType: hard
+
+"debug@npm:^2.2.0":
+  version: 2.6.9
+  resolution: "debug@npm:2.6.9"
+  dependencies:
+    ms: "npm:2.0.0"
+  checksum: 10c0/121908fb839f7801180b69a7e218a40b5a0b718813b886b7d6bdb82001b931c938e2941d1e4450f33a1b1df1da653f5f7a0440c197f29fbf8a6e9d45ff6ef589
   languageName: node
   linkType: hard
 
@@ -4465,6 +5115,13 @@ __metadata:
     has-property-descriptors: "npm:^1.0.0"
     object-keys: "npm:^1.1.1"
   checksum: 10c0/88a152319ffe1396ccc6ded510a3896e77efac7a1bfbaa174a7b00414a1747377e0bb525d303794a47cf30e805c2ec84e575758512c6e44a993076d29fd4e6c3
+  languageName: node
+  linkType: hard
+
+"delay@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "delay@npm:5.0.0"
+  checksum: 10c0/01cdc4cd0cd35fb622518a3df848e67e09763a38e7cdada2232b6fda9ddda72eddcf74f0e24211200fbe718434f2335f2a2633875a6c96037fefa6de42896ad7
   languageName: node
   linkType: hard
 
@@ -4597,7 +5254,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:^6.5.7":
+"elliptic@npm:6.6.1, elliptic@npm:^6.5.7":
   version: 6.6.1
   resolution: "elliptic@npm:6.6.1"
   dependencies:
@@ -4809,6 +5466,55 @@ __metadata:
     is-date-object: "npm:^1.0.5"
     is-symbol: "npm:^1.0.4"
   checksum: 10c0/c7e87467abb0b438639baa8139f701a06537d2b9bc758f23e8622c3b42fd0fdb5bde0f535686119e446dd9d5e4c0f238af4e14960f4771877cf818d023f6730b
+  languageName: node
+  linkType: hard
+
+"es5-ext@npm:^0.10.35, es5-ext@npm:^0.10.62, es5-ext@npm:^0.10.63, es5-ext@npm:^0.10.64, es5-ext@npm:~0.10.14":
+  version: 0.10.64
+  resolution: "es5-ext@npm:0.10.64"
+  dependencies:
+    es6-iterator: "npm:^2.0.3"
+    es6-symbol: "npm:^3.1.3"
+    esniff: "npm:^2.0.1"
+    next-tick: "npm:^1.1.0"
+  checksum: 10c0/4459b6ae216f3c615db086e02437bdfde851515a101577fd61b19f9b3c1ad924bab4d197981eb7f0ccb915f643f2fc10ff76b97a680e96cbb572d15a27acd9a3
+  languageName: node
+  linkType: hard
+
+"es6-iterator@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "es6-iterator@npm:2.0.3"
+  dependencies:
+    d: "npm:1"
+    es5-ext: "npm:^0.10.35"
+    es6-symbol: "npm:^3.1.1"
+  checksum: 10c0/91f20b799dba28fb05bf623c31857fc1524a0f1c444903beccaf8929ad196c8c9ded233e5ac7214fc63a92b3f25b64b7f2737fcca8b1f92d2d96cf3ac902f5d8
+  languageName: node
+  linkType: hard
+
+"es6-promise@npm:^4.0.3":
+  version: 4.2.8
+  resolution: "es6-promise@npm:4.2.8"
+  checksum: 10c0/2373d9c5e9a93bdd9f9ed32ff5cb6dd3dd785368d1c21e9bbbfd07d16345b3774ae260f2bd24c8f836a6903f432b4151e7816a7fa8891ccb4e1a55a028ec42c3
+  languageName: node
+  linkType: hard
+
+"es6-promisify@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "es6-promisify@npm:5.0.0"
+  dependencies:
+    es6-promise: "npm:^4.0.3"
+  checksum: 10c0/23284c6a733cbf7842ec98f41eac742c9f288a78753c4fe46652bae826446ced7615b9e8a5c5f121a08812b1cd478ea58630f3e1c3d70835bd5dcd69c7cd75c9
+  languageName: node
+  linkType: hard
+
+"es6-symbol@npm:^3.1.1, es6-symbol@npm:^3.1.3":
+  version: 3.1.4
+  resolution: "es6-symbol@npm:3.1.4"
+  dependencies:
+    d: "npm:^1.0.2"
+    ext: "npm:^1.7.0"
+  checksum: 10c0/777bf3388db5d7919e09a0fd175aa5b8a62385b17cb2227b7a137680cba62b4d9f6193319a102642aa23d5840d38a62e4784f19cfa5be4a2210a3f0e9b23d15d
   languageName: node
   linkType: hard
 
@@ -5135,6 +5841,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esniff@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "esniff@npm:2.0.1"
+  dependencies:
+    d: "npm:^1.0.1"
+    es5-ext: "npm:^0.10.62"
+    event-emitter: "npm:^0.3.5"
+    type: "npm:^2.7.2"
+  checksum: 10c0/7efd8d44ac20e5db8cb0ca77eb65eca60628b2d0f3a1030bcb05e71cc40e6e2935c47b87dba3c733db12925aa5b897f8e0e7a567a2c274206f184da676ea2e65
+  languageName: node
+  linkType: hard
+
 "espree@npm:^10.0.1, espree@npm:^10.3.0":
   version: 10.3.0
   resolution: "espree@npm:10.3.0"
@@ -5223,6 +5941,23 @@ __metadata:
     tslib: "npm:2.7.0"
     ws: "npm:8.17.1"
   checksum: 10c0/bb693e8714c6082ee2c1d2af8a209bbc10d83ca4a686de368e169bf1dc804e926be58280c4bdaf0c2e9a4d021317f0db694ecfa4040381728ca46d45427db2a7
+  languageName: node
+  linkType: hard
+
+"event-emitter@npm:^0.3.5":
+  version: 0.3.5
+  resolution: "event-emitter@npm:0.3.5"
+  dependencies:
+    d: "npm:1"
+    es5-ext: "npm:~0.10.14"
+  checksum: 10c0/75082fa8ffb3929766d0f0a063bfd6046bd2a80bea2666ebaa0cfd6f4a9116be6647c15667bea77222afc12f5b4071b68d393cf39fdaa0e8e81eda006160aff0
+  languageName: node
+  linkType: hard
+
+"eventemitter3@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "eventemitter3@npm:5.0.1"
+  checksum: 10c0/4ba5c00c506e6c786b4d6262cfbce90ddc14c10d4667e5c83ae993c9de88aa856033994dd2b35b83e8dc1170e224e66a319fa80adc4c32adcd2379bbc75da814
   languageName: node
   linkType: hard
 
@@ -5319,6 +6054,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ext@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "ext@npm:1.7.0"
+  dependencies:
+    type: "npm:^2.7.2"
+  checksum: 10c0/a8e5f34e12214e9eee3a4af3b5c9d05ba048f28996450975b369fc86e5d0ef13b6df0615f892f5396a9c65d616213c25ec5b0ad17ef42eac4a500512a19da6c7
+  languageName: node
+  linkType: hard
+
 "external-editor@npm:^3.1.0":
   version: 3.1.0
   resolution: "external-editor@npm:3.1.0"
@@ -5327,6 +6071,13 @@ __metadata:
     iconv-lite: "npm:^0.4.24"
     tmp: "npm:^0.0.33"
   checksum: 10c0/c98f1ba3efdfa3c561db4447ff366a6adb5c1e2581462522c56a18bf90dfe4da382f9cd1feee3e330108c3595a854b218272539f311ba1b3298f841eb0fbf339
+  languageName: node
+  linkType: hard
+
+"eyes@npm:^0.1.8":
+  version: 0.1.8
+  resolution: "eyes@npm:0.1.8"
+  checksum: 10c0/4c79a9cbf45746d8c9f48cc957e35ad8ea336add1c7b8d5a0e002efc791a7a62b27b2188184ef1a1eea7bc3cd06b161791421e0e6c5fe78309705a162c53eea8
   languageName: node
   linkType: hard
 
@@ -5389,6 +6140,13 @@ __metadata:
   version: 2.1.1
   resolution: "fast-safe-stringify@npm:2.1.1"
   checksum: 10c0/d90ec1c963394919828872f21edaa3ad6f1dddd288d2bd4e977027afff09f5db40f94e39536d4646f7e01761d704d72d51dce5af1b93717f3489ef808f5f4e4d
+  languageName: node
+  linkType: hard
+
+"fast-stable-stringify@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "fast-stable-stringify@npm:1.0.0"
+  checksum: 10c0/1d773440c7a9615950577665074746c2e92edafceefa789616ecb6166229e0ccc6dae206ca9b9f7da0d274ba5779162aab2d07940a0f6e52a41a4e555392eb3b
   languageName: node
   linkType: hard
 
@@ -5617,6 +6375,19 @@ __metadata:
     es-set-tostringtag: "npm:^2.1.0"
     mime-types: "npm:^2.1.12"
   checksum: 10c0/e534b0cf025c831a0929bf4b9bbe1a9a6b03e273a8161f9947286b9b13bf8fb279c6944aae0070c4c311100c6d6dbb815cd955dc217728caf73fad8dc5b8ee9c
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "form-data@npm:4.0.4"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    es-set-tostringtag: "npm:^2.1.0"
+    hasown: "npm:^2.0.2"
+    mime-types: "npm:^2.1.12"
+  checksum: 10c0/373525a9a034b9d57073e55eab79e501a714ffac02e7a9b01be1c820780652b16e4101819785e1e18f8d98f0aee866cc654d660a435c378e16a72f2e7cac9695
   languageName: node
   linkType: hard
 
@@ -6010,7 +6781,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hash.js@npm:^1.0.0, hash.js@npm:^1.0.3":
+"hash.js@npm:1.1.7, hash.js@npm:^1.0.0, hash.js@npm:^1.0.3":
   version: 1.1.7
   resolution: "hash.js@npm:1.1.7"
   dependencies:
@@ -6105,6 +6876,15 @@ __metadata:
   version: 2.1.0
   resolution: "human-signals@npm:2.1.0"
   checksum: 10c0/695edb3edfcfe9c8b52a76926cd31b36978782062c0ed9b1192b36bebc75c4c87c82e178dfcb0ed0fc27ca59d434198aac0bd0be18f5781ded775604db22304a
+  languageName: node
+  linkType: hard
+
+"humanize-ms@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "humanize-ms@npm:1.2.1"
+  dependencies:
+    ms: "npm:^2.0.0"
+  checksum: 10c0/f34a2c20161d02303c2807badec2f3b49cbfbbb409abd4f95a07377ae01cfe6b59e3d15ac609cffcd8f2521f0eb37b7e1091acf65da99aa2a4f1ad63c21e7e7a
   languageName: node
   linkType: hard
 
@@ -6495,6 +7275,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-typedarray@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-typedarray@npm:1.0.0"
+  checksum: 10c0/4c096275ba041a17a13cca33ac21c16bc4fd2d7d7eb94525e7cd2c2f2c1a3ab956e37622290642501ff4310601e413b675cf399ad6db49855527d2163b3eeeec
+  languageName: node
+  linkType: hard
+
 "is-unicode-supported@npm:^0.1.0":
   version: 0.1.0
   resolution: "is-unicode-supported@npm:0.1.0"
@@ -6553,6 +7340,15 @@ __metadata:
   version: 3.1.1
   resolution: "isexe@npm:3.1.1"
   checksum: 10c0/9ec257654093443eb0a528a9c8cbba9c0ca7616ccb40abd6dde7202734d96bb86e4ac0d764f0f8cd965856aacbff2f4ce23e730dc19dfb41e3b0d865ca6fdcc7
+  languageName: node
+  linkType: hard
+
+"isomorphic-ws@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "isomorphic-ws@npm:4.0.1"
+  peerDependencies:
+    ws: "*"
+  checksum: 10c0/7cb90dc2f0eb409825558982fb15d7c1d757a88595efbab879592f9d2b63820d6bbfb5571ab8abe36c715946e165a413a99f6aafd9f40ab1f514d73487bc9996
   languageName: node
   linkType: hard
 
@@ -6661,6 +7457,28 @@ __metadata:
   bin:
     jake: bin/cli.js
   checksum: 10c0/c4597b5ed9b6a908252feab296485a4f87cba9e26d6c20e0ca144fb69e0c40203d34a2efddb33b3d297b8bd59605e6c1f44f6221ca1e10e69175ecbf3ff5fe31
+  languageName: node
+  linkType: hard
+
+"jayson@npm:^4.1.1":
+  version: 4.2.0
+  resolution: "jayson@npm:4.2.0"
+  dependencies:
+    "@types/connect": "npm:^3.4.33"
+    "@types/node": "npm:^12.12.54"
+    "@types/ws": "npm:^7.4.4"
+    commander: "npm:^2.20.3"
+    delay: "npm:^5.0.0"
+    es6-promisify: "npm:^5.0.0"
+    eyes: "npm:^0.1.8"
+    isomorphic-ws: "npm:^4.0.1"
+    json-stringify-safe: "npm:^5.0.1"
+    stream-json: "npm:^1.9.1"
+    uuid: "npm:^8.3.2"
+    ws: "npm:^7.5.10"
+  bin:
+    jayson: bin/jayson.js
+  checksum: 10c0/062f525a0d15232c4361d10e0cd26960e998897e483408de03101e147c7bdf275db525bc1d5cc8aff4b777d1b1389004c8e9a5715304aedcf9930557787df6e3
   languageName: node
   linkType: hard
 
@@ -7131,6 +7949,13 @@ __metadata:
   version: 3.1.1
   resolution: "joycon@npm:3.1.1"
   checksum: 10c0/131fb1e98c9065d067fd49b6e685487ac4ad4d254191d7aa2c9e3b90f4e9ca70430c43cad001602bdbdabcf58717d3b5c5b7461c1bd8e39478c8de706b3fe6ae
+  languageName: node
+  linkType: hard
+
+"js-sha3@npm:0.8.0":
+  version: 0.8.0
+  resolution: "js-sha3@npm:0.8.0"
+  checksum: 10c0/43a21dc7967c871bd2c46cb1c2ae97441a97169f324e509f382d43330d8f75cf2c96dba7c806ab08a425765a9c847efdd4bffbac2d99c3a4f3de6c0218f40533
   languageName: node
   linkType: hard
 
@@ -7855,7 +8680,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:^2.1.1, ms@npm:^2.1.3":
+"ms@npm:2.0.0":
+  version: 2.0.0
+  resolution: "ms@npm:2.0.0"
+  checksum: 10c0/f8fda810b39fd7255bbdc451c46286e549794fcc700dc9cd1d25658bbc4dc2563a5de6fe7c60f798a16a60c6ceb53f033cb353f493f0cf63e5199b702943159d
+  languageName: node
+  linkType: hard
+
+"ms@npm:^2.0.0, ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: 10c0/d924b57e7312b3b63ad21fc5b3dc0af5e78d61a1fc7cfb5457edaf26326bf62be5307cc87ffb6862ef1c2b33b0233cdb5d4f01c4c958cc0d660948b65a287a48
@@ -7923,6 +8755,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"next-tick@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "next-tick@npm:1.1.0"
+  checksum: 10c0/3ba80dd805fcb336b4f52e010992f3e6175869c8d88bf4ff0a81d5d66e6049f89993463b28211613e58a6b7fe93ff5ccbba0da18d4fa574b96289e8f0b577f28
+  languageName: node
+  linkType: hard
+
 "nock@npm:^14.0.5":
   version: 14.0.5
   resolution: "nock@npm:14.0.5"
@@ -7973,7 +8812,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp-build@npm:^4.2.0":
+"node-gyp-build@npm:^4.2.0, node-gyp-build@npm:^4.3.0":
   version: 4.8.4
   resolution: "node-gyp-build@npm:4.8.4"
   bin:
@@ -8981,6 +9820,7 @@ __metadata:
     "@types/passport-jwt": "npm:^4"
     "@types/pg": "npm:^8"
     "@types/supertest": "npm:^6.0.2"
+    alchemy-sdk: "npm:^3.6.2"
     ccxt: "npm:^4.4.88"
     class-transformer: "npm:^0.5.1"
     class-validator: "npm:^0.14.2"
@@ -9250,6 +10090,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rpc-websockets@npm:^9.0.2":
+  version: 9.1.3
+  resolution: "rpc-websockets@npm:9.1.3"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.11"
+    "@types/uuid": "npm:^8.3.4"
+    "@types/ws": "npm:^8.2.2"
+    buffer: "npm:^6.0.3"
+    bufferutil: "npm:^4.0.1"
+    eventemitter3: "npm:^5.0.1"
+    utf-8-validate: "npm:^5.0.2"
+    uuid: "npm:^8.3.2"
+    ws: "npm:^8.5.0"
+  dependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/7106b235ccf29f71f39c64d43b191bf80e9e9e48b3a1914835610abf6e8505b1cff531baa08a0eea9b9352dd31aa10c8715b261566b3f00dd5d17b87ea9c671b
+  languageName: node
+  linkType: hard
+
 "run-parallel@npm:^1.1.9":
   version: 1.2.0
   resolution: "run-parallel@npm:1.2.0"
@@ -9366,6 +10228,13 @@ __metadata:
     ajv-formats: "npm:^2.1.1"
     ajv-keywords: "npm:^5.1.0"
   checksum: 10c0/981632f9bf59f35b15a9bcdac671dd183f4946fe4b055ae71a301e66a9797b95e5dd450de581eb6cca56fb6583ce8f24d67b2d9f8e1b2936612209697f6c277e
+  languageName: node
+  linkType: hard
+
+"scrypt-js@npm:3.0.1":
+  version: 3.0.1
+  resolution: "scrypt-js@npm:3.0.1"
+  checksum: 10c0/e2941e1c8b5c84c7f3732b0153fee624f5329fc4e772a06270ee337d4d2df4174b8abb5e6ad53804a29f53890ecbc78f3775a319323568c0313040c0e55f5b10
   languageName: node
   linkType: hard
 
@@ -9760,6 +10629,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stream-chain@npm:^2.2.5":
+  version: 2.2.5
+  resolution: "stream-chain@npm:2.2.5"
+  checksum: 10c0/c512f50190d7c92d688fa64e7af540c51b661f9c2b775fc72bca38ea9bca515c64c22c2197b1be463741daacbaaa2dde8a8ea24ebda46f08391224f15249121a
+  languageName: node
+  linkType: hard
+
+"stream-json@npm:^1.9.1":
+  version: 1.9.1
+  resolution: "stream-json@npm:1.9.1"
+  dependencies:
+    stream-chain: "npm:^2.2.5"
+  checksum: 10c0/0521e5cb3fb6b0e2561d715975e891bd81fa77d0239c8d0b1756846392bc3c7cdd7f1ddb0fe7ed77e6fdef58daab9e665d3b39f7d677bd0859e65a2bff59b92c
+  languageName: node
+  linkType: hard
+
 "streamsearch@npm:^1.1.0":
   version: 1.1.0
   resolution: "streamsearch@npm:1.1.0"
@@ -9941,6 +10826,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sturdy-websocket@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "sturdy-websocket@npm:0.2.1"
+  checksum: 10c0/d2aa8ad9542a18c83d13d0a6393ebcdf479827e4c39cbc78bf3f74df9d4e9140005bcb507a5bdd60c3d3ac3f3db348f17edc417447be7c951b6f38d2b2414a22
+  languageName: node
+  linkType: hard
+
 "superagent@npm:^10.2.1":
   version: 10.2.1
   resolution: "superagent@npm:10.2.1"
@@ -9955,6 +10847,13 @@ __metadata:
     mime: "npm:2.6.0"
     qs: "npm:^6.11.0"
   checksum: 10c0/526e3716f765873fc2f98a00fe0c8cbfe57976c501a30486307eefe54a6a5e379a0adf2ca8b29d40bc33a34d6baf7814972b0398b6002445ca3b4af07487f090
+  languageName: node
+  linkType: hard
+
+"superstruct@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "superstruct@npm:2.0.2"
+  checksum: 10c0/c6853db5240b4920f47b3c864dd1e23ede6819ea399ad29a65387d746374f6958c5f1c5b7e5bb152d9db117a74973e5005056d9bb83c24e26f18ec6bfae4a718
   languageName: node
   linkType: hard
 
@@ -10083,6 +10982,13 @@ __metadata:
     glob: "npm:^7.1.4"
     minimatch: "npm:^3.0.4"
   checksum: 10c0/019d33d81adff3f9f1bfcff18125fb2d3c65564f437d9be539270ee74b994986abb8260c7c2ce90e8f30162178b09dbbce33c6389273afac4f36069c48521f57
+  languageName: node
+  linkType: hard
+
+"text-encoding-utf-8@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "text-encoding-utf-8@npm:1.0.2"
+  checksum: 10c0/87a64b394c850e8387c2ca7fc6929a26ce97fb598f1c55cd0fdaec4b8e2c3ed6770f65b2f3309c9175ef64ac5e403c8e48b53ceeb86d2897940c5e19cc00bb99
   languageName: node
   linkType: hard
 
@@ -10334,7 +11240,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:2.8.1, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.8.1":
+"tslib@npm:2.8.1, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.8.0, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
@@ -10399,6 +11305,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type@npm:^2.7.2":
+  version: 2.7.3
+  resolution: "type@npm:2.7.3"
+  checksum: 10c0/dec6902c2c42fcb86e3adf8cdabdf80e5ef9de280872b5fd547351e9cca2fe58dd2aa6d2547626ddff174145db272f62d95c7aa7038e27c11315657d781a688d
+  languageName: node
+  linkType: hard
+
 "typed-array-buffer@npm:^1.0.3":
   version: 1.0.3
   resolution: "typed-array-buffer@npm:1.0.3"
@@ -10449,6 +11362,15 @@ __metadata:
     possible-typed-array-names: "npm:^1.0.0"
     reflect.getprototypeof: "npm:^1.0.6"
   checksum: 10c0/e38f2ae3779584c138a2d8adfa8ecf749f494af3cd3cdafe4e688ce51418c7d2c5c88df1bd6be2bbea099c3f7cea58c02ca02ed438119e91f162a9de23f61295
+  languageName: node
+  linkType: hard
+
+"typedarray-to-buffer@npm:^3.1.5":
+  version: 3.1.5
+  resolution: "typedarray-to-buffer@npm:3.1.5"
+  dependencies:
+    is-typedarray: "npm:^1.0.0"
+  checksum: 10c0/4ac5b7a93d604edabf3ac58d3a2f7e07487e9f6e98195a080e81dbffdc4127817f470f219d794a843b87052cedef102b53ac9b539855380b8c2172054b7d5027
   languageName: node
   linkType: hard
 
@@ -10740,6 +11662,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"utf-8-validate@npm:^5.0.2":
+  version: 5.0.10
+  resolution: "utf-8-validate@npm:5.0.10"
+  dependencies:
+    node-gyp: "npm:latest"
+    node-gyp-build: "npm:^4.3.0"
+  checksum: 10c0/23cd6adc29e6901aa37ff97ce4b81be9238d0023c5e217515b34792f3c3edb01470c3bd6b264096dd73d0b01a1690b57468de3a24167dd83004ff71c51cc025f
+  languageName: node
+  linkType: hard
+
 "util-deprecate@npm:^1.0.1, util-deprecate@npm:~1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
@@ -10773,6 +11705,15 @@ __metadata:
   bin:
     uuid: dist/esm/bin/uuid
   checksum: 10c0/34aa51b9874ae398c2b799c88a127701408cd581ee89ec3baa53509dd8728cbb25826f2a038f9465f8b7be446f0fbf11558862965b18d21c993684297628d4d3
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^8.3.2":
+  version: 8.3.2
+  resolution: "uuid@npm:8.3.2"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 10c0/bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
   languageName: node
   linkType: hard
 
@@ -11032,6 +11973,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"websocket@npm:^1.0.34":
+  version: 1.0.35
+  resolution: "websocket@npm:1.0.35"
+  dependencies:
+    bufferutil: "npm:^4.0.1"
+    debug: "npm:^2.2.0"
+    es5-ext: "npm:^0.10.63"
+    typedarray-to-buffer: "npm:^3.1.5"
+    utf-8-validate: "npm:^5.0.2"
+    yaeti: "npm:^0.0.6"
+  checksum: 10c0/8be9a68dc0228f18058c9010d1308479f05050af8f6d68b9dbc6baebd9ab484c15a24b2521a5d742a9d78e62ee19194c532992f1047a9b9adf8c3eedb0b1fcdc
+  languageName: node
+  linkType: hard
+
 "whatwg-url@npm:^5.0.0":
   version: 5.0.0
   resolution: "whatwg-url@npm:5.0.0"
@@ -11218,6 +12173,51 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ws@npm:8.18.0":
+  version: 8.18.0
+  resolution: "ws@npm:8.18.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/25eb33aff17edcb90721ed6b0eb250976328533ad3cd1a28a274bd263682e7296a6591ff1436d6cbc50fa67463158b062f9d1122013b361cec99a05f84680e06
+  languageName: node
+  linkType: hard
+
+"ws@npm:^7.5.10":
+  version: 7.5.10
+  resolution: "ws@npm:7.5.10"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/bd7d5f4aaf04fae7960c23dcb6c6375d525e00f795dd20b9385902bd008c40a94d3db3ce97d878acc7573df852056ca546328b27b39f47609f80fb22a0a9b61d
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.5.0":
+  version: 8.18.3
+  resolution: "ws@npm:8.18.3"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/eac918213de265ef7cb3d4ca348b891a51a520d839aa51cdb8ca93d4fa7ff9f6ccb339ccee89e4075324097f0a55157c89fa3f7147bde9d8d7e90335dc087b53
+  languageName: node
+  linkType: hard
+
 "ws@npm:^8.8.1":
   version: 8.18.2
   resolution: "ws@npm:8.18.2"
@@ -11268,6 +12268,13 @@ __metadata:
   version: 5.0.8
   resolution: "y18n@npm:5.0.8"
   checksum: 10c0/4df2842c36e468590c3691c894bc9cdbac41f520566e76e24f59401ba7d8b4811eb1e34524d57e54bc6d864bcb66baab7ffd9ca42bf1eda596618f9162b91249
+  languageName: node
+  linkType: hard
+
+"yaeti@npm:^0.0.6":
+  version: 0.0.6
+  resolution: "yaeti@npm:0.0.6"
+  checksum: 10c0/4e88702d8b34d7b61c1c4ec674422b835d453b8f8a6232be41e59fc98bc4d9ab6d5abd2da55bab75dfc07ae897fdc0c541f856ce3ab3b17de1630db6161aa3f6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Issue tracking
Part of #282 

## Context behind the change
- some exchanges (e.g. `alpaca`) do not allow getting trading pairs w/o api key, so we decided to go with a specific list of exchanges for now instead of supporting all from `ccxt`
- added statuses mapping for public API, so campaigns always have one of three statuses: `active`, `cancelled`, `completed` and UI can add extra details/clarifications based on supplied campaign data;
- in order to support the above - we added new campaign status to recording oracle and cron job to track escrow completion; also original status values returns just for convenience
- campaign might have different `quote` symbol, hence volume is calculate in `quote` currency; taking into account that stats must be provided in unified format (USD), we have to convert such value, so
  - we will use external API (alchemy) to get exchange rate
  - `alchemy` API supports top 1000 token symbols by market cap and we suppose that for trading pairs the quote token should be in this list, so using alchemy API in order to get price should work for us; if nope - we will get a warning message in logs and can replace it with something else
  - we are aware that the quote token price at the moment when we get it might be different from what it was when trade happened; however it's find for us because or stats on total volume doesn't have to be very precise

## How has this been tested?
- [x] unit tests
- [x] trigger API endpoints locally to verify new list of exchanges works
- [x] dropped DB; re-joined to some `Pending` campaigns that have `endDate < now`, verify they got `pending_completion` status
- [x] run results recording cycle, make sure volume in usd is recorded
- [x] trigger `/stats/total_volume`; make sure volume in usd is returned
- [x] retrieve `/campaigns` with ExcO address set up, make sure campaigns returned for provided address

## Release plan

- [x] Generate new wallet (exchange oracle) and update env on staging
- [x] Update recording oracle env (`ALCHEMY_API_KEY`)
- [ ] Introduced new squashed migration and squashed it, so we will need to drop staging DB before deployment.

## Potential risks; What to monitor; Rollback plan
Should be none