### PR TITLE
[v2] feat: normalize campaign address and add admin endpoints

### DIFF
--- a/recording-oracle/.env.example
+++ b/recording-oracle/.env.example
@@ -47,3 +47,5 @@ ALCHEMY_API_KEY=replace-me
 
 # Subgraph (Needed for accessing subgraph data)
 SUBGRAPH_API_KEY=replace-me
+
+ADMIN_API_KEY=replace-me-with-anything

--- a/recording-oracle/src/app.module.ts
+++ b/recording-oracle/src/app.module.ts
@@ -11,6 +11,7 @@ import { HttpValidationPipe } from './common/pipes';
 import Environment from './common/utils/environment';
 import { EnvConfigModule, envValidator } from './config';
 import { DatabaseModule } from './database';
+import { AdminModule } from './modules/admin';
 import { AuthModule } from './modules/auth';
 import { CampaignsModule } from './modules/campaigns';
 import { ExchangeApiKeysModule } from './modules/exchange-api-keys';
@@ -49,6 +50,7 @@ import { UsersModule } from './modules/users';
     },
   ],
   imports: [
+    AdminModule,
     ConfigModule.forRoot({
       /**
        * First value found takes precendece

--- a/recording-oracle/src/common/utils/crypto.ts
+++ b/recording-oracle/src/common/utils/crypto.ts
@@ -1,0 +1,13 @@
+import crypto from 'crypto';
+
+export function safeCompare(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+
+  // Must be same length to avoid early return timing leaks
+  if (bufA.length !== bufB.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(bufA, bufB);
+}

--- a/recording-oracle/src/config/auth-config.service.ts
+++ b/recording-oracle/src/config/auth-config.service.ts
@@ -38,4 +38,8 @@ export class AuthConfigService {
       Number(this.configService.get('JWT_REFRESH_TOKEN_EXPIRES_IN')) || 3600;
     return configValueSeconds * 1000;
   }
+
+  get adminApiKey(): string | undefined {
+    return this.configService.get('ADMIN_API_KEY');
+  }
 }

--- a/recording-oracle/src/modules/admin/admin.controller.ts
+++ b/recording-oracle/src/modules/admin/admin.controller.ts
@@ -4,6 +4,7 @@ import {
   Controller,
   HttpCode,
   Post,
+  UseFilters,
   UseGuards,
 } from '@nestjs/common';
 import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
@@ -11,18 +12,20 @@ import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Public } from '@/common/decorators';
 
 import { CheckCampaignProgressDto } from './admin.dto';
+import { AdminControllerErrorsFilter } from './admin.error-filter';
 import { AdminService } from './admin.service';
 import { ADMIN_API_KEY_HEADER, AdminApiKeyAuthGuard } from './api-key.guard';
 
 @ApiTags('Admin')
 @Controller('/admin')
 @Public()
-@UseGuards(AdminApiKeyAuthGuard)
 @ApiHeader({
   name: ADMIN_API_KEY_HEADER,
   description: 'Admin API key',
   required: true,
 })
+@UseGuards(AdminApiKeyAuthGuard)
+@UseFilters(AdminControllerErrorsFilter)
 export class AdminController {
   constructor(private readonly adminService: AdminService) {}
 
@@ -42,6 +45,6 @@ export class AdminController {
 
     const result = await this.adminService.checkCampaignProgress(input);
 
-    return result;
+    return { result };
   }
 }

--- a/recording-oracle/src/modules/admin/admin.controller.ts
+++ b/recording-oracle/src/modules/admin/admin.controller.ts
@@ -1,0 +1,47 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  HttpCode,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import { Public } from '@/common/decorators';
+
+import { CheckCampaignProgressDto } from './admin.dto';
+import { AdminService } from './admin.service';
+import { ADMIN_API_KEY_HEADER, AdminApiKeyAuthGuard } from './api-key.guard';
+
+@ApiTags('Admin')
+@Controller('/admin')
+@Public()
+@UseGuards(AdminApiKeyAuthGuard)
+@ApiHeader({
+  name: ADMIN_API_KEY_HEADER,
+  description: 'Admin API key',
+  required: true,
+})
+export class AdminController {
+  constructor(private readonly adminService: AdminService) {}
+
+  @ApiOperation({
+    summary: 'Check progress for campaign',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Intermediate results for the specified period',
+  })
+  @HttpCode(200)
+  @Post('/check-campaign-progress')
+  async checkCampaignProgress(@Body() input: CheckCampaignProgressDto) {
+    if (input.fromDate >= input.toDate) {
+      throw new BadRequestException('Invalid dates range provided');
+    }
+
+    const result = await this.adminService.checkCampaignProgress(input);
+
+    return result;
+  }
+}

--- a/recording-oracle/src/modules/admin/admin.dto.ts
+++ b/recording-oracle/src/modules/admin/admin.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsEthereumAddress, IsDateString } from 'class-validator';
+
+import { type ChainId, ChainIds } from '@/common/constants';
+
+export class CheckCampaignProgressDto {
+  @ApiProperty({ name: 'chain_id', enum: ChainIds })
+  @IsIn(ChainIds)
+  chainId: ChainId;
+
+  @ApiProperty()
+  @IsEthereumAddress()
+  address: string;
+
+  @ApiProperty({ name: 'from_date' })
+  @IsDateString()
+  fromDate: string;
+
+  @ApiProperty({ name: 'to_date' })
+  @IsDateString()
+  toDate: string;
+}

--- a/recording-oracle/src/modules/admin/admin.module.ts
+++ b/recording-oracle/src/modules/admin/admin.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+
+import { CampaignsModule } from '@/modules/campaigns';
+
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
+
+@Module({
+  imports: [CampaignsModule],
+  providers: [AdminService],
+  controllers: [AdminController],
+  exports: [],
+})
+export class AdminModule {}

--- a/recording-oracle/src/modules/admin/admin.service.ts
+++ b/recording-oracle/src/modules/admin/admin.service.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+
+import {
+  CampaignsRepository,
+  CampaignsService,
+  UserCampaignsRepository,
+} from '@/modules/campaigns';
+
+import { CheckCampaignProgressDto } from './admin.dto';
+
+@Injectable()
+export class AdminService {
+  constructor(
+    private readonly campaignsRepository: CampaignsRepository,
+    private readonly campaignsService: CampaignsService,
+    private readonly userCampaignsRepository: UserCampaignsRepository,
+  ) {}
+
+  async checkCampaignProgress({
+    chainId,
+    address,
+    fromDate,
+    toDate,
+  }: CheckCampaignProgressDto) {
+    const campaign = await this.campaignsRepository.findOneByChainIdAndAddress(
+      chainId,
+      address,
+    );
+    if (!campaign) {
+      throw new Error('Campaign not found');
+    }
+
+    const participants = await this.userCampaignsRepository.findCampaignUsers(
+      campaign.id,
+    );
+
+    const progress = await this.campaignsService.checkCampaignProgressForPeriod(
+      campaign,
+      participants,
+      new Date(fromDate),
+      new Date(toDate),
+    );
+
+    return {
+      from: progress.from,
+      to: progress.to,
+      totalVolume: progress.total_volume,
+      participantOutcomes: progress.participants_outcomes_batches.flatMap(
+        (batch) => batch.results,
+      ),
+    };
+  }
+}

--- a/recording-oracle/src/modules/admin/admin.service.ts
+++ b/recording-oracle/src/modules/admin/admin.service.ts
@@ -1,17 +1,12 @@
 import { Injectable } from '@nestjs/common';
 
-import {
-  CampaignsRepository,
-  CampaignsService,
-  UserCampaignsRepository,
-} from '@/modules/campaigns';
+import { CampaignsService, UserCampaignsRepository } from '@/modules/campaigns';
 
 import { CheckCampaignProgressDto } from './admin.dto';
 
 @Injectable()
 export class AdminService {
   constructor(
-    private readonly campaignsRepository: CampaignsRepository,
     private readonly campaignsService: CampaignsService,
     private readonly userCampaignsRepository: UserCampaignsRepository,
   ) {}
@@ -22,7 +17,7 @@ export class AdminService {
     fromDate,
     toDate,
   }: CheckCampaignProgressDto) {
-    const campaign = await this.campaignsRepository.findOneByChainIdAndAddress(
+    const campaign = await this.campaignsService.findOneByChainIdAndAddress(
       chainId,
       address,
     );

--- a/recording-oracle/src/modules/admin/api-key.guard.ts
+++ b/recording-oracle/src/modules/admin/api-key.guard.ts
@@ -4,9 +4,11 @@ import {
   HttpException,
   HttpStatus,
   Injectable,
+  UnauthorizedException,
 } from '@nestjs/common';
 import type { Request } from 'express';
 
+import * as cryptoUtils from '@/common/utils/crypto';
 import { AuthConfigService } from '@/config';
 
 export const ADMIN_API_KEY_HEADER = 'X-Admin-API-Key';
@@ -28,8 +30,13 @@ export class AdminApiKeyAuthGuard implements CanActivate {
 
     const providedApiKey =
       request.headers[ADMIN_API_KEY_HEADER.toLowerCase()] || '';
-    if (providedApiKey !== adminApiKey) {
-      throw new HttpException('Invalid API key', HttpStatus.UNAUTHORIZED);
+
+    if (typeof providedApiKey !== 'string') {
+      throw new UnauthorizedException();
+    }
+
+    if (!cryptoUtils.safeCompare(providedApiKey, adminApiKey)) {
+      throw new UnauthorizedException();
     }
 
     return true;

--- a/recording-oracle/src/modules/admin/api-key.guard.ts
+++ b/recording-oracle/src/modules/admin/api-key.guard.ts
@@ -1,0 +1,37 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+  Injectable,
+} from '@nestjs/common';
+import type { Request } from 'express';
+
+import { AuthConfigService } from '@/config';
+
+export const ADMIN_API_KEY_HEADER = 'X-Admin-API-Key';
+
+@Injectable()
+export class AdminApiKeyAuthGuard implements CanActivate {
+  constructor(private readonly authConfigService: AuthConfigService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const adminApiKey = this.authConfigService.adminApiKey;
+    if (!adminApiKey) {
+      throw new HttpException(
+        'Admin API key is not configured',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+
+    const request = context.switchToHttp().getRequest() as Request;
+
+    const providedApiKey =
+      request.headers[ADMIN_API_KEY_HEADER.toLowerCase()] || '';
+    if (providedApiKey !== adminApiKey) {
+      throw new HttpException('Invalid API key', HttpStatus.UNAUTHORIZED);
+    }
+
+    return true;
+  }
+}

--- a/recording-oracle/src/modules/admin/index.ts
+++ b/recording-oracle/src/modules/admin/index.ts
@@ -1,0 +1,1 @@
+export { AdminModule } from './admin.module';

--- a/recording-oracle/src/modules/campaigns/campaigns.error-filter.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.error-filter.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { Request, Response } from 'express';
 
+import { InvalidEvmAddressError } from '@/common/errors/web3';
 import logger from '@/logger';
 import {
   ExchangeApiKeyNotFoundError,
@@ -24,6 +25,7 @@ import {
   CampaignAlreadyFinishedError,
   ExchangeApiKeyNotFoundError,
   KeyAuthorizationError,
+  InvalidEvmAddressError,
 )
 export class CampaignsControllerErrorsFilter implements ExceptionFilter {
   private readonly logger = logger.child({
@@ -34,11 +36,13 @@ export class CampaignsControllerErrorsFilter implements ExceptionFilter {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
-    const status = HttpStatus.UNPROCESSABLE_ENTITY;
 
+    let status = HttpStatus.UNPROCESSABLE_ENTITY;
     let message: string = exception.message;
     if (exception instanceof InvalidCampaign) {
       message = exception.details;
+    } else if (exception instanceof InvalidEvmAddressError) {
+      status = HttpStatus.BAD_REQUEST;
     }
 
     return response.status(status).json({

--- a/recording-oracle/src/modules/campaigns/campaigns.module.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.module.ts
@@ -22,6 +22,11 @@ import { VolumeStatsRepository } from './volume-stats.repository';
     PgAdvisoryLock,
   ],
   controllers: [CampaignsController],
-  exports: [VolumeStatsRepository],
+  exports: [
+    CampaignsRepository,
+    CampaignsService,
+    VolumeStatsRepository,
+    UserCampaignsRepository,
+  ],
 })
 export class CampaignsModule {}

--- a/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
@@ -538,7 +538,7 @@ describe('CampaignsService', () => {
       const expectedCampaignData = {
         id: expect.any(String),
         chainId,
-        address: campaignAddress,
+        address: ethers.getAddress(campaignAddress),
         type: manifest.type,
         exchangeName: manifest.exchange,
         dailyVolumeTarget: manifest.daily_volume_target.toString(),
@@ -578,7 +578,12 @@ describe('CampaignsService', () => {
         true,
       );
 
-      const id = await campaignsService.join(userId, chainId, campaign.address);
+      const id = await campaignsService.join(
+        userId,
+        chainId,
+        // not checksummed address
+        campaign.address.toLowerCase(),
+      );
 
       expect(id).toBe(campaign.id);
 
@@ -1615,7 +1620,8 @@ describe('CampaignsService', () => {
       const result = await campaignsService.checkUserJoined(
         userId,
         chainId,
-        campaign.address,
+        // not checksummed address
+        campaign.address.toLowerCase(),
       );
 
       expect(result).toBe(false);

--- a/recording-oracle/src/modules/campaigns/fixtures/campaign.ts
+++ b/recording-oracle/src/modules/campaigns/fixtures/campaign.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker';
 import dayjs from 'dayjs';
+import { ethers } from 'ethers';
 
 import {
   generateExchangeName,
@@ -27,7 +28,7 @@ export function generateCampaignEntity(
   const campaign = {
     id: faker.string.uuid(),
     chainId: generateTestnetChainId(),
-    address: faker.finance.ethereumAddress(),
+    address: ethers.getAddress(faker.finance.ethereumAddress()),
     pair: generateTradingPair(),
     exchangeName: generateExchangeName(),
     startDate,

--- a/recording-oracle/src/modules/campaigns/index.ts
+++ b/recording-oracle/src/modules/campaigns/index.ts
@@ -4,4 +4,8 @@ export { VolumeStatEntity } from './volume-stat.entity';
 
 export { VolumeStatsRepository } from './volume-stats.repository';
 
+export { CampaignsRepository } from './campaigns.repository';
+export { CampaignsService } from './campaigns.service';
+export { UserCampaignsRepository } from './user-campaigns.repository';
+
 export { CampaignsModule } from './campaigns.module';


### PR DESCRIPTION
## Issue tracking
Freestyle

## Context behind the change
- added normalization to campaign addresses in order to properly handle search operations for `join` and `check-is-joined`
- added `admin` endpoint behind API key auth in order to enable convenient debug checks

## How has this been tested?
- [x] hit admin endpoint w/ & w/o API key locally for existing campaign
- [x] unit tests for campaigns pass

## Release plan
Merge. Add API key where needed

## Potential risks; What to monitor; Rollback plan
No