### PR TITLE
[v2] feat: endpoint to return user progress for campaign

### DIFF
--- a/recording-oracle/src/modules/campaigns/campaigns.dto.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.dto.ts
@@ -118,3 +118,31 @@ export class CheckUserJoinedResponseDto {
   })
   isJoined: boolean;
 }
+
+export class CampaignParamsDto {
+  @ApiProperty({
+    name: 'chain_id',
+    enum: ChainIds,
+  })
+  @Transform(({ value }) => Number(value))
+  @IsIn(ChainIds)
+  chainId: ChainId;
+
+  @ApiProperty({
+    name: 'campaign_address',
+  })
+  @IsEthereumAddress()
+  campaignAddress: string;
+}
+
+export class GetUserProgressResponseDto {
+  @ApiProperty({
+    name: 'total_score',
+  })
+  totalScore: number;
+
+  @ApiProperty({
+    name: 'total_volume',
+  })
+  totalVolume: number;
+}

--- a/recording-oracle/src/modules/campaigns/campaigns.error-filter.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.error-filter.ts
@@ -17,6 +17,7 @@ import {
   CampaignAlreadyFinishedError,
   CampaignNotFoundError,
   InvalidCampaign,
+  UserIsNotParticipatingError,
 } from './campaigns.errors';
 
 @Catch(
@@ -26,6 +27,7 @@ import {
   ExchangeApiKeyNotFoundError,
   KeyAuthorizationError,
   InvalidEvmAddressError,
+  UserIsNotParticipatingError,
 )
 export class CampaignsControllerErrorsFilter implements ExceptionFilter {
   private readonly logger = logger.child({

--- a/recording-oracle/src/modules/campaigns/campaigns.errors.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.errors.ts
@@ -1,13 +1,17 @@
 import { BaseError } from '@/common/errors/base';
 
 export class CampaignNotFoundError extends BaseError {
-  constructor(readonly address: string) {
+  constructor(
+    readonly chainId: number,
+    readonly address: string,
+  ) {
     super('Campaign not found');
   }
 }
 
 export class InvalidCampaign extends BaseError {
   constructor(
+    readonly chainId: number,
     readonly address: string,
     readonly details: string,
   ) {
@@ -16,7 +20,16 @@ export class InvalidCampaign extends BaseError {
 }
 
 export class CampaignAlreadyFinishedError extends BaseError {
-  constructor(readonly address: string) {
+  constructor(
+    readonly chainId: number,
+    readonly address: string,
+  ) {
     super('Campaign already finished');
+  }
+}
+
+export class UserIsNotParticipatingError extends BaseError {
+  constructor() {
+    super('User is not participating in campaign');
   }
 }

--- a/recording-oracle/src/modules/campaigns/progress-checking/progress-checker.spec.ts
+++ b/recording-oracle/src/modules/campaigns/progress-checking/progress-checker.spec.ts
@@ -286,7 +286,7 @@ describe('BaseCampaignProgressChecker', () => {
       const result = await resultsChecker.checkForParticipant(
         generateParticipantAuthKeys(),
       );
-      console.log(result);
+
       expect(result.abuseDetected).toBe(false);
       expect(result.score).toBeGreaterThan(0);
       expect(result.totalVolume).toBeGreaterThan(0);


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
We want to provide an ability to campaign participants to see if they have some results for a campaign they joined to. In order to do that we are going to check their progress for the whole campaign period returning totals to the client.

## How has this been tested?
- [x] unit tests
- [x] e2e locally via swagger: hit for existing campaign participant with valid API keys, verified correct results returned
- [x] e2e locally via swagger: hit for unknown campaign, make sure 404 is thrown

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No