### PR TITLE
[v2] feat: improve RecO processing

### DIFF
--- a/campaign-launcher/server/src/common/constants/index.ts
+++ b/campaign-launcher/server/src/common/constants/index.ts
@@ -1,15 +1,11 @@
 export const SUPPORTED_EXCHANGE_NAMES = [
   'bigone',
   'binance',
-  'bitget',
   'bybit',
-  'coinbaseexchange',
   'gate',
   'htx',
   'kraken',
-  'kucoin',
   'mexc',
-  'okx',
   'upbit',
   'xt',
 ] as const;

--- a/recording-oracle/src/common/constants/index.ts
+++ b/recording-oracle/src/common/constants/index.ts
@@ -6,15 +6,11 @@ export const JWT_STRATEGY_NAME = 'jwt-http';
 export const SUPPORTED_EXCHANGE_NAMES = [
   'bigone',
   'binance',
-  'bitget',
   'bybit',
-  'coinbaseexchange',
   'gate',
   'htx',
   'kraken',
-  'kucoin',
   'mexc',
-  'okx',
   'upbit',
   'xt',
 ] as const;

--- a/recording-oracle/src/modules/campaigns/campaigns.repository.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.repository.ts
@@ -27,15 +27,21 @@ export class CampaignsRepository extends Repository<CampaignEntity> {
   }
 
   async findForProgressRecording(): Promise<CampaignEntity[]> {
+    const now = new Date();
     const timeAgo = dayjs().subtract(1, 'day').toDate();
 
     const results = await this.createQueryBuilder('campaign')
       .where('campaign.status = :status', { status: CampaignStatus.ACTIVE })
       .andWhere('campaign.startDate <= :timeAgo', { timeAgo })
       .andWhere(
-        '(campaign.lastResultsAt IS NULL OR campaign.lastResultsAt <= :timeAgo)',
+        `
+          campaign.lastResultsAt IS NULL
+          OR campaign.lastResultsAt <= :timeAgo
+          OR campaign.endDate <= :now
+        `,
         {
           timeAgo,
+          now,
         },
       )
       .getMany();

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -373,8 +373,13 @@ export class CampaignsService {
               -1,
             ) as IntermediateResult;
 
+            const isOngoingCampaign = campaign.endDate > new Date();
             const lastResultDate = new Date(lastResultAt);
-            if (dayjs().diff(lastResultAt, 'day') === 0) {
+            if (isOngoingCampaign && dayjs().diff(lastResultAt, 'day') === 0) {
+              /**
+               * If campaign is ongoing - check results only once in 24.
+               * If campaing ended - let it record results immediately to reduce the wait.
+               */
               logger.debug('Less than a day passed from previous check', {
                 lastResultAt,
               });

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -325,21 +325,25 @@ export class CampaignsService {
   async recordCampaignsProgress(): Promise<void> {
     this.logger.debug('Campaigns progress recording job started');
 
-    /**
-     * Atm we don't expect many active campaigns
-     * so it's fine to get all at once, but later
-     * we might need to query them in batches or as stream.
-     */
-    const campaignsToCheck =
-      await this.campaignsRepository.findForProgressRecording();
-
-    for (const campaign of campaignsToCheck) {
+    try {
       /**
-       * Right now for simplicity process sequentially.
-       * Later we can add "fastq" usage for parallel processing
-       * and "backpressured" adding to the queue.
+       * Atm we don't expect many active campaigns
+       * so it's fine to get all at once, but later
+       * we might need to query them in batches or as stream.
        */
-      await this.recordCampaignProgress(campaign);
+      const campaignsToCheck =
+        await this.campaignsRepository.findForProgressRecording();
+
+      for (const campaign of campaignsToCheck) {
+        /**
+         * Right now for simplicity process sequentially.
+         * Later we can add "fastq" usage for parallel processing
+         * and "backpressured" adding to the queue.
+         */
+        await this.recordCampaignProgress(campaign);
+      }
+    } catch (error) {
+      this.logger.error('Error while recording campaigns progress', error);
     }
 
     this.logger.debug('Campaigns progress recording job finished');
@@ -642,23 +646,27 @@ export class CampaignsService {
   async trackCampaignsCompletion(): Promise<void> {
     this.logger.debug('Campaigns completion tracking job started');
 
-    const campaignsToTrack =
-      await this.campaignsRepository.findForCompletionTracking();
+    try {
+      const campaignsToTrack =
+        await this.campaignsRepository.findForCompletionTracking();
 
-    for (const campaign of campaignsToTrack) {
-      const escrow = await EscrowUtils.getEscrow(
-        campaign.chainId,
-        campaign.address,
-      );
+      for (const campaign of campaignsToTrack) {
+        const escrow = await EscrowUtils.getEscrow(
+          campaign.chainId,
+          campaign.address,
+        );
 
-      const completeStatusString = EscrowStatus[EscrowStatus.Complete];
-      if (escrow.status === completeStatusString) {
-        this.logger.info('Completing campaign', {
-          campaignId: campaign.id,
-        });
-        campaign.status = CampaignStatus.COMPLETED;
-        await this.campaignsRepository.save(campaign);
+        const completeStatusString = EscrowStatus[EscrowStatus.Complete];
+        if (escrow.status === completeStatusString) {
+          this.logger.info('Completing campaign', {
+            campaignId: campaign.id,
+          });
+          campaign.status = CampaignStatus.COMPLETED;
+          await this.campaignsRepository.save(campaign);
+        }
       }
+    } catch (error) {
+      this.logger.error('Error while tracking campaigns completion', error);
     }
 
     this.logger.debug('Campaigns completion tracking job finished');

--- a/recording-oracle/src/modules/campaigns/fixtures/campaign.ts
+++ b/recording-oracle/src/modules/campaigns/fixtures/campaign.ts
@@ -22,8 +22,8 @@ import {
 export function generateCampaignEntity(
   overrides: Partial<CampaignEntity> = {},
 ): CampaignEntity {
-  const startDate = new Date();
-  const durationInDays = faker.number.int({ min: 2, max: 7 });
+  const startDate = dayjs().subtract(1, 'days').toDate();
+  const durationInDays = faker.number.int({ min: 3, max: 7 });
 
   const campaign = {
     id: faker.string.uuid(),

--- a/recording-oracle/src/modules/web3/fixtures/index.ts
+++ b/recording-oracle/src/modules/web3/fixtures/index.ts
@@ -19,4 +19,5 @@ export const mockWeb3ConfigService: Omit<Web3ConfigService, 'configService'> = {
   operatorAddress: testWallet.address,
   gasPriceMultiplier: faker.number.int({ min: 1, max: 42 }),
   getRpcUrlByChainId: () => faker.internet.url(),
+  alchemyApiKey: faker.string.sample(),
 };

--- a/recording-oracle/src/modules/web3/web3.service.spec.ts
+++ b/recording-oracle/src/modules/web3/web3.service.spec.ts
@@ -163,13 +163,10 @@ describe('Web3Service', () => {
       expect(thrownError.message).toBe('Failed to get token price');
 
       expect(logger.error).toHaveBeenCalledTimes(1);
-      expect(logger.error).toHaveBeenCalledWith(
-        'Error while getting token price',
-        {
-          symbol: testTokenSymbol,
-          error: testError,
-        },
-      );
+      expect(logger.error).toHaveBeenCalledWith('Failed to get token price', {
+        symbol: testTokenSymbol,
+        error: testError,
+      });
     });
 
     it('should cache and return price if available', async () => {

--- a/recording-oracle/src/modules/web3/web3.service.ts
+++ b/recording-oracle/src/modules/web3/web3.service.ts
@@ -207,12 +207,13 @@ export class Web3Service {
 
       return tokenPriceUsd === MISSING_TOKEN_PRICE ? null : tokenPriceUsd;
     } catch (error) {
-      this.logger.error('Error while getting token price', {
+      const message = 'Failed to get token price';
+      this.logger.error(message, {
         symbol,
         error,
       });
 
-      throw new Error('Failed to get token price');
+      throw new Error(message);
     }
   }
 }

--- a/reputation-oracle/src/modules/payouts/payouts.service.ts
+++ b/reputation-oracle/src/modules/payouts/payouts.service.ts
@@ -133,6 +133,8 @@ export class PayoutsService {
           );
 
           logger.info('Rewards calculated', {
+            periodFrom: intermediateResult.from,
+            periodTo: intermediateResult.to,
             rewardsBatches,
           });
 


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
- changed DB query and code logic to allow intermediate results recording if less than a day passed from previous calculation, but campaign has already ended, so we don't have to wait e.g. for another 23h to get results just for 1h
- added payout period to RepO log for better observability
- some exchanges require passphrase w/ API key; we decided to remove them for now

## How has this been tested?
- [x] unit tests

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No