### PR TITLE
[Launcher UI V2] Add Daily Volume Target

### DIFF
--- a/campaign-launcher/interfaceV2/src/components/CampaignStats/index.tsx
+++ b/campaign-launcher/interfaceV2/src/components/CampaignStats/index.tsx
@@ -25,13 +25,25 @@ const StatsCard = styled(Box)(({ theme }) => ({
   border: '1px solid rgba(255, 255, 255, 0.1)',
 
   [theme.breakpoints.down('xl')]: {
-    height: '125px',
+    height: 'unset',
+    minHeight: '125px',
+    justifyContent: 'space-between',
     padding: '16px 32px 24px',
   },
 
   [theme.breakpoints.only('md')]: {
-    height: '125px',
+    height: 'unset',
+    minHeight: '125px',
     padding: '12px',
+  },
+}));
+
+const Title = styled(Typography)(({ theme }) => ({
+  color: theme.palette.text.primary,
+  marginBottom: '56px',
+
+  [theme.breakpoints.down('xl')]: {
+    marginBottom: '16px',
   },
 }));
 
@@ -41,10 +53,14 @@ const Value = styled(Typography)(({ theme }) => ({
   fontWeight: 800,
   letterSpacing: '-0.5px',
   lineHeight: '100%',
+}));
 
-  '& > span': {
-    fontSize: '30px',
-  },
+const Suffix = styled('span')(({ theme }) => ({
+  color: theme.palette.primary.violet,
+  fontSize: '30px',
+  fontWeight: 800,
+  letterSpacing: '-0.5px',
+  lineHeight: '100%',
 }));
 
 const FlexGrid = styled(Box)(({ theme }) => ({
@@ -77,51 +93,53 @@ const CampaignStats: FC<Props> = ({ campaign }) => {
 
   const totalFee = campaign.exchange_oracle_fee_percent + campaign.recording_oracle_fee_percent + campaign.reputation_oracle_fee_percent;
   const formattedTokenAmount = +formatTokenAmount(campaign.fund_amount, campaign.fund_token_decimals);
+  const formattedAmountPaid = +formatTokenAmount(campaign.amount_paid, campaign.fund_token_decimals);
 
   return (
     <Grid container spacing={2} width="100%">
       <Grid size={{ xs: 12, md: 6 }}>
         <FlexGrid>
           <StatsCard>
-            <Typography variant="subtitle2" mb={{ xs: 2, xl: 7 }}>Total Funded Amount</Typography>
+            <Title variant="subtitle2">Total Funded Amount</Title>
             <Value>
-              {formattedTokenAmount} <span>{campaign.fund_token_symbol}</span>
+              {formattedTokenAmount} <Suffix>{campaign.fund_token_symbol}</Suffix>
             </Value>
           </StatsCard>
           <StatsCard>
-            <Typography variant="subtitle2" mb={{ xs: 2, xl: 7 }}>Amount Paid</Typography>
+            <Title variant="subtitle2">Amount Paid</Title>
             <Value>
-              {formatTokenAmount(campaign.amount_paid, campaign.fund_token_decimals)} <span>{campaign.fund_token_symbol}</span>
+              {formattedAmountPaid} <Suffix>{campaign.fund_token_symbol}</Suffix>
             </Value>
           </StatsCard>
           <StatsCard>
-            <Typography variant="subtitle2" mb={{ xs: 2, xl: 7 }}>Exchange</Typography>
+            <Title variant="subtitle2">Oracle fees</Title>
+            <Value>
+              <FormattedNumber value={formattedTokenAmount * totalFee / 100} /> 
+              {' '}<Suffix>{campaign.fund_token_symbol}</Suffix>{' '}
+              <Typography variant="h6" fontWeight={700} component="span" color="rgba(255, 255, 255, 0.18)">
+                ({totalFee}%)
+              </Typography>
+            </Value>
+          </StatsCard>
+          <StatsCard>
+            <Title variant="subtitle2">Daily volume target</Title>
+            <Typography variant="h5" color="primary.violet" fontWeight={700}>
+              <FormattedNumber value={campaign.daily_volume_target} decimals={3} />
+              {' '}<span>{campaign.trading_pair.split('/')[1]}</span>
+            </Typography>
+          </StatsCard>
+          <StatsCard>
+            <Title variant="subtitle2">Exchange</Title>
             <Typography variant={isXl ? 'h4' : 'h6-mobile'}>
               {exchangeName}
             </Typography>
           </StatsCard>
           <StatsCard>
-            <Typography variant="subtitle2" mb={{ xs: 2, xl: 7 }}>Pair</Typography>
+            <Title variant="subtitle2">Pair</Title>
             <CryptoPairEntity
               symbol={campaign.trading_pair}
               size={isXl ? 'large' : 'medium'}
             />
-          </StatsCard>
-          <StatsCard 
-            sx={{ 
-              flexDirection: { xs: 'column', md: 'row' }, 
-              gap: 2,
-              alignItems: { xs: 'flex-start', md: 'center' }, 
-              py: { xs: 1.5, md: 2 }, 
-              height: { xs: 'unset' }, 
-              flexBasis: '100%'
-            }}
-          >
-            <Typography variant="subtitle2">Oracle fees</Typography>
-            <Typography variant="h6" color="primary.violet" fontWeight={700}>
-              <FormattedNumber value={formattedTokenAmount * totalFee / 100} suffix={' ' + campaign.fund_token_symbol} />
-              ({totalFee}%)
-            </Typography>
           </StatsCard>
         </FlexGrid>
       </Grid>

--- a/campaign-launcher/interfaceV2/src/components/CampaignStats/index.tsx
+++ b/campaign-launcher/interfaceV2/src/components/CampaignStats/index.tsx
@@ -102,13 +102,15 @@ const CampaignStats: FC<Props> = ({ campaign }) => {
           <StatsCard>
             <Title variant="subtitle2">Total Funded Amount</Title>
             <Value>
-              {formattedTokenAmount} <Suffix>{campaign.fund_token_symbol}</Suffix>
+              {formattedTokenAmount}
+              {' '}<Suffix>{campaign.fund_token_symbol}</Suffix>
             </Value>
           </StatsCard>
           <StatsCard>
             <Title variant="subtitle2">Amount Paid</Title>
             <Value>
-              {formattedAmountPaid} <Suffix>{campaign.fund_token_symbol}</Suffix>
+              {formattedAmountPaid}
+              {' '}<Suffix>{campaign.fund_token_symbol}</Suffix>
             </Value>
           </StatsCard>
           <StatsCard>

--- a/campaign-launcher/interfaceV2/src/components/CampaignsTable/index.tsx
+++ b/campaign-launcher/interfaceV2/src/components/CampaignsTable/index.tsx
@@ -174,14 +174,14 @@ const CampaignsTable: FC<Props> = ({
       field: 'pair',
       headerName: 'Pair',
       flex: 2,
-      minWidth: 240,
+      minWidth: 250,
       renderCell: (params) => <CryptoPairEntity symbol={params.row.trading_pair} size="medium" />,
     },
     {
       field: 'exchange',
       headerName: 'Exchange',
-      flex: 1.5,
-      minWidth: 170,
+      flex: 1,
+      minWidth: 120,
       renderCell: (params) => {
         const exchangeName = exchangesMap.get(params.row.exchange_name)?.display_name;
         return (
@@ -202,7 +202,7 @@ const CampaignsTable: FC<Props> = ({
       field: 'daily_volume_target',
       headerName: 'DVT',
       flex: 1.5,
-      minWidth: 130,
+      minWidth: 140,
       renderHeader: () => (
         <>
           <Typography variant="subtitle2" mr={1}>DVT</Typography>
@@ -260,7 +260,7 @@ const CampaignsTable: FC<Props> = ({
       field: 'fundAmount',
       headerName: 'Fund Amount',
       flex: 2,
-      minWidth: 130,
+      minWidth: 140,
       renderCell: (params) => {
         if (isJoinedCampaigns) {
           const { fund_amount, fund_token } = params.row

--- a/campaign-launcher/interfaceV2/src/components/CampaignsTable/index.tsx
+++ b/campaign-launcher/interfaceV2/src/components/CampaignsTable/index.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 
 import { Button, Typography, Box, Tooltip, Stack } from '@mui/material';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
+import { numericFormatter } from 'react-number-format';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAccount } from 'wagmi';
 
@@ -173,7 +174,7 @@ const CampaignsTable: FC<Props> = ({
       field: 'pair',
       headerName: 'Pair',
       flex: 2,
-      minWidth: 250,
+      minWidth: 240,
       renderCell: (params) => <CryptoPairEntity symbol={params.row.trading_pair} size="medium" />,
     },
     {
@@ -198,10 +199,34 @@ const CampaignsTable: FC<Props> = ({
       renderCell: (params) => <ExplorerLink address={params.row.address} chainId={params.row.chain_id} />,
     },
     {
+      field: 'daily_volume_target',
+      headerName: 'DVT',
+      flex: 1.5,
+      minWidth: 130,
+      renderHeader: () => (
+        <>
+          <Typography variant="subtitle2" mr={1}>DVT</Typography>
+          <Tooltip arrow placement="right" title="Daily Volume Target">
+            <InfoTooltipInner width={24} height={24} />
+          </Tooltip>
+        </>
+      ),
+      renderCell: (params) => {
+        const { daily_volume_target, trading_pair } = params.row;
+        const currency = trading_pair.split('/')[1];
+        const formattedDailyVolumeTarget = numericFormatter(daily_volume_target.toString(), {
+          decimalScale: 1,
+          fixedDecimalScale: false,
+          thousandSeparator: ',',
+        });
+        return <Typography variant="subtitle2">{formattedDailyVolumeTarget} {currency}</Typography>;
+      },
+    },
+    {
       field: 'network',
       headerName: 'Network',
       flex: 1,
-      minWidth: 110,
+      minWidth: 100,
       renderCell: (params) => {
         const networkName = getNetworkName(params.row.chain_id);
         return (
@@ -235,7 +260,7 @@ const CampaignsTable: FC<Props> = ({
       field: 'fundAmount',
       headerName: 'Fund Amount',
       flex: 2,
-      minWidth: 150,
+      minWidth: 130,
       renderCell: (params) => {
         if (isJoinedCampaigns) {
           const { fund_amount, fund_token } = params.row
@@ -259,7 +284,7 @@ const CampaignsTable: FC<Props> = ({
       field: 'status',
       headerName: 'Status',
       flex: 1,
-      minWidth: 80,
+      minWidth: 60,
       renderHeader: () => <StatusTooltip />,
       renderCell: (params) => {
         return (
@@ -358,14 +383,18 @@ const CampaignsTable: FC<Props> = ({
           px: isXl ? 0 : 1,
           textTransform: 'uppercase',
           cursor: 'default',
-          fontWeight: 500,
-          fontSize: '16px',
           '&[data-field="fundAmount"] .MuiDataGrid-columnHeaderTitleContainer': {
             justifyContent: isJoinedCampaigns ? 'flex-end' : 'flex-start',
           },
           '&[data-field="status"] .MuiDataGrid-columnHeaderTitleContainer': {
             justifyContent: 'center',
           },
+        },
+        '& .MuiDataGrid-columnHeaderTitle': {
+          fontWeight: 600,
+          fontSize: '14px',
+          lineHeight: '22px',
+          letterSpacing: '0.1px',
         },
         '& .MuiDataGrid-row': {
           display: 'flex',
@@ -394,7 +423,10 @@ const CampaignsTable: FC<Props> = ({
           '&[data-field="fundAmount"]': {
             justifyContent: isJoinedCampaigns ? 'flex-end' : 'flex-start',
           },
-          '&[data-field="status"], &[data-field="network"]': {
+          '&[data-field="network"]': {
+            justifyContent: 'flex-start',
+          },
+          '&[data-field="status"]': {
             justifyContent: 'center',
           },
         },

--- a/campaign-launcher/interfaceV2/src/components/DailyAmountPaidChart/index.tsx
+++ b/campaign-launcher/interfaceV2/src/components/DailyAmountPaidChart/index.tsx
@@ -84,8 +84,8 @@ const DailyAmountPaidChart: FC<Props> = ({ data, endDate, tokenSymbol }) => {
         borderWidth: 2,
         backgroundColor: (context: ScriptableContext<'line'>) => {
           const chart = context.chart;
-          const { ctx } = chart;
-          const gradient = ctx.createLinearGradient(0, 0, 0, 400);
+          const { ctx, chartArea } = chart;
+          const gradient = ctx.createLinearGradient(0, 0, 0, chartArea.height + 80);
           gradient.addColorStop(0.3, 'rgba(202, 207, 232, 0.3)');
           gradient.addColorStop(1, 'rgba(233, 236, 255, 0)');
           return gradient;

--- a/campaign-launcher/interfaceV2/src/components/FormattedNumber/index.tsx
+++ b/campaign-launcher/interfaceV2/src/components/FormattedNumber/index.tsx
@@ -4,11 +4,12 @@ import { NumericFormat } from 'react-number-format';
 
 type Props = {
   value: number | string | undefined | null;
+  decimals?: number;
   prefix?: string;
   suffix?: string;
 };
 
-const FormattedNumber: FC<Props> = ({ value, prefix = '', suffix = '' }) => {
+const FormattedNumber: FC<Props> = ({ value, decimals = 3, prefix = '', suffix = '',  }) => {
   const _value = Number(value || 0);
   
   return (
@@ -17,7 +18,7 @@ const FormattedNumber: FC<Props> = ({ value, prefix = '', suffix = '' }) => {
       value={_value}
       thousandsGroupStyle="thousand"
       thousandSeparator=","
-      decimalScale={3}
+      decimalScale={decimals}
       prefix={prefix}
       suffix={suffix}
     />

--- a/campaign-launcher/interfaceV2/src/components/InfoTooltipInner/index.tsx
+++ b/campaign-launcher/interfaceV2/src/components/InfoTooltipInner/index.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react"
 
-import { Box, Typography } from "@mui/material";
+import { Box, BoxProps, Typography } from "@mui/material";
 
-const InfoTooltipInner = forwardRef((props, ref) => {
+const InfoTooltipInner = forwardRef((props: BoxProps, ref) => {
   return (
     <Box 
       ref={ref}

--- a/campaign-launcher/interfaceV2/src/components/ModalState/Error.tsx
+++ b/campaign-launcher/interfaceV2/src/components/ModalState/Error.tsx
@@ -5,10 +5,13 @@ import { Box, Typography } from '@mui/material';
 import { CloseIcon } from '../../icons';
 
 type Props = {
-  error?: string;
+  message?: string;
 };
 
-const ModalError: FC<Props> = ({ error }) => {
+const DEFAULT_ERROR_MESSAGE = 'An error occurred, please try again.';
+const INTERNAL_SERVER_ERROR = 'Internal server error';
+
+const ModalError: FC<Props> = ({ message }) => {
   return (
     <>
       <Box
@@ -24,7 +27,7 @@ const ModalError: FC<Props> = ({ error }) => {
         <CloseIcon sx={{ width: 34, height: 34 }} />
       </Box>
       <Typography variant="subtitle2" color="error.main" mb={1} py={1}>
-        {error || 'An error occurred, please try again.'}
+        {message === INTERNAL_SERVER_ERROR ? DEFAULT_ERROR_MESSAGE : message || DEFAULT_ERROR_MESSAGE}
       </Typography>
     </>
   );

--- a/campaign-launcher/interfaceV2/src/components/ModalState/Error.tsx
+++ b/campaign-launcher/interfaceV2/src/components/ModalState/Error.tsx
@@ -2,14 +2,12 @@ import { FC } from 'react';
 
 import { Box, Typography } from '@mui/material';
 
+import { DEFAULT_ERROR_MESSAGE, INTERNAL_SERVER_ERROR } from '../../constants';
 import { CloseIcon } from '../../icons';
 
 type Props = {
   message?: string;
 };
-
-const DEFAULT_ERROR_MESSAGE = 'An error occurred, please try again.';
-const INTERNAL_SERVER_ERROR = 'Internal server error';
 
 const ModalError: FC<Props> = ({ message }) => {
   return (

--- a/campaign-launcher/interfaceV2/src/components/modals/AddApiKeyModal/index.tsx
+++ b/campaign-launcher/interfaceV2/src/components/modals/AddApiKeyModal/index.tsx
@@ -151,7 +151,7 @@ const AddApiKeyModal: FC<Props> = ({ open, onClose }) => {
               </Typography>
             </ModalSuccess>
           )}
-          {isError && <ModalError error={error?.message} />}
+          {isError && <ModalError message={error?.message} />}
           {isIdle && (
             <Button
               size="large"

--- a/campaign-launcher/interfaceV2/src/components/modals/EditApiKeyModal/index.tsx
+++ b/campaign-launcher/interfaceV2/src/components/modals/EditApiKeyModal/index.tsx
@@ -159,7 +159,7 @@ const EditApiKeyModal: FC<Props> = ({ open, onClose, exchangeName }) => {
               </Typography>
             </ModalSuccess>
           )}
-          {isError && <ModalError error={error.message} />}
+          {isError && <ModalError message={error.message} />}
           <Box display="flex" gap={1} mx="auto">
             {isIdle && (
               <>

--- a/campaign-launcher/interfaceV2/src/constants/index.ts
+++ b/campaign-launcher/interfaceV2/src/constants/index.ts
@@ -38,3 +38,6 @@ export const MAINNET_CHAIN_IDS = [ChainId.MAINNET, ChainId.POLYGON];
 export const LOCALHOST_CHAIN_IDS = [ChainId.LOCALHOST];
 
 export const MQ_MOBILE = 'screen and (max-width: 600px)';
+
+export const INTERNAL_SERVER_ERROR = 'Internal server error';
+export const DEFAULT_ERROR_MESSAGE = 'An error occurred, please try again.';

--- a/campaign-launcher/interfaceV2/src/types/index.ts
+++ b/campaign-launcher/interfaceV2/src/types/index.ts
@@ -47,6 +47,7 @@ export type Campaign = {
   address: `0x${string}`;
   exchange_name: string;
   trading_pair: string;
+  daily_volume_target: number;
   start_date: string;
   end_date: string;
   fund_amount: string;

--- a/campaign-launcher/interfaceV2/src/utils/index.ts
+++ b/campaign-launcher/interfaceV2/src/utils/index.ts
@@ -143,6 +143,7 @@ export const constructCampaignDetails = ({ chainId, address, data, tokenDecimals
     address: address,
     exchange_name: data.exchange,
     trading_pair: data.pair,
+    daily_volume_target: data.daily_volume_target,
     start_date: data.start_date,
     end_date: data.end_date,
     fund_amount: fundAmount.toString(),


### PR DESCRIPTION
## Issue tracking
Not ticketed

## Context behind the change
This PR adds daily volume target information in the campaigns table and on the campaign details page;
Also in this PR i've changed some elements such that they became more responsive and handled 500 error, when we need to display error message

## How has this been tested?
locally

## Release plan
regular

## Potential risks; What to monitor; Rollback plan
not found