### PR TITLE
[v2] feat: count sell trades volume

### DIFF
--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -516,6 +516,13 @@ export class CampaignsService {
         continue;
       }
 
+      /**
+       * !!! NOTE !!!
+       * There can be a situation where two campaign participants
+       * have a trade between each other, so total volume
+       * is not 100% accurate in this case, but probability of it is
+       * negligible so omit it here. Later RepO can verify it if needed.
+       */
       totalVolume += participantOutcomes.totalVolume;
 
       outcomes.push({

--- a/recording-oracle/src/modules/campaigns/progress-checking/market-making.spec.ts
+++ b/recording-oracle/src/modules/campaigns/progress-checking/market-making.spec.ts
@@ -52,7 +52,7 @@ describe('MarketMakingResultsChecker', () => {
       expect(score).toBe(trade.cost * 0.42);
     });
 
-    it('should return zero score for taker sell', () => {
+    it('should return proper score for taker sell', () => {
       const trade = generateTrade({
         takerOrMaker: TakerOrMakerFlag.TAKER,
         side: TradingSide.SELL,
@@ -60,7 +60,7 @@ describe('MarketMakingResultsChecker', () => {
 
       const score = resultsChecker['calculateTradeScore'](trade);
 
-      expect(score).toBe(0);
+      expect(score).toBe(trade.cost * 0.1);
     });
   });
 });

--- a/recording-oracle/src/modules/campaigns/progress-checking/market-making.ts
+++ b/recording-oracle/src/modules/campaigns/progress-checking/market-making.ts
@@ -14,7 +14,7 @@ export class MarketMakingResultsChecker extends BaseCampaignProgressChecker {
       ratio = 0.42;
     } else {
       // "taker" sells
-      ratio = 0;
+      ratio = 0.1;
     }
 
     return ratio * trade.cost;

--- a/recording-oracle/src/modules/campaigns/progress-checking/progress-checker.spec.ts
+++ b/recording-oracle/src/modules/campaigns/progress-checking/progress-checker.spec.ts
@@ -4,7 +4,6 @@ import { createMock } from '@golevelup/ts-jest';
 import {
   ExchangeApiClient,
   ExchangeApiClientFactory,
-  TradingSide,
 } from '@/modules/exchange';
 import { generateTrade } from '@/modules/exchange/fixtures';
 
@@ -132,7 +131,7 @@ describe('BaseCampaignProgressChecker', () => {
       );
     });
 
-    it('should count volume only for buy trades up to exclusive end date', async () => {
+    it('should count volume for trades up to exclusive end date', async () => {
       const tradesInRange = Array.from({ length: 3 }, () =>
         generateTrade({
           timestamp: faker.date
@@ -160,9 +159,10 @@ describe('BaseCampaignProgressChecker', () => {
       const result =
         await resultsChecker.checkForParticipant(participantAuthKeys);
 
-      const expectedTotalVolume = tradesInRange
-        .filter((t) => t.side === TradingSide.BUY)
-        .reduce((acc, curr) => acc + curr.cost, 0);
+      const expectedTotalVolume = tradesInRange.reduce(
+        (acc, curr) => acc + curr.cost,
+        0,
+      );
 
       expect(result.abuseDetected).toBe(false);
       expect(result.totalVolume).toBe(expectedTotalVolume);

--- a/recording-oracle/src/modules/campaigns/progress-checking/progress-checker.ts
+++ b/recording-oracle/src/modules/campaigns/progress-checking/progress-checker.ts
@@ -1,8 +1,4 @@
-import {
-  ExchangeApiClientFactory,
-  Trade,
-  TradingSide,
-} from '@/modules/exchange';
+import { ExchangeApiClientFactory, Trade } from '@/modules/exchange';
 
 import type {
   CampaignProgressChecker,
@@ -73,7 +69,7 @@ export abstract class BaseCampaignProgressChecker
           nTradesSampled += 1;
         }
 
-        totalVolume += trade.side === TradingSide.BUY ? trade.cost : 0;
+        totalVolume += trade.cost;
         score += this.calculateTradeScore(trade);
       }
 


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
- we revisited our score & volume calculation strategies and decided to count `sell` trades into total volume as well, so even if e.g. there is only participant doing maker sells they can solely reach daily volume target and be rewarded
- also count score for "taker sells" because eventually it does market making

## How has this been tested?
- [x] unit tests

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No