### PR TITLE
[Launcher UI] Rework campaign details 

### DIFF
--- a/campaign-launcher/client/src/components/CampaignAddress/index.tsx
+++ b/campaign-launcher/client/src/components/CampaignAddress/index.tsx
@@ -1,0 +1,69 @@
+import { FC, MouseEvent, useState } from "react"
+
+import { ChainId } from "@human-protocol/sdk"
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import { Box, IconButton, Tooltip, Typography } from "@mui/material"
+
+import { OpenInNewIcon } from "../../icons"
+import { getExplorerUrl } from "../../utils"
+
+type Props = {
+  address: string;
+  chainId: ChainId;
+}
+
+const handleAddressClick = (
+  e: MouseEvent<HTMLButtonElement>,
+  chainId: ChainId,
+  address: string
+) => {
+  e.stopPropagation();
+  const explorerUrl = getExplorerUrl(chainId, address);
+  window.open(explorerUrl, '_blank');
+};
+
+const CampaignAddress: FC<Props> = ({ address, chainId }) => {
+  const [isCopied, setIsCopied] = useState(false);
+
+  const handleCopy = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    navigator.clipboard.writeText(address);
+    setIsCopied(true);
+    setTimeout(() => {
+      setIsCopied(false);
+    }, 1500);
+  }
+
+  return (
+    <Box display="flex" alignItems="center" width={{ xs: "100%", md: "auto" }} gap={1} py={2} px={3} borderRadius="40px" border="1px solid" borderColor="divider">
+      <Typography variant="subtitle2" textOverflow="ellipsis" overflow="hidden" whiteSpace="nowrap">
+        {address}
+      </Typography>
+      <IconButton
+        onClick={(e) => handleCopy(e)}
+        sx={{
+          color: 'text.secondary',
+          p: 0,
+          ml: 2,
+          '&:hover': { background: 'none' },
+        }}
+      >
+        <Tooltip title="Copied" placement="top" open={isCopied}>
+          <ContentCopyIcon />
+        </Tooltip>
+      </IconButton>
+      <IconButton
+        onClick={(e) => handleAddressClick(e, chainId, address)}
+        sx={{
+          color: 'text.secondary',
+          p: 0,
+          '&:hover': { background: 'none' },
+        }}
+      >
+        <OpenInNewIcon />
+      </IconButton>
+    </Box>
+  )
+}
+
+export default CampaignAddress;

--- a/campaign-launcher/client/src/components/CampaignAddress/index.tsx
+++ b/campaign-launcher/client/src/components/CampaignAddress/index.tsx
@@ -1,4 +1,4 @@
-import { FC, MouseEvent, useState } from "react"
+import { FC, MouseEvent, useEffect, useRef, useState } from "react"
 
 import { ChainId } from "@human-protocol/sdk"
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
@@ -13,7 +13,7 @@ type Props = {
   chainId: ChainId;
 }
 
-const handleAddressClick = (
+const handleOpenInExplorerClick = (
   e: MouseEvent<HTMLButtonElement>,
   chainId: ChainId,
   address: string
@@ -25,14 +25,30 @@ const handleAddressClick = (
 
 const CampaignAddress: FC<Props> = ({ address, chainId }) => {
   const [isCopied, setIsCopied] = useState(false);
+  const timeoutRef = useRef<NodeJS.Timeout>();
 
   const isMobile = useIsMobile();
 
-  const handleCopy = (e: MouseEvent<HTMLButtonElement>) => {
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopyClick = (e: MouseEvent<HTMLButtonElement>) => {
+    if (isCopied) return;
+    
     e.stopPropagation();
     navigator.clipboard.writeText(address);
     setIsCopied(true);
-    setTimeout(() => {
+    
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    
+    timeoutRef.current = setTimeout(() => {
       setIsCopied(false);
     }, 1500);
   }
@@ -61,7 +77,8 @@ const CampaignAddress: FC<Props> = ({ address, chainId }) => {
         {isMobile ? formatAddress(address) : address}
       </Typography>
       <IconButton
-        onClick={(e) => handleCopy(e)}
+        disabled={isCopied}
+        onClick={handleCopyClick}
         sx={{
           color: 'text.secondary',
           p: 0,
@@ -74,7 +91,7 @@ const CampaignAddress: FC<Props> = ({ address, chainId }) => {
         </Tooltip>
       </IconButton>
       <IconButton
-        onClick={(e) => handleAddressClick(e, chainId, address)}
+        onClick={(e) => handleOpenInExplorerClick(e, chainId, address)}
         sx={{
           color: 'text.secondary',
           p: 0,

--- a/campaign-launcher/client/src/components/CampaignAddress/index.tsx
+++ b/campaign-launcher/client/src/components/CampaignAddress/index.tsx
@@ -4,8 +4,9 @@ import { ChainId } from "@human-protocol/sdk"
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { Box, IconButton, Tooltip, Typography } from "@mui/material"
 
+import { useIsMobile } from "../../hooks/useBreakpoints";
 import { OpenInNewIcon } from "../../icons"
-import { getExplorerUrl } from "../../utils"
+import { formatAddress, getExplorerUrl } from "../../utils"
 
 type Props = {
   address: string;
@@ -25,6 +26,8 @@ const handleAddressClick = (
 const CampaignAddress: FC<Props> = ({ address, chainId }) => {
   const [isCopied, setIsCopied] = useState(false);
 
+  const isMobile = useIsMobile();
+
   const handleCopy = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     navigator.clipboard.writeText(address);
@@ -35,9 +38,27 @@ const CampaignAddress: FC<Props> = ({ address, chainId }) => {
   }
 
   return (
-    <Box display="flex" alignItems="center" width={{ xs: "100%", md: "auto" }} gap={1} py={2} px={3} borderRadius="40px" border="1px solid" borderColor="divider">
-      <Typography variant="subtitle2" textOverflow="ellipsis" overflow="hidden" whiteSpace="nowrap">
-        {address}
+    <Box 
+      display="flex" 
+      alignItems="center" 
+      minWidth="250px"
+      maxWidth={{ xs: "100%", sm: "fit-content" }}
+      flexGrow={1}
+      flexShrink={1}
+      gap={1} 
+      py={2} 
+      px={3} 
+      borderRadius="40px" 
+      border="1px solid" 
+      borderColor="divider"
+    >
+      <Typography 
+        variant="subtitle2" 
+        textOverflow="ellipsis" 
+        overflow="hidden" 
+        whiteSpace="nowrap"
+      >
+        {isMobile ? formatAddress(address) : address}
       </Typography>
       <IconButton
         onClick={(e) => handleCopy(e)}

--- a/campaign-launcher/client/src/components/CampaignInfo/index.tsx
+++ b/campaign-launcher/client/src/components/CampaignInfo/index.tsx
@@ -5,30 +5,19 @@ import { Box, Typography } from '@mui/material';
 import { CalendarIcon } from '../../icons';
 import { CampaignDetails } from '../../types';
 import { getChainIcon, getNetworkName, mapStatusToColor } from '../../utils';
+import dayjs from '../../utils/dayjs';
 import CustomTooltip from '../CustomTooltip';
 
 const formatDate = (dateString: string): string => {
-  const date = new Date(dateString);
-  const day = date.getDate();
-  const month = date.toLocaleString('en-US', { month: 'short' });
-  const year = date.getFullYear();
-  return `${day} ${month} ${year}`;
+  return dayjs(dateString).format('D MMM YYYY');
 };
 
 const formatTime = (dateString: string): string => {
-  const date = new Date(dateString);
-  let hours = date.getHours().toString();
-  if (+hours < 10) {
-    hours = '0' + hours;
-  }
-  let minutes = date.getMinutes().toString();
-  if (+minutes < 10) {
-    minutes = '0' + minutes;
-  }
-  const tzOffset = date.getTimezoneOffset();
-  const sign = tzOffset > 0 ? '-' : '+';
-  const tzHours = Math.floor(Math.abs(tzOffset) / 60);
-  return `${hours}:${minutes} GMT${sign}${tzHours}`;
+  const date = dayjs(dateString);
+  const offset = date.utcOffset();
+  const sign = offset >= 0 ? '+' : '-';
+  const hours = Math.floor(Math.abs(offset) / 60);
+  return `${date.format('HH:mm')} GMT${sign}${hours}`;
 };
 
 type Props = {

--- a/campaign-launcher/client/src/components/CampaignInfo/index.tsx
+++ b/campaign-launcher/client/src/components/CampaignInfo/index.tsx
@@ -37,7 +37,7 @@ type Props = {
 const CampaignInfo: FC<Props> = ({ campaign }) => {
   const isCompleted = campaign.status === 'completed';
   return (
-    <Box display="flex" alignItems="center" gap={3}>
+    <Box display="flex" alignItems="center" gap={3} flexWrap={{ xs: "wrap", md: "nowrap" }}>
       <Box
         display="flex"
         alignItems="center"

--- a/campaign-launcher/client/src/components/CampaignInfo/index.tsx
+++ b/campaign-launcher/client/src/components/CampaignInfo/index.tsx
@@ -54,7 +54,7 @@ const CampaignInfo: FC<Props> = ({ campaign }) => {
       >
         {campaign.status}
       </Box>
-      <CustomTooltip title={getNetworkName(campaign.chain_id) || "Unknown Network"} placement="top">
+      <CustomTooltip arrow title={getNetworkName(campaign.chain_id) || "Unknown Network"} placement="top">
         <Box display="flex" sx={{ cursor: 'pointer' }}>
           {getChainIcon(campaign.chain_id)}
         </Box>
@@ -63,13 +63,13 @@ const CampaignInfo: FC<Props> = ({ campaign }) => {
         {campaign?.start_date && campaign?.end_date && (
           <>
             <CalendarIcon />
-            <CustomTooltip placement="top" title={formatTime(campaign.start_date)}>
+            <CustomTooltip arrow placement="top" title={formatTime(campaign.start_date)}>
               <Typography variant="subtitle2" borderBottom="1px dashed" sx={{ cursor: 'pointer' }}>
                 {formatDate(campaign.start_date)}
               </Typography>
             </CustomTooltip>
             <Typography component="span" variant="subtitle2">-</Typography>
-            <CustomTooltip placement="top" title={formatTime(campaign.end_date)}>
+            <CustomTooltip arrow placement="top" title={formatTime(campaign.end_date)}>
               <Typography variant="subtitle2" borderBottom="1px dashed" sx={{ cursor: 'pointer' }}>
                 {formatDate(campaign.end_date)}
               </Typography>

--- a/campaign-launcher/client/src/components/CampaignInfo/index.tsx
+++ b/campaign-launcher/client/src/components/CampaignInfo/index.tsx
@@ -14,10 +14,7 @@ const formatDate = (dateString: string): string => {
 
 const formatTime = (dateString: string): string => {
   const date = dayjs(dateString);
-  const offset = date.utcOffset();
-  const sign = offset >= 0 ? '+' : '-';
-  const hours = Math.floor(Math.abs(offset) / 60);
-  return `${date.format('HH:mm')} GMT${sign}${hours}`;
+  return date.format('HH:mm [GMT]Z');
 };
 
 type Props = {

--- a/campaign-launcher/client/src/components/CampaignInfo/index.tsx
+++ b/campaign-launcher/client/src/components/CampaignInfo/index.tsx
@@ -20,7 +20,10 @@ const formatTime = (dateString: string): string => {
   if (+hours < 10) {
     hours = '0' + hours;
   }
-  const minutes = date.getMinutes();
+  let minutes = date.getMinutes().toString();
+  if (+minutes < 10) {
+    minutes = '0' + minutes;
+  }
   const tzOffset = date.getTimezoneOffset();
   const sign = tzOffset > 0 ? '-' : '+';
   const tzHours = Math.floor(Math.abs(tzOffset) / 60);

--- a/campaign-launcher/client/src/components/CampaignInfo/index.tsx
+++ b/campaign-launcher/client/src/components/CampaignInfo/index.tsx
@@ -5,8 +5,6 @@ import { Box, Tooltip, Typography } from '@mui/material';
 import { CalendarIcon } from '../../icons';
 import { CampaignDetails } from '../../types';
 import { getChainIcon, getNetworkName, mapStatusToColor } from '../../utils';
-import ExplorerLink from '../ExplorerLink';
-import JoinCampaign from '../JoinCampaign';
 
 const formatDate = (dateString: string): string => {
   const date = new Date(dateString);
@@ -16,6 +14,19 @@ const formatDate = (dateString: string): string => {
   return `${day} ${month} ${year}`;
 };
 
+const formatTime = (dateString: string): string => {
+  const date = new Date(dateString);
+  let hours = date.getHours().toString();
+  if (+hours < 10) {
+    hours = '0' + hours;
+  }
+  const minutes = date.getMinutes();
+  const tzOffset = date.getTimezoneOffset();
+  const sign = tzOffset > 0 ? '-' : '+';
+  const tzHours = Math.floor(Math.abs(tzOffset) / 60);
+  return `${hours}:${minutes} GMT${sign}${tzHours}`;
+};
+
 type Props = {
   campaign: CampaignDetails;
 };
@@ -23,20 +34,15 @@ type Props = {
 const CampaignInfo: FC<Props> = ({ campaign }) => {
   const isCompleted = campaign.status === 'completed';
   return (
-    <>
+    <Box display="flex" alignItems="center" gap={3}>
       <Box
         display="flex"
         alignItems="center"
         justifyContent="center"
         py={0.5}
         px="10px"
-        mx={{ xs: 0, md: 2 }}
-        color={isCompleted ? 'text.primary' : 'primary.contrast'}
-        bgcolor={mapStatusToColor(
-          campaign.status,
-          campaign.start_date,
-          campaign.end_date
-        )}
+        color={isCompleted ? "text.primary" : "primary.contrast"}
+        bgcolor={mapStatusToColor(campaign.status, campaign.start_date, campaign.end_date)}
         fontSize="13px"
         fontWeight={600}
         borderRadius="4px"
@@ -44,26 +50,30 @@ const CampaignInfo: FC<Props> = ({ campaign }) => {
       >
         {campaign.status}
       </Box>
-      <ExplorerLink address={campaign.address} chainId={campaign.chain_id} />
-      <Box display="flex" alignItems="center" gap={1} ml={{ xs: 0, md: 2 }}>
-        {campaign?.start_date && campaign?.end_date && (
-          <>
-            <CalendarIcon />
-            <Typography variant="subtitle2" color="text.primary">
-              {`${formatDate(campaign.start_date)} - ${formatDate(
-                campaign.end_date
-              )}`}
-            </Typography>
-          </>
-        )}
-      </Box>
-      <Tooltip title={getNetworkName(campaign.chain_id) || 'Unknown Network'}>
-        <Box display="flex" ml={2} sx={{ cursor: 'pointer' }}>
+      <Tooltip title={getNetworkName(campaign.chain_id) || "Unknown Network"} placement="top">
+        <Box display="flex" sx={{ cursor: 'pointer' }}>
           {getChainIcon(campaign.chain_id)}
         </Box>
       </Tooltip>
-      <JoinCampaign campaign={campaign} />
-    </>
+      <Box display="flex" alignItems="center" gap={1}>
+        {campaign?.start_date && campaign?.end_date && (
+          <>
+            <CalendarIcon />
+            <Tooltip placement="top" title={formatTime(campaign.start_date)}>
+              <Typography variant="subtitle2" borderBottom="1px dashed" sx={{ cursor: 'pointer' }}>
+                {formatDate(campaign.start_date)}
+              </Typography>
+            </Tooltip>
+            <Typography component="span" variant="subtitle2">-</Typography>
+            <Tooltip placement="top" title={formatTime(campaign.end_date)}>
+              <Typography variant="subtitle2" borderBottom="1px dashed" sx={{ cursor: 'pointer' }}>
+                {formatDate(campaign.end_date)}
+              </Typography>
+            </Tooltip>
+          </>
+        )}
+      </Box>
+    </Box>
   );
 };
 

--- a/campaign-launcher/client/src/components/CampaignInfo/index.tsx
+++ b/campaign-launcher/client/src/components/CampaignInfo/index.tsx
@@ -1,10 +1,11 @@
 import { FC } from 'react';
 
-import { Box, Tooltip, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 
 import { CalendarIcon } from '../../icons';
 import { CampaignDetails } from '../../types';
 import { getChainIcon, getNetworkName, mapStatusToColor } from '../../utils';
+import CustomTooltip from '../CustomTooltip';
 
 const formatDate = (dateString: string): string => {
   const date = new Date(dateString);
@@ -53,26 +54,26 @@ const CampaignInfo: FC<Props> = ({ campaign }) => {
       >
         {campaign.status}
       </Box>
-      <Tooltip title={getNetworkName(campaign.chain_id) || "Unknown Network"} placement="top">
+      <CustomTooltip title={getNetworkName(campaign.chain_id) || "Unknown Network"} placement="top">
         <Box display="flex" sx={{ cursor: 'pointer' }}>
           {getChainIcon(campaign.chain_id)}
         </Box>
-      </Tooltip>
+      </CustomTooltip>
       <Box display="flex" alignItems="center" gap={1}>
         {campaign?.start_date && campaign?.end_date && (
           <>
             <CalendarIcon />
-            <Tooltip placement="top" title={formatTime(campaign.start_date)}>
+            <CustomTooltip placement="top" title={formatTime(campaign.start_date)}>
               <Typography variant="subtitle2" borderBottom="1px dashed" sx={{ cursor: 'pointer' }}>
                 {formatDate(campaign.start_date)}
               </Typography>
-            </Tooltip>
+            </CustomTooltip>
             <Typography component="span" variant="subtitle2">-</Typography>
-            <Tooltip placement="top" title={formatTime(campaign.end_date)}>
+            <CustomTooltip placement="top" title={formatTime(campaign.end_date)}>
               <Typography variant="subtitle2" borderBottom="1px dashed" sx={{ cursor: 'pointer' }}>
                 {formatDate(campaign.end_date)}
               </Typography>
-            </Tooltip>
+            </CustomTooltip>
           </>
         )}
       </Box>

--- a/campaign-launcher/client/src/components/Campaigns/index.tsx
+++ b/campaign-launcher/client/src/components/Campaigns/index.tsx
@@ -11,6 +11,7 @@ import JoinedCampaigns from '../JoinedCampaigns';
 import MyCampaigns from '../MyCampaigns';
 
 const Campaigns: FC = () => {
+  const [showActiveCampaigns, setShowActiveCampaigns] = useState(true);
   const [searchParams, setSearchParams] = useSearchParams();
   const [campaignsView, setCampaignsView] = useState(() => {
     if (searchParams.size === 0) {
@@ -24,8 +25,7 @@ const Campaigns: FC = () => {
 
     return CampaignsView.ALL;
   });
-  const [showActiveCampaigns, setShowActiveCampaigns] = useState(false);
-
+  
   useEffect(() => {
     const viewFromUrl = searchParams.get('view');
     if (viewFromUrl) {

--- a/campaign-launcher/client/src/components/CampaignsTable/index.tsx
+++ b/campaign-launcher/client/src/components/CampaignsTable/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 
-import { Button, Typography, Box, Tooltip, Stack } from '@mui/material';
+import { Button, Typography, Box, Stack } from '@mui/material';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import { numericFormatter } from 'react-number-format';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -17,6 +17,7 @@ import {
   mapStatusToColor,
 } from '../../utils';
 import { CryptoPairEntity } from '../CryptoPairEntity';
+import CustomTooltip from '../CustomTooltip';
 import ExplorerLink from '../ExplorerLink';
 import InfoTooltipInner from '../InfoTooltipInner';
 import LaunchCampaign from '../LaunchCampaign';
@@ -137,7 +138,7 @@ const statusTooltipData = [
 
 const StatusTooltip = () => {
   return (
-    <Tooltip
+    <CustomTooltip
       arrow
       placement="left"
       title={
@@ -159,7 +160,7 @@ const StatusTooltip = () => {
       }
     >
       <InfoTooltipInner />
-    </Tooltip>
+    </CustomTooltip>
   );
 };
 
@@ -230,9 +231,9 @@ const CampaignsTable: FC<Props> = ({
           <Typography variant="subtitle2" mr={1}>
             DVT
           </Typography>
-          <Tooltip arrow placement="right" title="Daily Volume Target">
+          <CustomTooltip arrow placement="right" title="Daily Volume Target">
             <InfoTooltipInner width={24} height={24} />
-          </Tooltip>
+          </CustomTooltip>
         </>
       ),
       renderCell: (params) => {
@@ -261,11 +262,11 @@ const CampaignsTable: FC<Props> = ({
       renderCell: (params) => {
         const networkName = getNetworkName(params.row.chain_id);
         return (
-          <Tooltip title={networkName || 'Unknown Network'}>
+          <CustomTooltip title={networkName || 'Unknown Network'} placement="top">
             <Box display="flex" alignItems="center">
               {getChainIcon(params.row.chain_id)}
             </Box>
-          </Tooltip>
+          </CustomTooltip>
         );
       },
     },

--- a/campaign-launcher/client/src/components/CustomTooltip/index.tsx
+++ b/campaign-launcher/client/src/components/CustomTooltip/index.tsx
@@ -23,7 +23,20 @@ const CustomTooltip = ({ children, ...props }: TooltipProps) => {
           onClose={handleTooltipClose}
           slotProps={{
             popper: {
-              disablePortal: true,
+              sx: {
+                '.MuiTooltip-tooltipPlacementTop': {
+                  mb: '8px !important',
+                },
+                '.MuiTooltip-tooltipPlacementBottom': {
+                  mt: '8px !important',
+                },
+                '.MuiTooltip-tooltipPlacementLeft': {
+                  mr: '8px !important',
+                },
+                '.MuiTooltip-tooltipPlacementRight': {
+                  ml: '8px !important',
+                },
+              },
             },
           }}
           {...props}

--- a/campaign-launcher/client/src/components/CustomTooltip/index.tsx
+++ b/campaign-launcher/client/src/components/CustomTooltip/index.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+
+import { Box, ClickAwayListener, Tooltip, TooltipProps } from '@mui/material';
+
+import { useIsMobile } from '../../hooks/useBreakpoints';
+
+const CustomTooltip = ({ children, ...props }: TooltipProps) => {
+  const [open, setOpen] = useState(false);
+  const isMobile = useIsMobile();
+
+  const handleTooltipClose = () => {
+    setOpen(false);
+  }
+
+  if (isMobile) {
+    return (
+      <ClickAwayListener onClickAway={handleTooltipClose}>
+        <Tooltip 
+          open={open}
+          disableFocusListener
+          disableHoverListener
+          disableTouchListener
+          onClose={handleTooltipClose}
+          slotProps={{
+            popper: {
+              disablePortal: true,
+            },
+          }}
+          {...props}
+        >
+          <Box onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setOpen(true);
+          }}>
+            {children}
+          </Box>
+        </Tooltip>
+      </ClickAwayListener>
+    );
+  }
+
+  return <Tooltip {...props}>{children}</Tooltip>;
+};
+
+export default CustomTooltip;

--- a/campaign-launcher/client/src/components/Header/index.tsx
+++ b/campaign-launcher/client/src/components/Header/index.tsx
@@ -107,6 +107,7 @@ const Header: FC = () => {
             onClose={() => toggleDrawer(false)}
             slotProps={{
               paper: {
+                elevation: 0,
                 sx: { width: '75%', bgcolor: 'background.default' },
               },
             }}

--- a/campaign-launcher/client/src/components/JoinCampaign/index.tsx
+++ b/campaign-launcher/client/src/components/JoinCampaign/index.tsx
@@ -51,8 +51,9 @@ const JoinCampaign: FC<Props> = ({ campaign }) => {
         size="medium"
         sx={{
           ml: { xs: 0, md: 'auto' },
+          mt: { xs: 2, md: 0 },
           color: 'primary.contrast',
-          minWidth: '135px',
+          minWidth: { xs: '100%', md: '135px' },
         }}
         disabled={isButtonDisabled}
         onClick={handleButtonClick}

--- a/campaign-launcher/client/src/components/JoinCampaign/index.tsx
+++ b/campaign-launcher/client/src/components/JoinCampaign/index.tsx
@@ -53,7 +53,7 @@ const JoinCampaign: FC<Props> = ({ campaign }) => {
           ml: { xs: 0, md: 'auto' },
           mt: { xs: 2, md: 0 },
           color: 'primary.contrast',
-          minWidth: { xs: '100%', md: '135px' },
+          minWidth: { xs: '100%', sm: '135px' },
         }}
         disabled={isButtonDisabled}
         onClick={handleButtonClick}

--- a/campaign-launcher/client/src/components/PageTitle/index.tsx
+++ b/campaign-launcher/client/src/components/PageTitle/index.tsx
@@ -17,7 +17,7 @@ const PageTitle: FC<PropsWithChildren<Props>> = ({ title, children }) => {
       flexWrap={{ xs: 'wrap', md: 'nowrap' }}
     >
       <JobsIcon sx={{ width: 66, height: 66 }} />
-      <Typography component="h1" variant="h4-mobile">
+      <Typography component="h1" variant="h4-mobile" minWidth="fit-content">
         {title}
       </Typography>
       {children}

--- a/campaign-launcher/client/src/components/modals/BaseModal/index.tsx
+++ b/campaign-launcher/client/src/components/modals/BaseModal/index.tsx
@@ -37,6 +37,8 @@ const BaseModal: FC<PropsWithChildren<Props>> = ({
           py: 4,
           px: 4,
           width: 870,
+          maxHeight: '80vh',
+          overflowY: 'auto',
           bgcolor: 'background.default',
           border: '1px solid rgba(255, 255, 255, 0.1)',
           borderRadius: 4,

--- a/campaign-launcher/client/src/components/modals/CreateCampaignModal/index.tsx
+++ b/campaign-launcher/client/src/components/modals/CreateCampaignModal/index.tsx
@@ -19,7 +19,6 @@ import {
   StepLabel,
   Stepper,
   TextField,
-  Tooltip,
   Typography,
 } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
@@ -32,12 +31,14 @@ import * as yup from 'yup';
 
 import { QUERY_KEYS } from '../../../constants/queryKeys';
 import { FUND_TOKENS, TOKENS } from '../../../constants/tokens';
+import { useIsMobile } from '../../../hooks/useBreakpoints';
 import useCreateEscrow from '../../../hooks/useCreateEscrow';
 import { useTradingPairs } from '../../../hooks/useTradingPairs';
 import { useNetwork } from '../../../providers/NetworkProvider';
 import { constructCampaignDetails } from '../../../utils';
 import { CryptoEntity } from '../../CryptoEntity';
 import { CryptoPairEntity } from '../../CryptoPairEntity';
+import CustomTooltip from '../../CustomTooltip';
 import FormExchangeSelect from '../../FormExchangeSelect';
 import InfoTooltipInner from '../../InfoTooltipInner';
 import { ModalError, ModalSuccess } from '../../ModalState';
@@ -110,10 +111,11 @@ const validationSchema = yup.object({
 const steps = ['Create Escrow', 'Fund Escrow', 'Setup Escrow'];
 
 const InfoTooltip = () => {
+  const isMobile = useIsMobile();
   return (
-    <Tooltip
+    <CustomTooltip
       arrow
-      placement="right"
+      placement={isMobile ? 'top' : 'right'}
       title={
         <>
           <Typography component="p" variant="tooltip" color="primary.contrast">
@@ -133,7 +135,7 @@ const InfoTooltip = () => {
       }
     >
       <InfoTooltipInner />
-    </Tooltip>
+    </CustomTooltip>
   );
 };
 
@@ -233,7 +235,6 @@ const CreateCampaignModal: FC<Props> = ({ open, onClose }) => {
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        justifyContent: 'center',
       }}
     >
       {showFinalView && (
@@ -324,7 +325,7 @@ const CreateCampaignModal: FC<Props> = ({ open, onClose }) => {
               gap={3}
               width={{ xs: '100%', sm: 625 }}
             >
-              <Box display="flex" gap={2}>
+              <Stack direction={{ xs: 'column', sm: 'row' }} gap={2}>
                 <Box display="flex" gap={2} alignItems="center" width="100%">
                   <FormControl error={!!errors.exchange} sx={{ width: '100%' }}>
                     <Controller
@@ -403,8 +404,8 @@ const CreateCampaignModal: FC<Props> = ({ open, onClose }) => {
                     <FormHelperText>{errors.pair.message}</FormHelperText>
                   )}
                 </FormControl>
-              </Box>
-              <Box display="flex" gap={2}>
+              </Stack>
+              <Stack direction={{ xs: 'column', sm: 'row' }} gap={2}>
                 <FormControl error={!!errors.start_date} sx={{ width: '100%' }}>
                   <Controller
                     name="start_date"
@@ -445,8 +446,8 @@ const CreateCampaignModal: FC<Props> = ({ open, onClose }) => {
                     <FormHelperText>{errors.end_date.message}</FormHelperText>
                   )}
                 </FormControl>
-              </Box>
-              <Box display="flex" gap={2}>
+              </Stack>
+              <Stack direction={{ xs: 'column', sm: 'row' }} gap={2}>
                 <FormControl error={!!errors.fund_token} sx={{ width: '100%' }}>
                   <InputLabel id="fund-token-select-label">
                     Fund Token
@@ -575,7 +576,7 @@ const CreateCampaignModal: FC<Props> = ({ open, onClose }) => {
                     </FormHelperText>
                   )}
                 </FormControl>
-              </Box>
+              </Stack>
               {stepsCompleted < steps.length ? (
                 <Button
                   size="large"

--- a/campaign-launcher/client/src/pages/Campaign/index.tsx
+++ b/campaign-launcher/client/src/pages/Campaign/index.tsx
@@ -3,9 +3,11 @@ import { FC, useMemo } from 'react';
 import { CircularProgress, Typography } from '@mui/material';
 import { useParams, useSearchParams } from 'react-router-dom';
 
+import CampaignAddress from '../../components/CampaignAddress';
 import CampaignInfo from '../../components/CampaignInfo';
 import CampaignStats from '../../components/CampaignStats';
 import HowToLaunch from '../../components/HowToLaunch';
+import JoinCampaign from '../../components/JoinCampaign';
 import JoinedCampaigns from '../../components/JoinedCampaigns';
 import PageTitle from '../../components/PageTitle';
 import PageWrapper from '../../components/PageWrapper';
@@ -43,11 +45,15 @@ const Campaign: FC = () => {
   return (
     <PageWrapper>
       <PageTitle title="Campaign Data">
-        {isCampaignLoading && (
-          <CircularProgress sx={{ width: '32px', height: '32px', ml: 3 }} />
+        {isCampaignLoading && <CircularProgress sx={{ width: '32px', height: '32px', ml: 3 }} />}
+        {!!campaignData && (
+          <>
+            <CampaignAddress address={campaignData.address} chainId={campaignData.chain_id} />
+            <JoinCampaign campaign={campaignData} />
+          </>
         )}
-        {!!campaignData && <CampaignInfo campaign={campaignData} />}
       </PageTitle>
+      {!!campaignData && <CampaignInfo campaign={campaignData} />}
       <CampaignStats campaign={campaignData} />
       <Typography variant="h6">Joined Campaigns</Typography>
       <JoinedCampaigns


### PR DESCRIPTION
## Issue tracking
Freestyle

## Context behind the change
This PR adds a full campaign address and the copy-to-clipboard functionality, which results in slight redesign of CampaignInfo component;
Also it introduces a custom tooltip component and a responsive fixes;
In the end, it shows only active campaigns by default

## How has this been tested?
locally

## Release plan
regular

## Potential risks; What to monitor; Rollback plan
not found