### PR TITLE
[Campaign Launcher] feat: fetch oracle fees from cl be

### DIFF
--- a/campaign-launcher/client/src/api/launcherApiClient.ts
+++ b/campaign-launcher/client/src/api/launcherApiClient.ts
@@ -1,6 +1,6 @@
 import { ChainId } from "@human-protocol/sdk";
 
-import { CampaignDetails, CampaignsResponse, CampaignsStats, Exchange } from "../types";
+import { CampaignDetails, CampaignsResponse, CampaignsStats, Exchange, OracleFees } from "../types";
 import { HttpClient, HttpError } from "../utils/HttpClient";
 
 export class LauncherApiClient extends HttpClient {
@@ -36,6 +36,11 @@ export class LauncherApiClient extends HttpClient {
 
   async getCampaignsStats(chain_id: ChainId): Promise<CampaignsStats> {
     const response = await this.get<CampaignsStats>(`/stats/campaigns`, { params: { chain_id } });
+    return response;
+  }
+
+  async getOracleFees(chain_id: ChainId): Promise<OracleFees> {
+    const response = await this.get<OracleFees>(`/web3/oracle-fees`, { params: { chain_id } });
     return response;
   }
 }

--- a/campaign-launcher/client/src/hooks/useCreateEscrow.ts
+++ b/campaign-launcher/client/src/hooks/useCreateEscrow.ts
@@ -1,12 +1,13 @@
 import { useCallback, useState } from 'react';
 
-import { EscrowClient, KVStoreKeys, KVStoreUtils } from '@human-protocol/sdk';
+import { EscrowClient } from '@human-protocol/sdk';
 import dayjs from 'dayjs';
 import { ethers } from 'ethers';
 import { v4 as uuidV4 } from 'uuid';
 
 import useRetrieveSigner from './useRetrieveSigner';
 import ERC20ABI from '../abi/ERC20.json';
+import { launcherApi } from '../api';
 import { oracles } from '../constants';
 import { useNetwork } from '../providers/NetworkProvider';
 import { EscrowCreateDto, ManifestUploadDto } from '../types';
@@ -76,51 +77,16 @@ const useCreateEscrow = (): CreateEscrowMutationState => {
         }
 
         let _exchangeOracleFee: string;
-        try {
-          _exchangeOracleFee = await KVStoreUtils.get(
-            appChainId,
-            oracles.exchangeOracle,
-            KVStoreKeys.fee
-          );
-        } catch (e) {
-          console.error('Error getting exchange oracle fee', e);
-          throw e;
-        }
-
-        if (!_exchangeOracleFee) {
-          throw new Error('Exchange oracle fee is not set.');
-        }
-
         let _recordingOracleFee: string;
-        try {
-          _recordingOracleFee = await KVStoreUtils.get(
-            appChainId,
-            oracles.recordingOracle,
-            KVStoreKeys.fee
-          );
-        } catch (e) {
-          console.error('Error getting recording oracle fee', e);
-          throw e;
-        }
-
-        if (!_recordingOracleFee) {
-          throw new Error('Recording oracle fee is not set.');
-        }
-
         let _reputationOracleFee: string;
         try {
-          _reputationOracleFee = await KVStoreUtils.get(
-            appChainId,
-            oracles.reputationOracle,
-            KVStoreKeys.fee
-          );
+          const oracleFees = await launcherApi.getOracleFees(appChainId);
+          _exchangeOracleFee = oracleFees.exchange_oracle_fee;
+          _recordingOracleFee = oracleFees.recording_oracle_fee;
+          _reputationOracleFee = oracleFees.reputation_oracle_fee;
         } catch (e) {
-          console.error(e);
+          console.error('Error getting oracle fees', e);
           throw e;
-        }
-
-        if (!_reputationOracleFee) {
-          throw new Error('Reputation oracle fee is not set.');
         }
 
         const tokenContract = new ethers.Contract(

--- a/campaign-launcher/client/src/types/index.ts
+++ b/campaign-launcher/client/src/types/index.ts
@@ -104,3 +104,9 @@ export type CampaignsQueryParams = {
   limit?: number;
   skip?: number;
 };
+
+export type OracleFees = {
+  exchange_oracle_fee: string;
+  recording_oracle_fee: string;
+  reputation_oracle_fee: string;
+};

--- a/campaign-launcher/server/src/modules/web3/web3.controller.ts
+++ b/campaign-launcher/server/src/modules/web3/web3.controller.ts
@@ -1,0 +1,86 @@
+import { KVStoreKeys, KVStoreUtils } from '@human-protocol/sdk';
+import {
+  Controller,
+  Get,
+  InternalServerErrorException,
+  Query,
+} from '@nestjs/common';
+
+import { Web3ConfigService } from '@/config';
+import logger from '@/logger';
+
+import { GetOracleFeesQueryDto } from './web3.dto';
+
+@Controller('web3')
+export class Web3Controller {
+  private readonly logger = logger.child({ context: Web3Controller.name });
+
+  constructor(private web3ConfigService: Web3ConfigService) {}
+
+  @Get('/oracle-fees')
+  async getOracleFees(@Query() { chainId }: GetOracleFeesQueryDto): Promise<{
+    exchangeOracleFee: string;
+    recordingOracleFee: string;
+    reputationOracleFee: string;
+  }> {
+    let exchangeOracleFee: string;
+    try {
+      exchangeOracleFee = await KVStoreUtils.get(
+        chainId as number,
+        this.web3ConfigService.exchangeOracle,
+        KVStoreKeys.fee,
+      );
+    } catch (error) {
+      const message = 'Error while getting exchange oracle fee';
+      this.logger.error(message, {
+        chainId,
+        oracleAddress: this.web3ConfigService.exchangeOracle,
+        error,
+      });
+
+      throw new InternalServerErrorException(message);
+    }
+
+    let recordingOracleFee: string;
+    try {
+      recordingOracleFee = await KVStoreUtils.get(
+        chainId as number,
+        this.web3ConfigService.recordingOracle,
+        KVStoreKeys.fee,
+      );
+    } catch (error) {
+      const message = 'Error while getting recording oracle fee';
+      this.logger.error(message, {
+        chainId,
+        oracleAddress: this.web3ConfigService.recordingOracle,
+        error,
+      });
+
+      throw new InternalServerErrorException(message);
+    }
+
+    let reputationOracleFee: string;
+    try {
+      reputationOracleFee = await KVStoreUtils.get(
+        chainId as number,
+        this.web3ConfigService.reputationOracle,
+        KVStoreKeys.fee,
+      );
+    } catch (error) {
+      const message = 'Error while getting reputation oracle fee';
+      this.logger.error(message, {
+        chainId,
+        oracleAddress: this.web3ConfigService.reputationOracle,
+        error,
+      });
+
+      throw new InternalServerErrorException(message);
+    }
+
+    return {
+      exchangeOracleFee,
+      recordingOracleFee,
+      reputationOracleFee,
+    };
+  }
+}

--- a/campaign-launcher/server/src/modules/web3/web3.dto.ts
+++ b/campaign-launcher/server/src/modules/web3/web3.dto.ts
@@ -1,0 +1,7 @@
+import type { ChainId } from '@/common/constants';
+import { IsChainId } from '@/common/validators';
+
+export class GetOracleFeesQueryDto {
+  @IsChainId()
+  chainId: ChainId;
+}

--- a/campaign-launcher/server/src/modules/web3/web3.module.ts
+++ b/campaign-launcher/server/src/modules/web3/web3.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 
+import { Web3Controller } from './web3.controller';
 import { Web3Service } from './web3.service';
 
 @Module({
   providers: [Web3Service],
+  controllers: [Web3Controller],
   exports: [Web3Service],
 })
 export class Web3Module {}


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Sometimes subgraph lags when use public version. In order to properly retrieve oracle fees we will use launcher backend now, but later will replace to direct RPC calls when SDK is updated (https://github.com/humanprotocol/human-protocol/issues/3523)

## How has this been tested?
- [x] launch new campaign and check oracle fees are taken from BE

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No