### PR TITLE
[Launcher UI] Specify adapter locale

### DIFF
--- a/campaign-launcher/client/src/App.tsx
+++ b/campaign-launcher/client/src/App.tsx
@@ -28,7 +28,7 @@ const App: FC = () => {
             <Web3AuthProvider>
               <ExchangesProvider>
                 <StakeProvider>
-                  <LocalizationProvider dateAdapter={AdapterDayjs}>
+                  <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="en">
                     <ThemeProvider>
                       <BrowserRouter>
                         <Layout>


### PR DESCRIPTION
## Issue tracking
Freestyle hotfix

## Context behind the change
After a massive lockfile updates seems like x-date-pickers slightly updated, so now we need to specify `adapterLocale`

## How has this been tested?
locally

## Release plan
regular

## Potential risks; What to monitor; Rollback plan
not found