### PR TITLE
feat: recording results log and avoid replay payouts for batches

### DIFF
--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -360,9 +360,11 @@ export class CampaignsService {
 
         const logger = this.logger.child({
           action: 'record-campaign-progress',
+          campaignId: campaign.id,
           chainId: campaign.chainId,
           campaignAdddress: campaign.address,
-          campaignId: campaign.id,
+          exchangeName: campaign.exchangeName,
+          pair: campaign.pair,
         });
         logger.debug('Campaign progress recording started');
 
@@ -437,23 +439,18 @@ export class CampaignsService {
             endDate,
           );
 
-          logger.debug('Campaign progress checked', {
-            from: progress.from,
-            to: progress.to,
-            total_volume: progress.total_volume,
-            participants_outcomes_batches:
-              progress.participants_outcomes_batches.map((b) => ({
-                id: b.id,
-                n_results: b.results.length,
-              })),
-          });
           await this.recordGeneratedVolume(campaign, progress);
 
           intermediateResults.results.push(progress);
           const storedResultsMeta =
             await this.recordCampaignIntermediateResults(intermediateResults);
 
-          logger.debug('Campaign progress recorded', storedResultsMeta);
+          logger.info('Campaign progress recorded', {
+            from: progress.from,
+            to: progress.to,
+            total_volume: progress.total_volume,
+            resultsUrl: storedResultsMeta.url,
+          });
 
           /**
            * There might be situations when due to delays/failures in processing

--- a/recording-oracle/src/modules/campaigns/fixtures/campaign.ts
+++ b/recording-oracle/src/modules/campaigns/fixtures/campaign.ts
@@ -7,6 +7,7 @@ import {
   generateTradingPair,
 } from '@/modules/exchange/fixtures';
 import { generateTestnetChainId } from '@/modules/web3/fixtures';
+import { generateRandomHashString } from '~/test/fixtures/crypto';
 
 import { CampaignEntity } from '../campaign.entity';
 import type {
@@ -96,4 +97,11 @@ export function generateIntermediateResultsData(
   Object.assign(data, overrides);
 
   return data;
+}
+
+export function generateStoredResultsMeta(): { url: string; hash: string } {
+  return {
+    url: faker.internet.url(),
+    hash: generateRandomHashString('sha256'),
+  };
 }


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
- refactored `oracle-fees` endpoint to have better visibility over KV values and avoid empty items being returned
- added recording result info log for better visibility
- fixed payouts to skip batches, not time frames

## How has this been tested?
- [x] unit tests for RecO
- [x] run CL and trigger fees endpoint for different chains to ensure logs and proper response

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
Should be none