### PR TITLE
[Reputation Oracle] fix: rely on decimals for total reward amount

### DIFF
--- a/reputation-oracle/src/common/utils/decimal.ts
+++ b/reputation-oracle/src/common/utils/decimal.ts
@@ -39,3 +39,10 @@ export function sub(a: number, b: number): number {
 
   return result.toNumber();
 }
+
+export function truncate(n: number, decimals: number): number {
+  const valueDecimal = new Decimal(n);
+  const result = valueDecimal.toFixed(decimals, Decimal.ROUND_DOWN);
+
+  return Number(result);
+}

--- a/reputation-oracle/src/modules/payouts/payouts.service.ts
+++ b/reputation-oracle/src/modules/payouts/payouts.service.ts
@@ -146,18 +146,24 @@ export class PayoutsService {
 
             const recipientToAmountMap = new Map<string, bigint>();
             for (const { address, amount } of rewardsBatch.rewards) {
+              const truncatedAmount = decimalUtils.truncate(
+                amount,
+                campaign.fundTokenDecimals,
+              );
               /**
                * Escrow contract doesn't allow payout of 0 amount,
-               * so just skip it for final payouts
+               * so just skip it for final payouts. It covers cases when:
+               * - 0 reward in general
+               * - reward became 0 after truncating, i.e. it was too small
                */
-              if (amount === 0) {
+              if (truncatedAmount === 0) {
                 continue;
               }
 
               recipientToAmountMap.set(
                 address,
                 ethers.parseUnits(
-                  amount.toString(),
+                  truncatedAmount.toString(),
                   campaign.fundTokenDecimals,
                 ),
               );


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Rewards are calculated as regular numbers and when passing them to `ethers.parseUnits` with `unit` lower than N decimals in reward - `parseUnits` throws. Fix it with truncating the amount and filtering out rewards that are too small.

## How has this been tested?
- [ ] TBD

## Release plan
Merge

## Potential risks; What to monitor; Rollback plan
No