### PR TITLE
[Reputation Oracle] feat: temporarily disable scheduled runs for testnet

### DIFF
--- a/.github/workflows/run-reputation-oracle.yaml
+++ b/.github/workflows/run-reputation-oracle.yaml
@@ -39,7 +39,7 @@ jobs:
         id: get_env_names
         run: |
           if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
-            ENV_NAMES='["testnet","mainnet"]'
+            ENV_NAMES='["mainnet"]'
           else
             INPUT_VAL="${{ inputs.environment }}"
             ENV_NAMES="[\"${INPUT_VAL}\"]"


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
We are in process of applying contracts upgrades. Taking into account that RepO GitHub action runs from default branch (recently updated to be `main`) and uses same code for testnet and mainnet, we need to disable scheduled runs for testnet to avoid unnecessary potential bugs and obvious errors due to incompatible changes in contracts and SDK.

During development process we will be able to manually trigger it either via GitHub CLI or UI for specific branch with changed code

## How has this been tested?
–

## Release plan
Merge to develop and then to main, so change is reflected on default branch

## Potential risks; What to monitor; Rollback plan
No