### PR TITLE
[Reputation Oracle] fix: bulk transfer logs count

### DIFF
--- a/reputation-oracle/src/modules/payouts/payouts.service.ts
+++ b/reputation-oracle/src/modules/payouts/payouts.service.ts
@@ -365,18 +365,31 @@ export class PayoutsService {
       })
     )[0];
 
-    const bulkInterface = new ethers.Interface([
-      'event BulkTransferV2(uint256 indexed _txId, address[] _recipients, uint256[] _amounts, bool _isPartial, string finalResultsUrl)',
+    const bulkInterfaceV3 = new ethers.Interface([
+      'event BulkTransferV3(bytes32 indexed payoutId, address[] recipients, uint256[] amounts, bool isPartial, string finalResultsUrl)',
     ]);
+    const topicV3 = bulkInterfaceV3.getEvent('BulkTransferV3')!.topicHash;
 
-    const topic = bulkInterface.getEvent('BulkTransferV2')!.topicHash;
-
-    const logs = await signer.provider.getLogs({
+    let logs = await signer.provider.getLogs({
       address: escrowAddress,
-      topics: [topic],
+      topics: [topicV3],
       fromBlock: Number(block),
       toBlock: 'latest',
     });
+
+    if (logs.length === 0) {
+      const bulkInterfaceV2 = new ethers.Interface([
+        'event BulkTransferV2(uint256 indexed _txId, address[] _recipients, uint256[] _amounts, bool _isPartial, string finalResultsUrl)',
+      ]);
+      const topicV2 = bulkInterfaceV2.getEvent('BulkTransferV2')!.topicHash;
+
+      logs = await signer.provider.getLogs({
+        address: escrowAddress,
+        topics: [topicV2],
+        fromBlock: Number(block),
+        toBlock: 'latest',
+      });
+    }
 
     return logs.length;
   }


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
New contracts on testnet emit `bulkTransferV3` events, so in order to properly count executed payouts we need to search logs for this event, at the same time providing backward compatibility for v2 for further release.

## How has this been tested?
- [x] have a campaign with multiple days result, attempt to run payouts for it, make sure it's successful

> [!NOTE]
> I got this situation with my local testnet setup and calls of `bulkPayout` method were failing because of the same `payoutId` passed. With this fix - worked as expected and campaign completed 

## Release plan
As part of parent branch. Nothing special in this PR.
Remove lines with v2 when all old contracts completed after release.

## Potential risks; What to monitor; Rollback plan
N/A