### PR TITLE
[Launcher UI] Fix Campaign Results

### DIFF
--- a/campaign-launcher/client/src/components/CampaignResultsWidget/index.tsx
+++ b/campaign-launcher/client/src/components/CampaignResultsWidget/index.tsx
@@ -3,8 +3,10 @@ import { FC, MouseEvent } from 'react';
 import { Box, IconButton, Stack, Typography } from '@mui/material';
 
 import { OpenInNewIcon } from '../../icons';
+import { CampaignStatus } from '../../types';
 
 type Props = {
+  campaignStatus: CampaignStatus;
   finalResultsUrl: string | null;
   intermediateResultsUrl: string | null;
 };
@@ -14,7 +16,7 @@ const handleOpenUrl = (e: MouseEvent<HTMLButtonElement>, url: string) => {
   window.open(url, '_blank');
 };
 
-const STATUS = {
+const RESULT = {
   none: {
     label: 'N/A',
     description: 'Campaign is active but no results have been recorded yet.',
@@ -35,28 +37,29 @@ const STATUS = {
 export const StatusTooltip = () => (
   <Stack width={150} gap={0.5}>
     <Box display="flex" alignItems="baseline" gap={0.5}>
-      <Box p={0.5} borderRadius="50%" bgcolor={STATUS.final.bgcolor} />
-      <Typography variant="tooltip"><strong>Final:</strong>{' '}{STATUS.final.description}</Typography>
+      <Box p={0.5} borderRadius="50%" bgcolor={RESULT.final.bgcolor} />
+      <Typography variant="tooltip"><strong>Final:</strong>{' '}{RESULT.final.description}</Typography>
     </Box>
     <Box display="flex" alignItems="baseline" gap={0.5}>
-      <Box p={0.5} borderRadius="50%" bgcolor={STATUS.intermediate.bgcolor} />
-      <Typography variant="tooltip"><strong>Intermediate:</strong>{' '}{STATUS.intermediate.description}</Typography>
+      <Box p={0.5} borderRadius="50%" bgcolor={RESULT.intermediate.bgcolor} />
+      <Typography variant="tooltip"><strong>Intermediate:</strong>{' '}{RESULT.intermediate.description}</Typography>
     </Box>
     <Box display="flex" alignItems="baseline" gap={0.5}>
-      <Box p={0.5} borderRadius="50%" bgcolor={STATUS.none.bgcolor} />
-      <Typography variant="tooltip"><strong>N/A:</strong>{' '}{STATUS.none.description}</Typography>
+      <Box p={0.5} borderRadius="50%" bgcolor={RESULT.none.bgcolor} />
+      <Typography variant="tooltip"><strong>N/A:</strong>{' '}{RESULT.none.description}</Typography>
     </Box>
   </Stack>
 );
 
-const CampaignResultsWidget: FC<Props> = ({ finalResultsUrl, intermediateResultsUrl }) => {
-  const status = finalResultsUrl ? STATUS.final : intermediateResultsUrl ? STATUS.intermediate : STATUS.none;
+const CampaignResultsWidget: FC<Props> = ({ campaignStatus, finalResultsUrl, intermediateResultsUrl }) => {
+  const isFinished = campaignStatus !== CampaignStatus.ACTIVE;
+  const result = isFinished && finalResultsUrl ? RESULT.final : intermediateResultsUrl ? RESULT.intermediate : RESULT.none;
 
   return (
     <Box display="flex" alignItems="center">
-      <Box p={0.5} borderRadius="50%" bgcolor={status.bgcolor} mr={1} />
-      <Typography variant="h6">{status.label}</Typography>
-      {status !== STATUS.none && (
+      <Box p={0.5} borderRadius="50%" bgcolor={result.bgcolor} mr={1} />
+      <Typography variant="h6">{result.label}</Typography>
+      {result !== RESULT.none && (
         <IconButton 
           sx={{
             color: 'text.secondary',

--- a/campaign-launcher/client/src/components/CampaignStats/index.tsx
+++ b/campaign-launcher/client/src/components/CampaignStats/index.tsx
@@ -4,6 +4,7 @@ import ZoomOutMapIcon from '@mui/icons-material/ZoomOutMap';
 import { Box, IconButton, styled, Typography } from '@mui/material';
 import Grid from '@mui/material/Grid2';
 
+import { TOKENS } from '../../constants/tokens';
 import { useIsXlDesktop } from '../../hooks/useBreakpoints';
 import { MiniChartIcon } from '../../icons';
 import { useExchangesContext } from '../../providers/ExchangesProvider';
@@ -125,7 +126,11 @@ const CampaignStats: FC<Props> = ({ campaign, isJoined }) => {
     campaign.amount_paid,
     campaign.fund_token_decimals
   );
-  const volumeTokenSymbol = campaign.trading_pair.split('/')[1];
+
+  const volumeToken = campaign.trading_pair.split('/')[1];
+  const { label: volumeTokenSymbol } = TOKENS.find(
+    (token) => token.name.toLowerCase() === volumeToken.toLowerCase()
+  ) || { label: volumeToken };
 
   return (
     <>
@@ -211,7 +216,11 @@ const CampaignStats: FC<Props> = ({ campaign, isJoined }) => {
                 <InfoTooltipInner />
               </CustomTooltip>
             </Title>
-            <CampaignResultsWidget finalResultsUrl={campaign.final_results_url} intermediateResultsUrl={campaign.intermediate_results_url} />
+            <CampaignResultsWidget 
+              campaignStatus={campaign.status}
+              finalResultsUrl={campaign.final_results_url} 
+              intermediateResultsUrl={campaign.intermediate_results_url} 
+            />
           </StatsCard>
         </Grid>
         <Grid size={{ xs: 12, md: 3 }}>

--- a/campaign-launcher/client/src/components/CampaignStats/index.tsx
+++ b/campaign-launcher/client/src/components/CampaignStats/index.tsx
@@ -4,13 +4,12 @@ import ZoomOutMapIcon from '@mui/icons-material/ZoomOutMap';
 import { Box, IconButton, styled, Typography } from '@mui/material';
 import Grid from '@mui/material/Grid2';
 
-import { TOKENS } from '../../constants/tokens';
 import { useIsXlDesktop } from '../../hooks/useBreakpoints';
 import { MiniChartIcon } from '../../icons';
 import { useExchangesContext } from '../../providers/ExchangesProvider';
 import { useWeb3Auth } from '../../providers/Web3AuthProvider';
 import { CampaignDetails, CampaignStatus } from '../../types';
-import { formatTokenAmount } from '../../utils';
+import { formatTokenAmount, getTokenInfo } from '../../utils';
 import CampaignResultsWidget, { StatusTooltip } from '../CampaignResultsWidget';
 import { CryptoPairEntity } from '../CryptoPairEntity';
 import CustomTooltip from '../CustomTooltip';
@@ -128,9 +127,7 @@ const CampaignStats: FC<Props> = ({ campaign, isJoined }) => {
   );
 
   const volumeToken = campaign.trading_pair.split('/')[1];
-  const { label: volumeTokenSymbol } = TOKENS.find(
-    (token) => token.name.toLowerCase() === volumeToken.toLowerCase()
-  ) || { label: volumeToken };
+  const { label: volumeTokenSymbol } = getTokenInfo(volumeToken);
 
   return (
     <>

--- a/campaign-launcher/client/src/components/CampaignsTable/index.tsx
+++ b/campaign-launcher/client/src/components/CampaignsTable/index.tsx
@@ -5,6 +5,7 @@ import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import { numericFormatter } from 'react-number-format';
 import { useLocation, useNavigate } from 'react-router-dom';
 
+import { TOKENS } from '../../constants/tokens';
 import { useIsXlDesktop, useIsLgDesktop } from '../../hooks/useBreakpoints';
 import useRetrieveSigner from '../../hooks/useRetrieveSigner';
 import { useExchangesContext } from '../../providers/ExchangesProvider';
@@ -235,7 +236,10 @@ const CampaignsTable: FC<Props> = ({
       ),
       renderCell: (params) => {
         const { daily_volume_target, trading_pair } = params.row;
-        const currency = trading_pair.split('/')[1];
+        const volumeToken = trading_pair.split('/')[1];
+        const { label: tokenLabel } = TOKENS.find(
+          (token) => token.name.toLowerCase() === volumeToken.toLowerCase()
+        ) || { label: volumeToken };
         const formattedDailyVolumeTarget = numericFormatter(
           daily_volume_target.toString(),
           {
@@ -246,7 +250,7 @@ const CampaignsTable: FC<Props> = ({
         );
         return (
           <Typography variant="subtitle2">
-            {formattedDailyVolumeTarget} {currency}
+            {formattedDailyVolumeTarget} {tokenLabel}
           </Typography>
         );
       },

--- a/campaign-launcher/client/src/components/CampaignsTable/index.tsx
+++ b/campaign-launcher/client/src/components/CampaignsTable/index.tsx
@@ -5,7 +5,6 @@ import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import { numericFormatter } from 'react-number-format';
 import { useLocation, useNavigate } from 'react-router-dom';
 
-import { TOKENS } from '../../constants/tokens';
 import { useIsXlDesktop, useIsLgDesktop } from '../../hooks/useBreakpoints';
 import useRetrieveSigner from '../../hooks/useRetrieveSigner';
 import { useExchangesContext } from '../../providers/ExchangesProvider';
@@ -15,6 +14,7 @@ import {
   formatTokenAmount,
   getChainIcon,
   getNetworkName,
+  getTokenInfo,
   mapStatusToColor,
 } from '../../utils';
 import CampaignAddress from '../CampaignAddress';
@@ -237,9 +237,7 @@ const CampaignsTable: FC<Props> = ({
       renderCell: (params) => {
         const { daily_volume_target, trading_pair } = params.row;
         const volumeToken = trading_pair.split('/')[1];
-        const { label: tokenLabel } = TOKENS.find(
-          (token) => token.name.toLowerCase() === volumeToken.toLowerCase()
-        ) || { label: volumeToken };
+        const { label: tokenLabel } = getTokenInfo(volumeToken);
         const formattedDailyVolumeTarget = numericFormatter(
           daily_volume_target.toString(),
           {

--- a/campaign-launcher/client/src/components/CryptoEntity/index.tsx
+++ b/campaign-launcher/client/src/components/CryptoEntity/index.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react';
 
 import { Box, Typography } from '@mui/material';
 
-import { TOKENS } from '../../constants/tokens';
+import { getTokenInfo } from '../../utils';
 
 export type CryptoEntityProps = {
   name: string;
@@ -15,16 +15,12 @@ export const CryptoEntity: FC<CryptoEntityProps> = ({
   displayName,
   logo,
 }) => {
-  const { icon, label } = TOKENS.find(
-    (token) => token.name?.toLowerCase() === name?.toLowerCase()
-  ) || {
-    icon: logo,
-    label: displayName ?? name,
-  };
-
+  const { icon, label } = getTokenInfo(name);
+  const entityIcon = icon || logo;
+  
   return (
     <Box display="flex" alignItems="center" gap={1}>
-      {icon && <img src={icon} alt={name} width={24} />}
+      {entityIcon && <img src={entityIcon} alt={name} width={24} />}
       <Typography
         color="primary"
         variant="body2"

--- a/campaign-launcher/client/src/components/CryptoPairEntity/index.tsx
+++ b/campaign-launcher/client/src/components/CryptoPairEntity/index.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react';
 
 import { Box, Typography } from '@mui/material';
 
-import { TOKENS } from '../../constants/tokens';
+import { getTokenInfo } from '../../utils';
 
 export type CryptoPairEntityProps = {
   symbol: string;
@@ -59,13 +59,8 @@ export const CryptoPairEntity: FC<CryptoPairEntityProps> = ({
 }) => {
   const [base, quote] = symbol.split('/');
 
-  const { icon: baseIcon, label: baseLabel } = TOKENS.find(
-    (token) => token.name.toLowerCase() === base.toLowerCase()
-  ) || { label: base };
-
-  const { icon: quoteIcon, label: quoteLabel } = TOKENS.find(
-    (token) => token.name.toLowerCase() === quote.toLowerCase()
-  ) || { label: quote };
+  const { icon: baseIcon, label: baseLabel } = getTokenInfo(base);
+  const { icon: quoteIcon, label: quoteLabel } = getTokenInfo(quote);
 
   const isLarge = size === 'large';
 

--- a/campaign-launcher/client/src/components/modals/CreateCampaignModal/index.tsx
+++ b/campaign-launcher/client/src/components/modals/CreateCampaignModal/index.tsx
@@ -30,7 +30,7 @@ import { useAccount } from 'wagmi';
 import * as yup from 'yup';
 
 import { QUERY_KEYS } from '../../../constants/queryKeys';
-import { FUND_TOKENS, FundToken } from '../../../constants/tokens';
+import { FUND_TOKENS, FundToken, TOKENS } from '../../../constants/tokens';
 import { useIsMobile } from '../../../hooks/useBreakpoints';
 import useCreateEscrow from '../../../hooks/useCreateEscrow';
 import { useTradingPairs } from '../../../hooks/useTradingPairs';
@@ -353,11 +353,18 @@ const CreateCampaignModal: FC<Props> = ({ open, onClose }) => {
                     control={control}
                     render={({ field }) => {
                       return (
-                        <Autocomplete
-                          id="trading-pair-select"
-                          options={tradingPairs || []}
-                          loading={isLoadingTradingPairs}
-                          slotProps={{
+                          <Autocomplete
+                            id="trading-pair-select"
+                            options={tradingPairs || []}
+                            loading={isLoadingTradingPairs}
+                            getOptionLabel={(option) => {
+                              if (!option) return '';
+                              const [base, quote] = option.split('/');
+                              const baseToken = TOKENS.find(token => token.name.toLowerCase() === base.toLowerCase());
+                              const quoteToken = TOKENS.find(token => token.name.toLowerCase() === quote.toLowerCase());
+                              return `${baseToken?.label ?? base}/${quoteToken?.label ?? quote}`;
+                            }}
+                            slotProps={{
                             paper: {
                               elevation: 4,
                               sx: {
@@ -564,7 +571,9 @@ const CreateCampaignModal: FC<Props> = ({ open, onClose }) => {
                                   variant="body1"
                                   color="text.primary"
                                 >
-                                  {pair?.split('/')[1] || ''}
+                                  {TOKENS.find(
+                                    (token) => token.name.toLowerCase() === pair?.split('/')[1]?.toLowerCase()
+                                  )?.label || pair?.split('/')[1] || ''}
                                 </Typography>
                               </InputAdornment>
                             ),

--- a/campaign-launcher/client/src/components/modals/CreateCampaignModal/index.tsx
+++ b/campaign-launcher/client/src/components/modals/CreateCampaignModal/index.tsx
@@ -30,12 +30,12 @@ import { useAccount } from 'wagmi';
 import * as yup from 'yup';
 
 import { QUERY_KEYS } from '../../../constants/queryKeys';
-import { FUND_TOKENS, FundToken, TOKENS } from '../../../constants/tokens';
+import { FUND_TOKENS, FundToken } from '../../../constants/tokens';
 import { useIsMobile } from '../../../hooks/useBreakpoints';
 import useCreateEscrow from '../../../hooks/useCreateEscrow';
 import { useTradingPairs } from '../../../hooks/useTradingPairs';
 import { useNetwork } from '../../../providers/NetworkProvider';
-import { constructCampaignDetails } from '../../../utils';
+import { constructCampaignDetails, getTokenInfo } from '../../../utils';
 import { CryptoEntity } from '../../CryptoEntity';
 import { CryptoPairEntity } from '../../CryptoPairEntity';
 import CustomTooltip from '../../CustomTooltip';
@@ -188,6 +188,7 @@ const CreateCampaignModal: FC<Props> = ({ open, onClose }) => {
 
   const exchange = watch('exchange');
   const pair = watch('pair');
+  const volumeToken = pair?.split('/')[1] || '';
   const { data: tradingPairs, isLoading: isLoadingTradingPairs } =
     useTradingPairs(exchange);
 
@@ -360,9 +361,9 @@ const CreateCampaignModal: FC<Props> = ({ open, onClose }) => {
                             getOptionLabel={(option) => {
                               if (!option) return '';
                               const [base, quote] = option.split('/');
-                              const baseToken = TOKENS.find(token => token.name.toLowerCase() === base.toLowerCase());
-                              const quoteToken = TOKENS.find(token => token.name.toLowerCase() === quote.toLowerCase());
-                              return `${baseToken?.label ?? base}/${quoteToken?.label ?? quote}`;
+                              const { label: baseToken } = getTokenInfo(base);
+                              const { label: quoteToken } = getTokenInfo(quote);
+                              return `${baseToken}/${quoteToken}`;
                             }}
                             slotProps={{
                             paper: {
@@ -571,9 +572,7 @@ const CreateCampaignModal: FC<Props> = ({ open, onClose }) => {
                                   variant="body1"
                                   color="text.primary"
                                 >
-                                  {TOKENS.find(
-                                    (token) => token.name.toLowerCase() === pair?.split('/')[1]?.toLowerCase()
-                                  )?.label || pair?.split('/')[1] || ''}
+                                  {getTokenInfo(volumeToken).label || ''}
                                 </Typography>
                               </InputAdornment>
                             ),

--- a/campaign-launcher/client/src/types/index.ts
+++ b/campaign-launcher/client/src/types/index.ts
@@ -56,7 +56,7 @@ export type Campaign = {
   fund_token_symbol: string;
   fund_token_decimals: number;
   intermediate_results_url: string | null;
-  status: 'active' | 'cancelled' | 'completed';
+  status: CampaignStatus;
   escrow_status: string;
   launcher: string;
   exchange_oracle: string;

--- a/campaign-launcher/client/src/utils/index.ts
+++ b/campaign-launcher/client/src/utils/index.ts
@@ -10,6 +10,7 @@ import {
   LOCALHOST_CHAIN_IDS,
 } from '../constants';
 import { CHAIN_ICONS } from '../constants/chainIcons';
+import { TOKENS } from '../constants/tokens';
 import { Campaign, CampaignDetails, EscrowCreateDto } from '../types';
 
 export const formatAddress = (address?: string) => {
@@ -220,4 +221,12 @@ export const filterFalsyQueryParams = (
   }
 
   return result;
+};
+
+export const getTokenInfo = (token: string) => {
+  return TOKENS.find((t) => t.name.toLowerCase() === token.toLowerCase()) || {
+    name: token,
+    label: token,
+    icon: null,
+  };
 };


### PR DESCRIPTION
## Issue tracking
Closes #395

## Context behind the change
This PR changes the logic of the widget: final result should be displayed only if the campaign is already not active and has a final results url; otherwise it's intermediate or N/A (if no results have yet been recorded)
Also, this PR tweaks a displaying of daily volume token (usdt -> usdt0)

## How has this been tested?
locally

## Release plan
regular

## Potential risks; What to monitor; Rollback plan
not found