### PR TITLE
[Oracles] feat: change campaign schema to support different types

### DIFF
--- a/recording-oracle/src/database/migrations/1758725472133-abstract-campaign-type.ts
+++ b/recording-oracle/src/database/migrations/1758725472133-abstract-campaign-type.ts
@@ -1,0 +1,57 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AbstractCampaignType1758725472133 implements MigrationInterface {
+  name = 'AbstractCampaignType1758725472133';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "hu_fi"."campaigns" DROP COLUMN "pair"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hu_fi"."campaigns" DROP COLUMN "daily_volume_target"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hu_fi"."campaigns" ADD "symbol" character varying(20) NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hu_fi"."campaigns" ADD "fund_token_decimals" integer NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hu_fi"."campaigns" ADD "details" jsonb NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hu_fi"."campaigns" DROP COLUMN "type"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "hu_fi"."campaigns_type_enum" AS ENUM('LIQUIDITY', 'VOLUME')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hu_fi"."campaigns" ADD "type" "hu_fi"."campaigns_type_enum" NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "hu_fi"."campaigns" DROP COLUMN "type"`,
+    );
+    await queryRunner.query(`DROP TYPE "hu_fi"."campaigns_type_enum"`);
+    await queryRunner.query(
+      `ALTER TABLE "hu_fi"."campaigns" ADD "type" character varying(40) NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hu_fi"."campaigns" DROP COLUMN "details"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hu_fi"."campaigns" DROP COLUMN "fund_token_decimals"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hu_fi"."campaigns" DROP COLUMN "symbol"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hu_fi"."campaigns" ADD "daily_volume_target" numeric(20,8) NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "hu_fi"."campaigns" ADD "pair" character varying(20) NOT NULL`,
+    );
+  }
+}

--- a/recording-oracle/src/logger/index.ts
+++ b/recording-oracle/src/logger/index.ts
@@ -11,6 +11,7 @@ import Environment from '@/common/utils/environment';
 const isDevelopment = Environment.isDevelopment();
 
 const LOG_LEVEL_OVERRIDE = process.env.LOG_LEVEL;
+const LOG_PRETTY_OVERRIDE = process.env.LOG_PRETTY;
 
 let logLevel = LogLevel.INFO;
 if (isLogLevel(LOG_LEVEL_OVERRIDE)) {
@@ -23,7 +24,7 @@ const defaultLogger = createLogger(
   {
     name: 'DefaultLogger',
     level: logLevel,
-    pretty: isDevelopment,
+    pretty: isDevelopment || LOG_PRETTY_OVERRIDE === 'true',
     disabled: Environment.isTest(),
   },
   {

--- a/recording-oracle/src/modules/campaigns/campaign.entity.ts
+++ b/recording-oracle/src/modules/campaigns/campaign.entity.ts
@@ -9,7 +9,7 @@ import {
 
 import { DATABASE_SCHEMA_NAME } from '@/common/constants';
 
-import { CampaignStatus } from './types';
+import { type CampaignDetails, CampaignStatus, CampaignType } from './types';
 
 @Entity({ schema: DATABASE_SCHEMA_NAME, name: 'campaigns' })
 @Index(['chainId', 'address'], { unique: true })
@@ -23,17 +23,17 @@ export class CampaignEntity {
   @Column('varchar', { length: 42 })
   address: string;
 
-  @Column('varchar', { length: 40 })
-  type: string;
-
-  @Column({ type: 'decimal', precision: 20, scale: 8 })
-  dailyVolumeTarget: string;
+  @Column({
+    type: 'enum',
+    enum: CampaignType,
+  })
+  type: CampaignType;
 
   @Column('varchar', { length: 20 })
   exchangeName: string;
 
   @Column('varchar', { length: 20 })
-  pair: string;
+  symbol: string;
 
   @Column({ type: 'timestamptz' })
   startDate: Date;
@@ -46,6 +46,12 @@ export class CampaignEntity {
 
   @Column('varchar', { length: 20 })
   fundToken: string;
+
+  @Column('int')
+  fundTokenDecimals: number;
+
+  @Column('jsonb')
+  details: CampaignDetails;
 
   @Column({ type: 'timestamptz', nullable: true })
   lastResultsAt: Date | null;

--- a/recording-oracle/src/modules/campaigns/campaigns.controller.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.controller.ts
@@ -103,15 +103,16 @@ export class CampaignsController {
         .map((campaign) => ({
           chainId: campaign.chainId,
           address: campaign.address,
-          status: CAMPAIGN_STATUS_TO_RETURNED_STATUS[campaign.status],
-          processingStatus: campaign.status,
+          type: campaign.type,
           exchangeName: campaign.exchangeName,
-          tradingPair: campaign.pair,
-          dailyVolumeTarget: Number(campaign.dailyVolumeTarget),
+          symbol: campaign.symbol,
           startDate: campaign.startDate.toISOString(),
           endDate: campaign.endDate.toISOString(),
           fundAmount: Number(campaign.fundAmount),
           fundToken: campaign.fundToken,
+          details: campaign.details,
+          status: CAMPAIGN_STATUS_TO_RETURNED_STATUS[campaign.status],
+          processingStatus: campaign.status,
         }))
         .slice(0, limit),
     };

--- a/recording-oracle/src/modules/campaigns/constants.ts
+++ b/recording-oracle/src/modules/campaigns/constants.ts
@@ -1,4 +1,0 @@
-import { CampaignType } from './types';
-
-export const SUPPORTED_CAMPAIGN_TYPES: CampaignType[] =
-  Object.values(CampaignType);

--- a/recording-oracle/src/modules/campaigns/fixtures/manifest.ts
+++ b/recording-oracle/src/modules/campaigns/fixtures/manifest.ts
@@ -5,15 +5,47 @@ import {
   generateTradingPair,
 } from '@/modules/exchange/fixtures';
 
-import { CampaignType, type CampaignManifest } from '../types';
+import {
+  CampaignType,
+  type LiquidityCampaignManifest,
+  type VolumeCampaignManifest,
+  type CampaignManifest,
+  type CampaignManifestBase,
+} from '../types';
 
-export function generateCampaignManifest(): CampaignManifest {
-  return {
-    type: faker.helpers.arrayElement([CampaignType.VOLUME]),
-    daily_volume_target: faker.number.float(),
+export function generateCampaignManifest(
+  type?: string,
+): CampaignManifestBase | CampaignManifest {
+  const manifestBase: CampaignManifestBase = {
+    type: '',
     exchange: generateExchangeName(),
-    symbol: generateTradingPair(),
+    symbol: '',
     start_date: faker.date.recent(),
     end_date: faker.date.future(),
   };
+
+  switch (type) {
+    case CampaignType.VOLUME: {
+      const manifest: VolumeCampaignManifest = {
+        ...manifestBase,
+        type,
+        symbol: generateTradingPair(),
+        daily_volume_target: faker.number.float(),
+      };
+      return manifest;
+    }
+    case CampaignType.LIQUIDITY: {
+      const manifest: LiquidityCampaignManifest = {
+        ...manifestBase,
+        type,
+        symbol: faker.finance.currencyCode(),
+        daily_balance_target: faker.number.float(),
+      };
+      return manifest;
+    }
+    default:
+      manifestBase.type = faker.lorem.word();
+      manifestBase.symbol = faker.lorem.word();
+      return manifestBase;
+  }
 }

--- a/recording-oracle/src/modules/campaigns/fixtures/manifest.ts
+++ b/recording-oracle/src/modules/campaigns/fixtures/manifest.ts
@@ -5,15 +5,14 @@ import {
   generateTradingPair,
 } from '@/modules/exchange/fixtures';
 
-import { SUPPORTED_CAMPAIGN_TYPES } from '../constants';
-import type { CampaignManifest } from '../types';
+import { CampaignType, type CampaignManifest } from '../types';
 
 export function generateCampaignManifest(): CampaignManifest {
   return {
-    type: faker.helpers.arrayElement(SUPPORTED_CAMPAIGN_TYPES),
+    type: faker.helpers.arrayElement([CampaignType.VOLUME]),
     daily_volume_target: faker.number.float(),
     exchange: generateExchangeName(),
-    pair: generateTradingPair(),
+    symbol: generateTradingPair(),
     start_date: faker.date.recent(),
     end_date: faker.date.future(),
   };

--- a/recording-oracle/src/modules/campaigns/fixtures/manifest.ts
+++ b/recording-oracle/src/modules/campaigns/fixtures/manifest.ts
@@ -9,43 +9,51 @@ import {
   CampaignType,
   type LiquidityCampaignManifest,
   type VolumeCampaignManifest,
-  type CampaignManifest,
   type CampaignManifestBase,
 } from '../types';
 
-export function generateCampaignManifest(
-  type?: string,
-): CampaignManifestBase | CampaignManifest {
+export function generateBaseCampaignManifest(): CampaignManifestBase {
   const manifestBase: CampaignManifestBase = {
-    type: '',
+    type: faker.lorem.word(),
     exchange: generateExchangeName(),
-    symbol: '',
+    symbol: faker.lorem.word(),
     start_date: faker.date.recent(),
     end_date: faker.date.future(),
   };
 
-  switch (type) {
-    case CampaignType.VOLUME: {
-      const manifest: VolumeCampaignManifest = {
-        ...manifestBase,
-        type,
-        symbol: generateTradingPair(),
-        daily_volume_target: faker.number.float(),
-      };
-      return manifest;
-    }
-    case CampaignType.LIQUIDITY: {
-      const manifest: LiquidityCampaignManifest = {
-        ...manifestBase,
-        type,
-        symbol: faker.finance.currencyCode(),
-        daily_balance_target: faker.number.float(),
-      };
-      return manifest;
-    }
-    default:
-      manifestBase.type = faker.lorem.word();
-      manifestBase.symbol = faker.lorem.word();
-      return manifestBase;
-  }
+  return manifestBase;
+}
+
+export function generateVolumeCampaignManifest(): VolumeCampaignManifest {
+  const manifestBase = generateBaseCampaignManifest();
+
+  const manifest: VolumeCampaignManifest = {
+    ...manifestBase,
+    type: CampaignType.VOLUME,
+    symbol: generateTradingPair(),
+    daily_volume_target: faker.number.float(),
+  };
+  return manifest;
+}
+
+export function generateLiquidityCampaignManifest(): LiquidityCampaignManifest {
+  const manifestBase = generateBaseCampaignManifest();
+
+  const manifest: LiquidityCampaignManifest = {
+    ...manifestBase,
+    type: CampaignType.LIQUIDITY,
+    symbol: faker.finance.currencyCode(),
+    daily_balance_target: faker.number.float(),
+  };
+  return manifest;
+}
+
+export function generateManifestResponse() {
+  const manifest = generateBaseCampaignManifest();
+
+  return {
+    ...manifest,
+    start_date: manifest.start_date.toISOString(),
+    end_date: manifest.end_date.toISOString(),
+  };
 }

--- a/recording-oracle/src/modules/campaigns/manifest.utils.spec.ts
+++ b/recording-oracle/src/modules/campaigns/manifest.utils.spec.ts
@@ -5,19 +5,13 @@ import nock from 'nock';
 
 import { generateTradingPair } from '@/modules/exchange/fixtures';
 
-import { generateCampaignManifest } from './fixtures';
+import {
+  generateManifestResponse,
+  generateVolumeCampaignManifest,
+  generateLiquidityCampaignManifest,
+} from './fixtures';
 import * as manifestUtils from './manifest.utils';
 import { CampaignType } from './types';
-
-function generateManifestResponse(type?: string) {
-  const manifest = generateCampaignManifest(type);
-
-  return {
-    ...manifest,
-    start_date: manifest.start_date.toISOString(),
-    end_date: manifest.end_date.toISOString(),
-  };
-}
 
 describe('manifest utils', () => {
   describe('downloadCampaignManifest', () => {
@@ -183,7 +177,7 @@ describe('manifest utils', () => {
   });
 
   describe('assertValidVolumeCampaignManifest', () => {
-    const validManifest = generateCampaignManifest(CampaignType.VOLUME);
+    const validManifest = generateVolumeCampaignManifest();
 
     it('should not throw for valid manifest', () => {
       expect(
@@ -231,7 +225,7 @@ describe('manifest utils', () => {
   });
 
   describe('assertValidLiquidityCampaignManifest', () => {
-    const validManifest = generateCampaignManifest(CampaignType.LIQUIDITY);
+    const validManifest = generateLiquidityCampaignManifest();
 
     it('should not throw for valid manifest', () => {
       expect(

--- a/recording-oracle/src/modules/campaigns/manifest.utils.spec.ts
+++ b/recording-oracle/src/modules/campaigns/manifest.utils.spec.ts
@@ -1,3 +1,5 @@
+import * as crypto from 'crypto';
+
 import { faker } from '@faker-js/faker';
 import nock from 'nock';
 
@@ -5,9 +7,10 @@ import { generateTradingPair } from '@/modules/exchange/fixtures';
 
 import { generateCampaignManifest } from './fixtures';
 import * as manifestUtils from './manifest.utils';
+import { CampaignType } from './types';
 
-function generateManifestResponse() {
-  const manifest = generateCampaignManifest();
+function generateManifestResponse(type?: string) {
+  const manifest = generateCampaignManifest(type);
 
   return {
     ...manifest,
@@ -16,14 +19,12 @@ function generateManifestResponse() {
   };
 }
 
-const MANIFEST_RESPONSE_KEYS = Object.keys(generateManifestResponse());
-
 describe('manifest utils', () => {
   describe('downloadCampaignManifest', () => {
-    let manifest: string;
+    let manifestUrl: string;
 
     beforeEach(() => {
-      manifest = faker.internet.url();
+      manifestUrl = faker.internet.url();
     });
 
     afterEach(() => {
@@ -35,12 +36,12 @@ describe('manifest utils', () => {
     });
 
     it('should throw when manifest not found', async () => {
-      const scope = nock(manifest).get('/').reply(404);
+      const scope = nock(manifestUrl).get('/').reply(404);
 
       let thrownError;
       try {
         await manifestUtils.downloadCampaignManifest(
-          manifest,
+          manifestUrl,
           faker.string.hexadecimal(),
         );
       } catch (error) {
@@ -56,11 +57,11 @@ describe('manifest utils', () => {
     it('should throw when invalid manifest hash', async () => {
       const mockedManifest = generateManifestResponse();
       const invalidHash = faker.string.hexadecimal();
-      const scope = nock(manifest).get('/').reply(200, mockedManifest);
+      const scope = nock(manifestUrl).get('/').reply(200, mockedManifest);
 
       let thrownError;
       try {
-        await manifestUtils.downloadCampaignManifest(manifest, invalidHash);
+        await manifestUtils.downloadCampaignManifest(manifestUrl, invalidHash);
       } catch (error) {
         thrownError = error;
       }
@@ -71,12 +72,34 @@ describe('manifest utils', () => {
       expect(thrownError.message).toBe('Invalid file hash');
     });
 
+    it('should download manifest and return when hash is valid', async () => {
+      const mockedManifest = JSON.stringify(generateManifestResponse());
+      const mockedManifestHash = crypto
+        .createHash('sha1')
+        .update(mockedManifest)
+        .digest('hex');
+      const scope = nock(manifestUrl).get('/').reply(200, mockedManifest);
+
+      const manifest = await manifestUtils.downloadCampaignManifest(
+        manifestUrl,
+        mockedManifestHash,
+      );
+
+      scope.done();
+
+      expect(manifest).toBe(mockedManifest);
+    });
+  });
+
+  describe('validateBaseSchema', () => {
+    const MANIFEST_RESPONSE_KEYS = Object.keys(generateManifestResponse());
+
     it.each([
+      // all properties are invalid format
       {
-        type: faker.number.int(),
-        exchange: faker.lorem.word(),
-        daily_volume_target: faker.number.float({ min: -42, max: 0 }),
-        pair: generateTradingPair().replace('/', '-'),
+        type: faker.string.symbol(),
+        exchange: faker.string.symbol(),
+        symbol: faker.string.symbol(),
         // dates are not in ISO format
         start_date: faker.date.recent().toDateString(),
         end_date: faker.date.future().toDateString(),
@@ -111,12 +134,12 @@ describe('manifest utils', () => {
         return invalidResponses;
       })(),
     ])(
-      'should throw when invalid manifest schema [%#]',
+      'should throw when invalid base manifest schema [%#]',
       async (manifestResponse) => {
         const manifest = JSON.stringify(manifestResponse);
         let thrownError;
         try {
-          manifestUtils.validateSchema(manifest);
+          manifestUtils.validateBaseSchema(manifest);
         } catch (error) {
           thrownError = error;
         }
@@ -126,10 +149,10 @@ describe('manifest utils', () => {
       },
     );
 
-    it('should validate manifest', async () => {
+    it('should validate base manifest schema', async () => {
       const mockedManifest = generateManifestResponse();
 
-      const manifest = manifestUtils.validateSchema(
+      const manifest = manifestUtils.validateBaseSchema(
         JSON.stringify(mockedManifest),
       );
 
@@ -140,22 +163,114 @@ describe('manifest utils', () => {
       });
     });
 
-    it('should validate manifest and strip unknown fields', async () => {
+    it('should validate base manifest and keep unknown fields', async () => {
       const strippedManifest = generateManifestResponse();
       const manifestWithExtra = {
         ...strippedManifest,
         unknown_field: faker.string.sample(),
       };
 
-      const manifest = manifestUtils.validateSchema(
+      const manifest = manifestUtils.validateBaseSchema(
         JSON.stringify(manifestWithExtra),
       );
 
       expect(manifest).toEqual({
-        ...strippedManifest,
+        ...manifestWithExtra,
         start_date: new Date(strippedManifest.start_date),
         end_date: new Date(strippedManifest.end_date),
       });
     });
+  });
+
+  describe('assertValidVolumeCampaignManifest', () => {
+    const validManifest = generateCampaignManifest(CampaignType.VOLUME);
+
+    it('should not throw for valid manifest', () => {
+      expect(
+        manifestUtils.assertValidVolumeCampaignManifest(validManifest),
+      ).toBeUndefined();
+    });
+
+    it.each([
+      // invalid (lowercased) type
+      Object.assign({}, validManifest, {
+        type: CampaignType.VOLUME.toLowerCase(),
+      }),
+      // invalid trading pair symbol
+      Object.assign({}, validManifest, {
+        symbol: generateTradingPair().replace('/', '-'),
+      }),
+      // token symbol instead of trading pair
+      Object.assign({}, validManifest, {
+        symbol: faker.finance.currencyCode(),
+      }),
+      // invalid volume target
+      Object.assign({}, validManifest, {
+        daily_volume_target: faker.number.int({ min: -42, max: 0 }),
+      }),
+      // missing volume target
+      Object.assign({}, validManifest, {
+        daily_volume_target: undefined,
+      }),
+    ])(
+      'should throw when invalid base manifest schema [%#]',
+      async (manifest) => {
+        let thrownError;
+        try {
+          manifestUtils.assertValidVolumeCampaignManifest(manifest);
+        } catch (error) {
+          thrownError = error;
+        }
+
+        expect(thrownError).toBeInstanceOf(Error);
+        expect(thrownError.message).toBe(
+          'Invalid volume campaign manifest schema',
+        );
+      },
+    );
+  });
+
+  describe('assertValidLiquidityCampaignManifest', () => {
+    const validManifest = generateCampaignManifest(CampaignType.LIQUIDITY);
+
+    it('should not throw for valid manifest', () => {
+      expect(
+        manifestUtils.assertValidLiquidityCampaignManifest(validManifest),
+      ).toBeUndefined();
+    });
+
+    it.each([
+      // invalid (lowercased) type
+      Object.assign({}, validManifest, {
+        type: CampaignType.LIQUIDITY.toLowerCase(),
+      }),
+      // trading pair instead of token symbol
+      Object.assign({}, validManifest, {
+        symbol: generateTradingPair(),
+      }),
+      // invalid balance target
+      Object.assign({}, validManifest, {
+        daily_balance_target: faker.number.int({ min: -42, max: 0 }),
+      }),
+      // missing balance target
+      Object.assign({}, validManifest, {
+        daily_balance_target: undefined,
+      }),
+    ])(
+      'should throw when invalid base manifest schema [%#]',
+      async (manifest) => {
+        let thrownError;
+        try {
+          manifestUtils.assertValidLiquidityCampaignManifest(manifest);
+        } catch (error) {
+          thrownError = error;
+        }
+
+        expect(thrownError).toBeInstanceOf(Error);
+        expect(thrownError.message).toBe(
+          'Invalid liquidity campaign manifest schema',
+        );
+      },
+    );
   });
 });

--- a/recording-oracle/src/modules/campaigns/manifest.utils.ts
+++ b/recording-oracle/src/modules/campaigns/manifest.utils.ts
@@ -35,14 +35,8 @@ export async function downloadCampaignManifest(
 }
 
 export function validateBaseSchema(manifest: string): CampaignManifestBase {
-  let manifestJson;
   try {
-    manifestJson = JSON.parse(manifest);
-  } catch {
-    throw new Error('Failed to parse manifest JSON');
-  }
-
-  try {
+    const manifestJson = JSON.parse(manifest);
     const validatedManifest = Joi.attempt(manifestJson, baseManifestSchema);
 
     return validatedManifest;

--- a/recording-oracle/src/modules/campaigns/manifest.utils.ts
+++ b/recording-oracle/src/modules/campaigns/manifest.utils.ts
@@ -4,18 +4,28 @@ import Joi from 'joi';
 
 import * as httpUtils from '@/common/utils/http';
 
-import type { CampaignManifest } from './types';
+import {
+  CampaignDetails,
+  CampaignType,
+  LiquidityCampaignDetails,
+  VolumeCampaignDetails,
+  type CampaignManifest,
+  type LiquidityCampaignManifest,
+  type VolumeCampaignManifest,
+} from './types';
 
-const manifestSchema = Joi.object({
+const baseManifestSchema = Joi.object({
   type: Joi.string().required(),
   exchange: Joi.string().required(),
-  daily_volume_target: Joi.number().greater(0).required(),
-  pair: Joi.string()
-    .pattern(/^[A-Z]{3,10}\/[A-Z]{3,10}$/)
+  symbol: Joi.alternatives()
+    .try(
+      Joi.string().pattern(/^[A-Z]{3,10}\/[A-Z]{3,10}$/),
+      Joi.string().pattern(/^[A-Z]{3,10}/),
+    )
     .required(),
   start_date: Joi.date().iso().required(),
   end_date: Joi.date().iso().greater(Joi.ref('start_date')).required(),
-}).options({ allowUnknown: true, stripUnknown: true });
+}).options({ allowUnknown: true, stripUnknown: false });
 
 export async function downloadCampaignManifest(
   url: string,
@@ -34,13 +44,68 @@ export function calculateManifestHash(manifest: string): string {
   return crypto.createHash('sha1').update(manifest).digest('hex');
 }
 
-export function validateSchema(manifest: string): CampaignManifest {
+export function validateBaseSchema(manifest: string): CampaignManifest {
+  let manifestJson;
   try {
-    const manifestJson = JSON.parse(manifest);
-    const validatedManifest = Joi.attempt(manifestJson, manifestSchema);
+    manifestJson = JSON.parse(manifest);
+  } catch {
+    throw new Error('Failed to parse manifest JSON');
+  }
+
+  try {
+    const validatedManifest = Joi.attempt(manifestJson, baseManifestSchema);
 
     return validatedManifest;
   } catch {
     throw new Error('Invalid manifest schema');
+  }
+}
+
+const volumeManifestSchema = baseManifestSchema.keys({
+  daily_volume_target: Joi.number().greater(0).required(),
+});
+export function assertValidVolumeCampaignManifest(
+  manifest: CampaignManifest,
+): asserts manifest is VolumeCampaignManifest {
+  try {
+    Joi.assert(manifest, volumeManifestSchema);
+  } catch {
+    throw new Error('Invalid volume campaign manifest schema');
+  }
+}
+
+const liquidityManifestSchema = baseManifestSchema.keys({
+  daily_balance_target: Joi.number().greater(0).required(),
+});
+export function assertValidLiquidityCampaignManifest(
+  manifest: CampaignManifest,
+): asserts manifest is LiquidityCampaignManifest {
+  try {
+    Joi.assert(manifest, liquidityManifestSchema);
+  } catch {
+    throw new Error('Invalid liquidity campaign manifest schema');
+  }
+}
+
+export function extractCampaignDetails(
+  manifest: CampaignManifest,
+): CampaignDetails {
+  switch (manifest.type) {
+    case CampaignType.VOLUME: {
+      const details: VolumeCampaignDetails = {
+        dailyVolumeTarget: (manifest as VolumeCampaignManifest)
+          .daily_volume_target,
+      };
+      return details;
+    }
+    case CampaignType.LIQUIDITY: {
+      const details: LiquidityCampaignDetails = {
+        dailyBalanceTarget: (manifest as LiquidityCampaignManifest)
+          .daily_balance_target,
+      };
+      return details;
+    }
+    default:
+      throw new Error(`Can't extract ${manifest.type} campaign details`);
   }
 }

--- a/recording-oracle/src/modules/campaigns/progress-checking/index.ts
+++ b/recording-oracle/src/modules/campaigns/progress-checking/index.ts
@@ -1,3 +1,3 @@
-export { MarketMakingResultsChecker } from './market-making';
+export { MarketMakingResultsChecker as VolumeResultsChecker } from './market-making';
 
 export type * from './types';

--- a/recording-oracle/src/modules/campaigns/progress-checking/progress-checker.spec.ts
+++ b/recording-oracle/src/modules/campaigns/progress-checking/progress-checker.spec.ts
@@ -116,17 +116,17 @@ describe('BaseCampaignProgressChecker', () => {
       expect(mockedExchangeApiClient.fetchMyTrades).toHaveBeenCalledTimes(3);
       expect(mockedExchangeApiClient.fetchMyTrades).toHaveBeenNthCalledWith(
         1,
-        progressCheckerSetup.tradingPair,
+        progressCheckerSetup.symbol,
         progressCheckerSetup.tradingPeriodStart.valueOf(),
       );
       expect(mockedExchangeApiClient.fetchMyTrades).toHaveBeenNthCalledWith(
         2,
-        progressCheckerSetup.tradingPair,
+        progressCheckerSetup.symbol,
         pages[0].at(-1)!.timestamp + 1,
       );
       expect(mockedExchangeApiClient.fetchMyTrades).toHaveBeenNthCalledWith(
         3,
-        progressCheckerSetup.tradingPair,
+        progressCheckerSetup.symbol,
         pages[1].at(-1)!.timestamp + 1,
       );
     });

--- a/recording-oracle/src/modules/campaigns/progress-checking/progress-checker.ts
+++ b/recording-oracle/src/modules/campaigns/progress-checking/progress-checker.ts
@@ -24,7 +24,7 @@ export abstract class BaseCampaignProgressChecker
     setupData: CampaignProgressCheckerSetup,
   ) {
     this.exchangeName = setupData.exchangeName;
-    this.tradingPair = setupData.tradingPair;
+    this.tradingPair = setupData.symbol;
     this.tradingPeriodStart = setupData.tradingPeriodStart;
     this.tradingPeriodEnd = setupData.tradingPeriodEnd;
   }

--- a/recording-oracle/src/modules/campaigns/progress-checking/types.ts
+++ b/recording-oracle/src/modules/campaigns/progress-checking/types.ts
@@ -1,6 +1,6 @@
 export type CampaignProgressCheckerSetup = {
   exchangeName: string;
-  tradingPair: string;
+  symbol: string;
   tradingPeriodStart: Date;
   tradingPeriodEnd: Date;
 };

--- a/recording-oracle/src/modules/campaigns/type-guards.ts
+++ b/recording-oracle/src/modules/campaigns/type-guards.ts
@@ -1,0 +1,18 @@
+import type { CampaignEntity } from './campaign.entity';
+import {
+  CampaignType,
+  type LiquidityCampaignDetails,
+  type VolumeCampaignDetails,
+} from './types';
+
+export function isVolumeCampaign(
+  campaign: CampaignEntity,
+): campaign is CampaignEntity & { details: VolumeCampaignDetails } {
+  return campaign.type === CampaignType.VOLUME;
+}
+
+export function isLiquidityCampaign(
+  campaign: CampaignEntity,
+): campaign is CampaignEntity & { details: LiquidityCampaignDetails } {
+  return campaign.type === CampaignType.LIQUIDITY;
+}

--- a/recording-oracle/src/modules/campaigns/types.ts
+++ b/recording-oracle/src/modules/campaigns/types.ts
@@ -17,27 +17,49 @@ export enum ReturnedCampaignStatus {
 }
 
 export enum CampaignType {
-  MARKET_MAKING = 'MARKET_MAKING',
+  VOLUME = 'VOLUME',
+  LIQUIDITY = 'LIQUIDITY',
 }
+
+export type VolumeCampaignDetails = {
+  dailyVolumeTarget: number;
+};
+
+export type LiquidityCampaignDetails = {
+  dailyBalanceTarget: number;
+};
+
+export type CampaignDetails = VolumeCampaignDetails | LiquidityCampaignDetails;
 
 export type CampaignManifest = {
   type: string;
-  daily_volume_target: number;
   exchange: string;
-  pair: string;
+  symbol: string;
   start_date: Date;
   end_date: Date;
+};
+
+export type VolumeCampaignManifest = CampaignManifest & {
+  type: CampaignType.VOLUME;
+  daily_volume_target: number;
+};
+
+export type LiquidityCampaignManifest = CampaignManifest & {
+  type: CampaignType.LIQUIDITY;
+  daily_balance_target: number;
 };
 
 export type CampaignEscrowInfo = {
   fundAmount: number;
   fundTokenSymbol: string;
+  fundTokenDecimals: number;
 };
 
 export type ParticipantOutcome = {
   address: string;
   score: number;
-  total_volume: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [x: string]: any;
 };
 
 export type ParticipantsOutcomesBatch = {
@@ -48,15 +70,16 @@ export type ParticipantsOutcomesBatch = {
 export type IntermediateResult = {
   from: string;
   to: string;
-  total_volume: number;
   participants_outcomes_batches: ParticipantsOutcomesBatch[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [x: string]: any;
 };
 
 export type IntermediateResultsData = {
   chain_id: number;
   address: string;
   exchange: string;
-  pair: string;
+  symbol: string;
   results: IntermediateResult[];
 };
 

--- a/recording-oracle/src/modules/campaigns/types.ts
+++ b/recording-oracle/src/modules/campaigns/types.ts
@@ -31,7 +31,7 @@ export type LiquidityCampaignDetails = {
 
 export type CampaignDetails = VolumeCampaignDetails | LiquidityCampaignDetails;
 
-export type CampaignManifest = {
+export type CampaignManifestBase = {
   type: string;
   exchange: string;
   symbol: string;
@@ -39,15 +39,19 @@ export type CampaignManifest = {
   end_date: Date;
 };
 
-export type VolumeCampaignManifest = CampaignManifest & {
+export type VolumeCampaignManifest = CampaignManifestBase & {
   type: CampaignType.VOLUME;
   daily_volume_target: number;
 };
 
-export type LiquidityCampaignManifest = CampaignManifest & {
+export type LiquidityCampaignManifest = CampaignManifestBase & {
   type: CampaignType.LIQUIDITY;
   daily_balance_target: number;
 };
+
+export type CampaignManifest =
+  | VolumeCampaignManifest
+  | LiquidityCampaignManifest;
 
 export type CampaignEscrowInfo = {
   fundAmount: number;
@@ -58,8 +62,7 @@ export type CampaignEscrowInfo = {
 export type ParticipantOutcome = {
   address: string;
   score: number;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [x: string]: any;
+  total_volume: number;
 };
 
 export type ParticipantsOutcomesBatch = {
@@ -71,8 +74,7 @@ export type IntermediateResult = {
   from: string;
   to: string;
   participants_outcomes_batches: ParticipantsOutcomesBatch[];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [x: string]: any;
+  total_volume: number;
 };
 
 export type IntermediateResultsData = {


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
- we are going to add new campaign type and current DB schema does not fit it. In this PR change the schema to be agnostic to campaign type by keeping only common details in typed columns and all campaign specific details in `details` json column
- in order to have just one migration, also added fund token decimals that we will need for follow-up PRs (port rewards calculation from https://github.com/Hu-Fi/hufi/pull/372)
- also do renamed of `MARKET_MAKING` -> `VOLUME` campaign type.

> [!NOTE]
> Taking into account that we can sacrifice campaigns history in RecO DB for the release (all results live in blockchain), we implemented simplest possible migration and avoiding code parts for backward compatibility due to renaming of fields in manifest & intermediate results

## How has this been tested?
- [x] launched new `LIQUIDITY` campaign on mainnet; joined it via API call; ensured DB entry created properly
- [x] unit tests
- [x] play around via swagger API 

## Release plan
As part of common branch related to new campaign type: 
1. Ensure no active campaigns on PRD (i.e. all are either `completed` or `cancelled`)
2. Pause Launcher & RecO
3. Remove all entries from `campaigns` and `user_campaigns` tables
4. Deploy w/ migration run

## Potential risks; What to monitor; Rollback plan
Not fully tested e2e because we have only mainnet atm, so there might be some regressions. In order to mitigate it - we will have to e2e test it for all campaign types before release.