### PR TITLE
[Launcher UI] Fix issue with mismatched networks

### DIFF
--- a/campaign-launcher/client/src/hooks/useRetrieveSigner.ts
+++ b/campaign-launcher/client/src/hooks/useRetrieveSigner.ts
@@ -12,11 +12,11 @@ const useRetrieveSigner = () => {
 
   const { appChainId, isSwitching } = useNetwork();
   const { activeAddress } = useActiveAccount();
-  const { isConnected } = useAccount();
+  const { isConnected, chainId: walletChainId } = useAccount();
   const { data: client } = useWalletClient<Config>({
     account: activeAddress,
-    chainId: appChainId,
-    query: { enabled: !!activeAddress && isConnected },
+    chainId: walletChainId, // this is crucial to avoid the mismatch error
+    query: { enabled: !!activeAddress && isConnected && !isSwitching },
   });
 
   const isTransportReady = client && 'request' in client.transport;
@@ -33,7 +33,8 @@ const useRetrieveSigner = () => {
           if (Number(network.chainId) !== appChainId) {
             await client.switchChain({ id: appChainId });
             /* 
-              Need to re-create provider after switching chain, because it uses previous chain and can't create signer
+              Need to re-create provider after switching chain, 
+              because it uses previous chain and can't create signer
             */
             provider = new BrowserProvider(client.transport);
           }


### PR DESCRIPTION
## Issue tracking
Freestyle

## Context behind the change
If app's network isn't equal to metamask's network, `useWalletClient` throws an error `ConnectorChainMismatchError: The current chain of the connector (id: 1) does not match the connection’s chain (id: 2).` That results in failing creating a signer and therefore bad UI/UX.
In order to avoid this error I decided to initially create a signer object using metamask's network, and then force metamask to change the network to align with app's network 

## How has this been tested?
locally

## Release plan
regular

## Potential risks; What to monitor; Rollback plan
not found