### PR TITLE
[Recording Oracle] test: refactor campaign service unit tests to abstract campaign types

### DIFF
--- a/recording-oracle/src/modules/campaigns/campaigns.repository.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.repository.ts
@@ -32,16 +32,15 @@ export class CampaignsRepository extends Repository<CampaignEntity> {
 
     const results = await this.createQueryBuilder('campaign')
       .where('campaign.status = :status', { status: CampaignStatus.ACTIVE })
-      .andWhere('campaign.startDate <= :timeAgo', { timeAgo })
       .andWhere(
         `
-          (campaign.lastResultsAt IS NULL
-          OR campaign.lastResultsAt <= :timeAgo
-          OR campaign.endDate <= :now)
-        `,
+        campaign.endDate <= :now
+        OR (campaign.startDate <= :timeAgo AND campaign.lastResultsAt IS NULL)
+        OR campaign.lastResultsAt <= :timeAgo
+      `,
         {
-          timeAgo,
           now,
+          timeAgo,
         },
       )
       .getMany();

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -323,6 +323,17 @@ export class CampaignsService {
       );
     }
 
+    /*
+     * Not including this into Joi schema to send meaningful errors
+     */
+    if (!isValidExchangeName(manifest.exchange)) {
+      throw new InvalidCampaign(
+        chainId,
+        campaignAddress,
+        `Exchange not supported: ${manifest.exchange}`,
+      );
+    }
+
     try {
       switch (manifest.type) {
         case CampaignType.MARKET_MAKING:
@@ -339,17 +350,6 @@ export class CampaignsService {
         chainId,
         campaignAddress,
         error.message as string,
-      );
-    }
-
-    /*
-     * Not including this into Joi schema to send meaningful errors
-     */
-    if (!isValidExchangeName(manifest.exchange)) {
-      throw new InvalidCampaign(
-        chainId,
-        campaignAddress,
-        `Exchange not supported: ${manifest.exchange}`,
       );
     }
 

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -513,6 +513,7 @@ export class CampaignsService {
               `Unknown campaign type for reward pool calculation: ${campaign.type}`,
             );
           }
+
           const rewardPool = this.calculateRewardPool({
             maxRewardPool: this.calculateDailyReward(campaign),
             progressValueTarget,

--- a/recording-oracle/src/modules/campaigns/fixtures/campaign.ts
+++ b/recording-oracle/src/modules/campaigns/fixtures/campaign.ts
@@ -10,6 +10,10 @@ import { generateTestnetChainId } from '@/modules/web3/fixtures';
 import { generateRandomHashString } from '~/test/fixtures/crypto';
 
 import { CampaignEntity } from '../campaign.entity';
+import type {
+  BaseProgressCheckResult,
+  CampaignProgressChecker,
+} from '../progress-checking';
 import { MarketMakingMeta } from '../progress-checking/market-making';
 import {
   CampaignDetails,
@@ -21,22 +25,22 @@ import {
   ParticipantOutcome,
 } from '../types';
 
-/**
- * TODO
- *
- * Add other campaign types
- */
-export function generateCampaignEntity(
-  type: CampaignType.MARKET_MAKING = CampaignType.MARKET_MAKING,
-): CampaignEntity {
+export function generateCampaignEntity(type?: CampaignType): CampaignEntity {
+  const _type = type || faker.helpers.arrayElement(Object.values(CampaignType));
+
   const startDate = dayjs().subtract(1, 'days').toDate();
   const durationInDays = faker.number.int({ min: 3, max: 7 });
 
   let details: CampaignDetails;
-  switch (type) {
+  switch (_type) {
     case CampaignType.MARKET_MAKING:
       details = {
         dailyVolumeTarget: faker.number.float({ min: 1, max: 1000 }),
+      };
+      break;
+    case CampaignType.HOLDING:
+      details = {
+        dailyBalanceTarget: faker.number.float({ min: 1, max: 1000 }),
       };
       break;
   }
@@ -45,7 +49,7 @@ export function generateCampaignEntity(
     id: faker.string.uuid(),
     chainId: generateTestnetChainId(),
     address: ethers.getAddress(faker.finance.ethereumAddress()),
-    type,
+    type: _type,
     exchangeName: generateExchangeName(),
     symbol: generateTradingPair(),
     startDate,
@@ -68,7 +72,6 @@ export function generateParticipantOutcome(
 ): ParticipantOutcome {
   const outcome: ParticipantOutcome = {
     address: ethers.getAddress(faker.finance.ethereumAddress()),
-    total_volume: faker.number.float(),
     score: faker.number.float(),
   };
 
@@ -92,16 +95,25 @@ export function generateCampaignProgress(
   };
 }
 
-export function generateIntermediateResult(endDate?: Date): IntermediateResult {
+export function generateIntermediateResult({
+  endDate,
+  meta,
+}: {
+  endDate?: Date;
+  meta?: Record<string, unknown>;
+} = {}): IntermediateResult {
   const to = endDate || faker.date.past();
 
-  return {
+  const intermediateResult = {
     from: dayjs(to).subtract(1, 'day').toISOString(),
     to: to.toISOString(),
-    total_volume: 0,
     reserved_funds: faker.number.float(),
     participants_outcomes_batches: [],
   };
+
+  Object.assign(intermediateResult, meta);
+
+  return intermediateResult;
 }
 
 export function generateIntermediateResultsData(
@@ -125,4 +137,20 @@ export function generateStoredResultsMeta(): { url: string; hash: string } {
     url: faker.internet.url(),
     hash: generateRandomHashString('sha256'),
   };
+}
+
+export type MockProgressCheckResult = BaseProgressCheckResult & {
+  [meta: string]: unknown;
+};
+export class MockCampaignProgressChecker
+  implements
+    CampaignProgressChecker<
+      MockProgressCheckResult,
+      {
+        [meta: string]: unknown;
+      }
+    >
+{
+  checkForParticipant = jest.fn();
+  getCollectedMeta = jest.fn();
 }

--- a/recording-oracle/src/modules/campaigns/fixtures/campaign.ts
+++ b/recording-oracle/src/modules/campaigns/fixtures/campaign.ts
@@ -13,8 +13,8 @@ import { CampaignEntity } from '../campaign.entity';
 import type {
   BaseProgressCheckResult,
   CampaignProgressChecker,
+  CampaignProgressMeta,
 } from '../progress-checking';
-import { MarketMakingMeta } from '../progress-checking/market-making';
 import {
   CampaignDetails,
   CampaignProgress,
@@ -81,16 +81,29 @@ export function generateParticipantOutcome(
 }
 
 export function generateCampaignProgress(
+  type: CampaignType,
   endDate?: Date,
-): CampaignProgress<MarketMakingMeta> {
+): CampaignProgress<CampaignProgressMeta> {
   const to = endDate || faker.date.past();
+
+  let meta: CampaignProgressMeta;
+  switch (type) {
+    case CampaignType.MARKET_MAKING:
+      meta = {
+        total_volume: 0,
+      };
+      break;
+    case CampaignType.HOLDING:
+      meta = {
+        total_balance: 0,
+      };
+      break;
+  }
 
   return {
     from: dayjs(to).subtract(1, 'day').toISOString(),
     to: to.toISOString(),
-    meta: {
-      total_volume: 0,
-    },
+    meta,
     participants_outcomes: [],
   };
 }

--- a/recording-oracle/src/modules/campaigns/fixtures/manifest.ts
+++ b/recording-oracle/src/modules/campaigns/fixtures/manifest.ts
@@ -10,11 +10,12 @@ import {
   type HoldingCampaignManifest,
   type MarketMakingCampaignManifest,
   type CampaignManifestBase,
+  CampaignManifest,
 } from '../types';
 
 export function generateBaseCampaignManifest(): CampaignManifestBase {
   const manifestBase: CampaignManifestBase = {
-    type: faker.lorem.word(),
+    type: faker.string.sample(),
     exchange: generateExchangeName(),
     start_date: faker.date.recent(),
     end_date: faker.date.future(),
@@ -55,4 +56,13 @@ export function generateManifestResponse() {
     start_date: manifest.start_date.toISOString(),
     end_date: manifest.end_date.toISOString(),
   };
+}
+
+export function generateCampaignManifest(): CampaignManifest {
+  const generatorFn = faker.helpers.arrayElement([
+    generateMarketMakingCampaignManifest,
+    generateHoldingCampaignManifest,
+  ]);
+
+  return generatorFn();
 }


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Refactored campaign service unit tests to abstract campaign types.

Also improved `findForProgressRecording` to query campaigns that ended, no matter when they started.

## How has this been tested?
- [x] yarn test

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No