### PR TITLE
[Recording Oracle] feat: discover new campaigns

### DIFF
--- a/recording-oracle/src/modules/campaigns/campaigns.repository.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.repository.ts
@@ -55,4 +55,24 @@ export class CampaignsRepository extends Repository<CampaignEntity> {
       },
     });
   }
+
+  async findLatestCampaignForChain(
+    chainId: number,
+  ): Promise<CampaignEntity | null> {
+    return this.findOne({
+      where: {
+        chainId,
+      },
+      order: {
+        createdAt: 'desc',
+      },
+    });
+  }
+
+  async checkCampaignExists(
+    chainId: number,
+    address: string,
+  ): Promise<boolean> {
+    return this.existsBy({ chainId, address });
+  }
 }

--- a/recording-oracle/src/modules/web3/web3.service.ts
+++ b/recording-oracle/src/modules/web3/web3.service.ts
@@ -4,6 +4,7 @@ import { Wallet, ethers } from 'ethers';
 import { LRUCache } from 'lru-cache';
 
 import {
+  ChainId,
   ChainIds,
   ERC20_ABI_DECIMALS,
   ERC20_ABI_SYMBOL,
@@ -75,6 +76,10 @@ export class Web3Service {
     }
 
     return supportedChains;
+  }
+
+  get supportedChainIds(): ChainId[] {
+    return this.supportedChains.map((v) => v.id);
   }
 
   getSigner(chainId: number): WalletWithProvider {


### PR DESCRIPTION
## Issue tracking
#389 

## Context behind the change
Added campaign discovery cron job in order to save campaigns w/o waiting for users to join them and be able to move them to completion.

## How has this been tested?
- [x] run locally for old lookback, make sure it works and skips existing campaigns
- [x] unit tests for new cron job

## Release plan
Deploy and check if existing empty campaigns get added.

## Potential risks; What to monitor; Rollback plan
Should be none