### PR TITLE
[Recording Oracle] fix: discover campaigns only in pending status

### DIFF
--- a/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
@@ -2695,6 +2695,7 @@ describe('CampaignsService', () => {
       expect(mockedEscrowUtils.getEscrows).toHaveBeenCalledWith({
         chainId: supportedChainId,
         recordingOracle: mockWeb3ConfigService.operatorAddress.toLowerCase(),
+        status: EscrowStatus.Pending,
         from: new Date(escrowTimestamp * 1000),
         orderDirection: OrderDirection.ASC,
         first: 10,
@@ -2719,6 +2720,7 @@ describe('CampaignsService', () => {
       expect(mockedEscrowUtils.getEscrows).toHaveBeenCalledWith({
         chainId: supportedChainId,
         recordingOracle: mockWeb3ConfigService.operatorAddress.toLowerCase(),
+        status: EscrowStatus.Pending,
         from: dayAgo,
         orderDirection: OrderDirection.ASC,
         first: 10,

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -972,6 +972,7 @@ export class CampaignsService {
         const newEscrows = await EscrowUtils.getEscrows({
           chainId: chainId as number,
           recordingOracle: this.web3ConfigService.operatorAddress.toLowerCase(),
+          status: EscrowStatus.Pending,
           from: lookbackDate,
           orderDirection: OrderDirection.ASC,
           first: 10,


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Atm when discover new campaigns in Recording Oracle we query escrows in all statuses. Even though they won't be processed due to strict checks we have for creation, processing them is just extra time and noise in logs, so changing query to search only escrows in `Pending` status, i.e. they are created and set up, but need to be picked up by RecO

## How has this been tested?
- [x] unit tests

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No