### PR TITLE
fix: accept digits in token regex

### DIFF
--- a/campaign-launcher/client/src/components/modals/CreateCampaignModal/validation.ts
+++ b/campaign-launcher/client/src/components/modals/CreateCampaignModal/validation.ts
@@ -1,9 +1,9 @@
-import * as yup from "yup";
-import type { ObjectSchema } from "yup";
+import * as yup from 'yup';
+import type { ObjectSchema } from 'yup';
 
-import { FundToken } from "../../../constants/tokens";
-import type { HoldingFormValues, MarketMakingFormValues } from "../../../types";
-import { CampaignType } from "../../../types";
+import { FundToken } from '../../../constants/tokens';
+import type { HoldingFormValues, MarketMakingFormValues } from '../../../types';
+import { CampaignType } from '../../../types';
 
 const mapTokenToMinValue: Record<FundToken, number> = {
   usdt: 0.001,
@@ -12,7 +12,10 @@ const mapTokenToMinValue: Record<FundToken, number> = {
 };
 
 const baseValidationSchema = {
-  type: yup.mixed<CampaignType>().oneOf(Object.values(CampaignType)).required('Required'),
+  type: yup
+    .mixed<CampaignType>()
+    .oneOf(Object.values(CampaignType))
+    .required('Required'),
   exchange: yup.string().required('Required'),
   fund_token: yup.string().required('Required'),
   fund_amount: yup
@@ -32,7 +35,7 @@ const baseValidationSchema = {
 
       return true;
     }),
-  start_date: yup.date().required('Required'),  
+  start_date: yup.date().required('Required'),
   end_date: yup
     .date()
     .required('Required')
@@ -50,12 +53,15 @@ const baseValidationSchema = {
         minEndDate.setDate(minEndDate.getDate() + 1);
         return endDate >= minEndDate;
       }
-    ),  
+    ),
 };
 
 export const marketMakingValidationSchema = yup.object({
   ...baseValidationSchema,
-  pair: yup.string().matches(/^[A-Z]{3,10}\/[A-Z]{3,10}$/, 'Invalid pair').required('Required'),
+  pair: yup
+    .string()
+    .matches(/^[\dA-Z]{3,10}\/[\dA-Z]{3,10}$/, 'Invalid pair')
+    .required('Required'),
   daily_volume_target: yup
     .number()
     .typeError('Daily volume target is required')
@@ -65,7 +71,10 @@ export const marketMakingValidationSchema = yup.object({
 
 export const holdingValidationSchema = yup.object({
   ...baseValidationSchema,
-  symbol: yup.string().matches(/^[A-Z]{3,10}$/, 'Invalid symbol').required('Required'),
+  symbol: yup
+    .string()
+    .matches(/^[\dA-Z]{3,10}$/, 'Invalid symbol')
+    .required('Required'),
   daily_balance_target: yup
     .number()
     .typeError('Daily balance target is required')

--- a/campaign-launcher/server/src/modules/campaigns/manifest.utils.ts
+++ b/campaign-launcher/server/src/modules/campaigns/manifest.utils.ts
@@ -26,7 +26,7 @@ const marketMakingManifestSchema = Joi.object({
   exchange: Joi.string().required(),
   daily_volume_target: Joi.number().greater(0).required(),
   pair: Joi.string()
-    .pattern(/^[A-Z]{3,10}\/[A-Z]{3,10}$/)
+    .pattern(/^[\dA-Z]{3,10}\/[\dA-Z]{3,10}$/)
     .required(),
   start_date: Joi.date().iso().required(),
   end_date: Joi.date().iso().greater(Joi.ref('start_date')).required(),
@@ -37,7 +37,7 @@ const holdingManifestSchema = Joi.object({
   exchange: Joi.string().required(),
   daily_balance_target: Joi.number().greater(0).required(),
   symbol: Joi.string()
-    .pattern(/^[A-Z]{3,10}$/)
+    .pattern(/^[\dA-Z]{3,10}$/)
     .required(),
   start_date: Joi.date().iso().required(),
   end_date: Joi.date().iso().greater(Joi.ref('start_date')).required(),

--- a/recording-oracle/src/modules/campaigns/manifest.utils.spec.ts
+++ b/recording-oracle/src/modules/campaigns/manifest.utils.spec.ts
@@ -178,9 +178,22 @@ describe('manifest utils', () => {
   describe('assertValidMarketMakingCampaignManifest', () => {
     const validManifest = generateMarketMakingCampaignManifest();
 
-    it('should not throw for valid manifest', () => {
+    it.each([
+      {
+        ...validManifest,
+      },
+      Object.assign({}, validManifest, {
+        pair: `1${faker.string.alphanumeric({
+          casing: 'upper',
+          length: faker.number.int({ min: 3, max: 8 }),
+        })}2/3${faker.string.alphanumeric({
+          casing: 'upper',
+          length: faker.number.int({ min: 3, max: 8 }),
+        })}4`,
+      }),
+    ])('should not throw for valid manifest [%#]', (testManifest) => {
       expect(
-        manifestUtils.assertValidMarketMakingCampaignManifest(validManifest),
+        manifestUtils.assertValidMarketMakingCampaignManifest(testManifest),
       ).toBeUndefined();
     });
 
@@ -196,6 +209,10 @@ describe('manifest utils', () => {
       // token symbol instead of trading pair
       Object.assign({}, validManifest, {
         pair: faker.finance.currencyCode(),
+      }),
+      // lowercase pair
+      Object.assign({}, validManifest, {
+        pair: generateTradingPair().toLowerCase(),
       }),
       // invalid volume target
       Object.assign({}, validManifest, {
@@ -223,9 +240,17 @@ describe('manifest utils', () => {
   describe('assertValidHoldingCampaignManifest', () => {
     const validManifest = generateHoldingCampaignManifest();
 
-    it('should not throw for valid manifest', () => {
+    it.each([
+      { ...validManifest },
+      Object.assign({}, validManifest, {
+        symbol: `5${faker.string.alphanumeric({
+          casing: 'upper',
+          length: faker.number.int({ min: 3, max: 8 }),
+        })}6`,
+      }),
+    ])('should not throw for valid manifest [%#]', (testManifest) => {
       expect(
-        manifestUtils.assertValidHoldingCampaignManifest(validManifest),
+        manifestUtils.assertValidHoldingCampaignManifest(testManifest),
       ).toBeUndefined();
     });
 
@@ -237,6 +262,10 @@ describe('manifest utils', () => {
       // trading pair instead of token symbol
       Object.assign({}, validManifest, {
         symbol: generateTradingPair(),
+      }),
+      // lowercased symbol
+      Object.assign({}, validManifest, {
+        symbol: faker.finance.currencyCode().toLowerCase(),
       }),
       // invalid balance target
       Object.assign({}, validManifest, {

--- a/recording-oracle/src/modules/campaigns/manifest.utils.ts
+++ b/recording-oracle/src/modules/campaigns/manifest.utils.ts
@@ -47,7 +47,7 @@ export function validateBaseSchema(manifest: string): CampaignManifestBase {
 const marketMakingManifestSchema = baseManifestSchema.keys({
   type: Joi.string().valid(CampaignType.MARKET_MAKING),
   pair: Joi.string()
-    .pattern(/^[A-Z]{3,10}\/[A-Z]{3,10}$/)
+    .pattern(/^[\dA-Z]{3,10}\/[\dA-Z]{3,10}$/)
     .required(),
   daily_volume_target: Joi.number().greater(0).required(),
 });
@@ -64,7 +64,7 @@ export function assertValidMarketMakingCampaignManifest(
 const holdingManifestSchema = baseManifestSchema.keys({
   type: Joi.string().valid(CampaignType.HOLDING),
   symbol: Joi.string()
-    .pattern(/^[A-Z]{3,10}$/)
+    .pattern(/^[\dA-Z]{3,10}$/)
     .required(),
   daily_balance_target: Joi.number().greater(0).required(),
 });


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Found out on UI that we have tokens w/ digit character in it, but our regex accepts only letters. Fixed to accept also digits.
<img width="656" height="190" alt="image" src="https://github.com/user-attachments/assets/5129f40d-e609-4f14-9fdf-cd0a3e941f8c" />


## How has this been tested?
- [x] unit tests

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No