### PR TITLE
[Reputation Oracle] refactor: write calculated rewards as artifacts instead of logs

### DIFF
--- a/.github/workflows/run-reputation-oracle.yaml
+++ b/.github/workflows/run-reputation-oracle.yaml
@@ -116,6 +116,14 @@ jobs:
 
           SUBGRAPH_API_KEY: ${{ secrets.SUBGRAPH_API_KEY }}
 
+      - name: Upload rewards info
+        uses: actions/upload-artifact@v4
+        with:
+          name: rewards-info-${{ github.run_id }}-${{ github.run_attempt }}
+          path: rewards_batch_*.json
+          if-no-files-found: warn
+          overwrite: false
+
       - name: Send action logs to DataDog
         env:
           DD_API_KEY: ${{ secrets.DATADOG_API_KEY }}

--- a/reputation-oracle/.gitignore
+++ b/reputation-oracle/.gitignore
@@ -62,3 +62,5 @@ pids
 *.sublime-workspace
 *.sublime-project
 
+# Application artifacts
+rewards_batch_*.json

--- a/reputation-oracle/src/modules/payouts/payouts.service.spec.ts
+++ b/reputation-oracle/src/modules/payouts/payouts.service.spec.ts
@@ -352,6 +352,7 @@ describe('PayoutsService', () => {
     let spyOnDownloadIntermediateResults: jest.SpyInstance;
     let spyOnUploadFinalResults: jest.SpyInstance;
     let spyOnGetBulkPayoutsCount: jest.SpyInstance;
+    let spyOnWriteRewardsBatchToFile: jest.SpyInstance;
 
     const mockedGetEscrowBalance = jest.fn();
     const mockedGetEscrowStatus = jest.fn();
@@ -385,6 +386,12 @@ describe('PayoutsService', () => {
         'getBulkPayoutsCount',
       );
       spyOnGetBulkPayoutsCount.mockImplementation();
+
+      spyOnWriteRewardsBatchToFile = jest.spyOn(
+        payoutsService as any,
+        'writeRewardsBatchToFile',
+      );
+      spyOnWriteRewardsBatchToFile.mockImplementation();
     });
 
     afterAll(() => {
@@ -392,6 +399,7 @@ describe('PayoutsService', () => {
       spyOnDownloadIntermediateResults.mockRestore();
       spyOnUploadFinalResults.mockRestore();
       spyOnGetBulkPayoutsCount.mockRestore();
+      spyOnWriteRewardsBatchToFile.mockRestore();
     });
 
     beforeEach(() => {

--- a/reputation-oracle/src/modules/payouts/payouts.service.ts
+++ b/reputation-oracle/src/modules/payouts/payouts.service.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import fs from 'fs/promises';
 
 import {
   EscrowClient,
@@ -157,8 +158,13 @@ export class PayoutsService {
               continue;
             }
 
+            const rewardsFileName =
+              await this.writeRewardsBatchToFile(rewardsBatch);
             logger.info('Got new rewards batch to pay', {
               batchId: rewardsBatch.id,
+              rewardsFileName,
+              githubRunId: process.env.GITHUB_RUN_ID,
+              githubRunAttempt: process.env.GITHUB_RUN_ATTEMPT,
             });
 
             rewardsBatchesToPay.push(rewardsBatch);
@@ -436,5 +442,15 @@ export class PayoutsService {
     });
 
     return logs.length;
+  }
+
+  private async writeRewardsBatchToFile(
+    rewardsBatch: CalculatedRewardsBatch,
+  ): Promise<string> {
+    const fileName = `rewards_batch_${rewardsBatch.id}.json`;
+
+    await fs.writeFile(fileName, JSON.stringify(rewardsBatch.rewards, null, 2));
+
+    return fileName;
   }
 }


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Atm we log all calculated rewards. For 10 participants it's ~1Kb for 1 result period and maximum size of a single log in DataDog is 1Mb. Even though we must fit it, it's not necessary to send this info there because we don't need to index/search on this. At the same time we might want to look at it for debug purpose and also want this info to be available in public, so instead of sending it in DD we will be writing it as a GitHub Action artifact that has the same retention period as GitHub Action logs (90 days atm is our default).

## How has this been tested?
- [x] ran locally, verified that file for new rewards batch is written

## Release plan
Merge & check GA run

## Potential risks; What to monitor; Rollback plan
Should be none