### PR TITLE
[Reputation Oracle] fix: GA artifacts path

### DIFF
--- a/.github/workflows/run-reputation-oracle.yaml
+++ b/.github/workflows/run-reputation-oracle.yaml
@@ -120,7 +120,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: rewards-info-${{ github.run_id }}-${{ github.run_attempt }}
-          path: rewards_batch_*.json
+          path: reputation-oracle/rewards_batch_*.json
           if-no-files-found: warn
           overwrite: false
 


### PR DESCRIPTION
## Issue tracking
Follow up to https://github.com/Hu-Fi/hufi/pull/447

## Context behind the change
After testing GA on testnet, it appeared that artifacts aren't uploaded because action can't find files. After digging in, seems that `working-directory` option that we have set for the entire job doesn't apply to `actions/upload-artifact` (it applies only to "run" steps [[ref](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/set-default-values-for-jobs#setting-default-shell-and-working-directory)]), i.e. this action relies only on its `with` section, so changed `path` to reflect that.

## How has this been tested?
Can't test it locally, will need to merge it, rebase to `develop-new-contracts` to get it running on staging and test there again

## Release plan
Merge & test as written above

## Potential risks; What to monitor; Rollback plan
Should be none