### PR TITLE
[Reputation Oracle] fix: use deposit addr network for gate

### DIFF
--- a/recording-oracle/src/modules/exchange/ccxt-exchange-client.spec.ts
+++ b/recording-oracle/src/modules/exchange/ccxt-exchange-client.spec.ts
@@ -212,7 +212,10 @@ describe('CcxtExchangeClient', () => {
         expect(mockedExchange.fetchBalance).toHaveBeenCalledTimes(1);
 
         expect(mockedExchange.fetchDepositAddress).toHaveBeenCalledTimes(1);
-        expect(mockedExchange.fetchDepositAddress).toHaveBeenCalledWith('ETH');
+        expect(mockedExchange.fetchDepositAddress).toHaveBeenCalledWith(
+          'ETH',
+          {},
+        );
       });
 
       it('should return true if has all necessary permissions', async () => {
@@ -416,6 +419,7 @@ describe('CcxtExchangeClient', () => {
         expect(mockedExchange.fetchDepositAddress).toHaveBeenCalledTimes(1);
         expect(mockedExchange.fetchDepositAddress).toHaveBeenCalledWith(
           mockedAddressStructure.currency,
+          {},
         );
       });
 
@@ -440,6 +444,35 @@ describe('CcxtExchangeClient', () => {
           'Api access failed for fetchDepositAddress',
         );
         expect(thrownError.cause).toBe(testError.message);
+      });
+
+      it('shold fetch deposit address info for ERC20 network on gate', async () => {
+        const CCXT_GATE_NAME = 'gate';
+        mockedCcxt[CCXT_GATE_NAME].mockReturnValueOnce(mockedExchange);
+
+        const mockedAddressStructure = generateDepositAddressStructure();
+        mockedExchange.fetchDepositAddress.mockResolvedValueOnce(
+          mockedAddressStructure,
+        );
+
+        ccxtExchangeApiClient = new CcxtExchangeClient(CCXT_GATE_NAME, {
+          apiKey: faker.string.sample(),
+          secret: faker.string.sample(),
+        });
+
+        const address = await ccxtExchangeApiClient.fetchDepositAddress(
+          mockedAddressStructure.currency,
+        );
+
+        expect(address).toEqual(mockedAddressStructure.address);
+
+        expect(mockedExchange.fetchDepositAddress).toHaveBeenCalledTimes(1);
+        expect(mockedExchange.fetchDepositAddress).toHaveBeenCalledWith(
+          mockedAddressStructure.currency,
+          {
+            network: 'ERC20',
+          },
+        );
       });
     });
   });

--- a/recording-oracle/src/modules/exchange/ccxt-exchange-client.ts
+++ b/recording-oracle/src/modules/exchange/ccxt-exchange-client.ts
@@ -173,7 +173,18 @@ export class CcxtExchangeClient implements ExchangeApiClient {
 
   @CatchApiAccessErrors()
   async fetchDepositAddress(symbol: string): Promise<string> {
-    const result = await this.ccxtClient.fetchDepositAddress(symbol);
+    const fetchParams: Record<string, unknown> = {};
+
+    switch (this.exchangeName) {
+      case 'gate': {
+        fetchParams.network = 'ERC20';
+      }
+    }
+
+    const result = await this.ccxtClient.fetchDepositAddress(
+      symbol,
+      fetchParams,
+    );
 
     return result.address;
   }

--- a/recording-oracle/types/ccxt.d.ts
+++ b/recording-oracle/types/ccxt.d.ts
@@ -56,7 +56,10 @@ declare module 'ccxt' {
     fetchBalance(): Promise<AccountBalance>;
     fetchOpenOrders(symbol: string, since: number): Promise<Order[]>;
     fetchMyTrades(symbol: string, since: number): Promise<Trade[]>;
-    fetchDepositAddress(symbol: string): Promise<AddressStructure>;
+    fetchDepositAddress(
+      symbol: string,
+      params?: Record<string, unknown>,
+    ): Promise<AddressStructure>;
   }
 
   const ccxt: {


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
When fetching deposit address for `gate` we have to pass some network param because `ccxt` can't detect a default one.

## How has this been tested?
- [x] unit test

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No