### PR TITLE
[Recording Oracle] fix: flaky ccxt tests

### DIFF
--- a/recording-oracle/src/modules/exchange/ccxt-exchange-client.spec.ts
+++ b/recording-oracle/src/modules/exchange/ccxt-exchange-client.spec.ts
@@ -116,7 +116,11 @@ describe('CcxtExchangeClient', () => {
     let ccxtExchangeApiClient: CcxtExchangeClient;
 
     beforeAll(() => {
-      const exchangeName = generateExchangeName();
+      /**
+       * In some methods we rely on exact exchange name to adjust params,
+       * so for general tests we don't mind, but will override where needed
+       */
+      const exchangeName = faker.lorem.slug();
       mockedCcxt[exchangeName].mockReturnValueOnce(mockedExchange);
 
       ccxtExchangeApiClient = new CcxtExchangeClient(exchangeName, {


### PR DESCRIPTION
## Issue tracking
Follow up to https://github.com/Hu-Fi/hufi/pull/454

## Context behind the change
`generateExchangeName` generates a real exchange name that is valid for `ccxt` and it causes some tests to fail because we adjust params per exchange there, so generate random slug instead.

## How has this been tested?
- [x] `yarn test`

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No