### PR TITLE
chore: bump sdk version

### DIFF
--- a/campaign-launcher/client/package.json
+++ b/campaign-launcher/client/package.json
@@ -18,7 +18,7 @@
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@hookform/resolvers": "^3.3.4",
-    "@human-protocol/sdk": "^5.0.0-beta.3",
+    "@human-protocol/sdk": "^5.0.0",
     "@mui/icons-material": "^6.4.10",
     "@mui/material": "^6.4.10",
     "@mui/x-data-grid": "^7.28.3",

--- a/campaign-launcher/client/yarn.lock
+++ b/campaign-launcher/client/yarn.lock
@@ -787,20 +787,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@human-protocol/core@npm:5.0.0-beta.2":
-  version: 5.0.0-beta.2
-  resolution: "@human-protocol/core@npm:5.0.0-beta.2"
+"@human-protocol/core@npm:5.0.0":
+  version: 5.0.0
+  resolution: "@human-protocol/core@npm:5.0.0"
   peerDependencies:
     ethers: ~6.15.0
-  checksum: 10c0/22fef96bcc9ba0c840b5f336d7f0cc251da1b19ad548c3ade64fd183f9b02c10fdebff02e128972881486cce27e707f6c078065c2ee1ba087b271489c1f799ee
+  checksum: 10c0/2cfb8446fbf35dbbe9a3d453ebb915affd5cd6be4d280bb773a19a9d4363e81989ecfef8651cc8ab90103f33c5265e1f14a2d5fdb7cea5ac079b85b731491dd4
   languageName: node
   linkType: hard
 
-"@human-protocol/sdk@npm:^5.0.0-beta.3":
-  version: 5.0.0-beta.3
-  resolution: "@human-protocol/sdk@npm:5.0.0-beta.3"
+"@human-protocol/sdk@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@human-protocol/sdk@npm:5.0.0"
   dependencies:
-    "@human-protocol/core": "npm:5.0.0-beta.2"
+    "@human-protocol/core": "npm:5.0.0"
     axios: "npm:^1.4.0"
     ethers: "npm:~6.15.0"
     graphql: "npm:^16.8.1"
@@ -811,7 +811,7 @@ __metadata:
     secp256k1: "npm:^5.0.1"
     validator: "npm:^13.12.0"
     vitest: "npm:^3.0.9"
-  checksum: 10c0/145d1874df9c2b91ad41911b175e427aa90cce38c61c114dab65a0ced65ab95f6a1e1456b36a6d6e61bb721ae6d97b04d597ab0cb72d50701668dfb02a9c7321
+  checksum: 10c0/6341ebe1b821cdaba0bd63855ca34c4d75bc498958571fc6507a4d60a1af84df716073de6e53faa9c4f5095e1596775b2ec7b7b51e61df32510e6e76da09a78c
   languageName: node
   linkType: hard
 
@@ -3895,7 +3895,7 @@ __metadata:
     "@emotion/styled": "npm:^11.11.5"
     "@eslint/js": "npm:^9.37.0"
     "@hookform/resolvers": "npm:^3.3.4"
-    "@human-protocol/sdk": "npm:^5.0.0-beta.3"
+    "@human-protocol/sdk": "npm:^5.0.0"
     "@mui/icons-material": "npm:^6.4.10"
     "@mui/material": "npm:^6.4.10"
     "@mui/x-data-grid": "npm:^7.28.3"

--- a/campaign-launcher/server/package.json
+++ b/campaign-launcher/server/package.json
@@ -21,9 +21,8 @@
     "test:e2e": "jest --config ./test/e2e/jest.config.json"
   },
   "dependencies": {
-    "@human-protocol/core": "^4.2.0",
     "@human-protocol/logger": "^1.1.0",
-    "@human-protocol/sdk": "^5.0.0-beta.3",
+    "@human-protocol/sdk": "^5.0.0",
     "@nestjs/common": "^11.1.5",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.5",

--- a/campaign-launcher/server/yarn.lock
+++ b/campaign-launcher/server/yarn.lock
@@ -1199,21 +1199,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@human-protocol/core@npm:5.0.0-beta.2":
-  version: 5.0.0-beta.2
-  resolution: "@human-protocol/core@npm:5.0.0-beta.2"
+"@human-protocol/core@npm:5.0.0":
+  version: 5.0.0
+  resolution: "@human-protocol/core@npm:5.0.0"
   peerDependencies:
     ethers: ~6.15.0
-  checksum: 10c0/22fef96bcc9ba0c840b5f336d7f0cc251da1b19ad548c3ade64fd183f9b02c10fdebff02e128972881486cce27e707f6c078065c2ee1ba087b271489c1f799ee
-  languageName: node
-  linkType: hard
-
-"@human-protocol/core@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@human-protocol/core@npm:4.2.0"
-  peerDependencies:
-    ethers: ~6.13.5
-  checksum: 10c0/af433d47dfd85c639043ee69b6ac7e5f3d66db67fd9c6111477d24832fb25602b6be3c01c1c9203104a0cd635429ac1f47a35c9374fec9a955abf405e473298c
+  checksum: 10c0/2cfb8446fbf35dbbe9a3d453ebb915affd5cd6be4d280bb773a19a9d4363e81989ecfef8651cc8ab90103f33c5265e1f14a2d5fdb7cea5ac079b85b731491dd4
   languageName: node
   linkType: hard
 
@@ -1229,11 +1220,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@human-protocol/sdk@npm:^5.0.0-beta.3":
-  version: 5.0.0-beta.3
-  resolution: "@human-protocol/sdk@npm:5.0.0-beta.3"
+"@human-protocol/sdk@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@human-protocol/sdk@npm:5.0.0"
   dependencies:
-    "@human-protocol/core": "npm:5.0.0-beta.2"
+    "@human-protocol/core": "npm:5.0.0"
     axios: "npm:^1.4.0"
     ethers: "npm:~6.15.0"
     graphql: "npm:^16.8.1"
@@ -1244,7 +1235,7 @@ __metadata:
     secp256k1: "npm:^5.0.1"
     validator: "npm:^13.12.0"
     vitest: "npm:^3.0.9"
-  checksum: 10c0/145d1874df9c2b91ad41911b175e427aa90cce38c61c114dab65a0ced65ab95f6a1e1456b36a6d6e61bb721ae6d97b04d597ab0cb72d50701668dfb02a9c7321
+  checksum: 10c0/6341ebe1b821cdaba0bd63855ca34c4d75bc498958571fc6507a4d60a1af84df716073de6e53faa9c4f5095e1596775b2ec7b7b51e61df32510e6e76da09a78c
   languageName: node
   linkType: hard
 
@@ -4358,9 +4349,8 @@ __metadata:
     "@eslint/js": "npm:^9.31.0"
     "@faker-js/faker": "npm:^9.9.0"
     "@golevelup/ts-jest": "npm:^0.7.0"
-    "@human-protocol/core": "npm:^4.2.0"
     "@human-protocol/logger": "npm:^1.1.0"
-    "@human-protocol/sdk": "npm:^5.0.0-beta.3"
+    "@human-protocol/sdk": "npm:^5.0.0"
     "@nestjs/cli": "npm:^11.0.7"
     "@nestjs/common": "npm:^11.1.5"
     "@nestjs/config": "npm:^4.0.2"

--- a/recording-oracle/package.json
+++ b/recording-oracle/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@human-protocol/logger": "^1.1.0",
-    "@human-protocol/sdk": "^5.0.0-beta.3",
+    "@human-protocol/sdk": "^5.0.0",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",

--- a/recording-oracle/yarn.lock
+++ b/recording-oracle/yarn.lock
@@ -1199,12 +1199,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@human-protocol/core@npm:5.0.0-beta.2":
-  version: 5.0.0-beta.2
-  resolution: "@human-protocol/core@npm:5.0.0-beta.2"
+"@human-protocol/core@npm:5.0.0":
+  version: 5.0.0
+  resolution: "@human-protocol/core@npm:5.0.0"
   peerDependencies:
     ethers: ~6.15.0
-  checksum: 10c0/22fef96bcc9ba0c840b5f336d7f0cc251da1b19ad548c3ade64fd183f9b02c10fdebff02e128972881486cce27e707f6c078065c2ee1ba087b271489c1f799ee
+  checksum: 10c0/2cfb8446fbf35dbbe9a3d453ebb915affd5cd6be4d280bb773a19a9d4363e81989ecfef8651cc8ab90103f33c5265e1f14a2d5fdb7cea5ac079b85b731491dd4
   languageName: node
   linkType: hard
 
@@ -1220,11 +1220,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@human-protocol/sdk@npm:^5.0.0-beta.3":
-  version: 5.0.0-beta.3
-  resolution: "@human-protocol/sdk@npm:5.0.0-beta.3"
+"@human-protocol/sdk@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@human-protocol/sdk@npm:5.0.0"
   dependencies:
-    "@human-protocol/core": "npm:5.0.0-beta.2"
+    "@human-protocol/core": "npm:5.0.0"
     axios: "npm:^1.4.0"
     ethers: "npm:~6.15.0"
     graphql: "npm:^16.8.1"
@@ -1235,7 +1235,7 @@ __metadata:
     secp256k1: "npm:^5.0.1"
     validator: "npm:^13.12.0"
     vitest: "npm:^3.0.9"
-  checksum: 10c0/145d1874df9c2b91ad41911b175e427aa90cce38c61c114dab65a0ced65ab95f6a1e1456b36a6d6e61bb721ae6d97b04d597ab0cb72d50701668dfb02a9c7321
+  checksum: 10c0/6341ebe1b821cdaba0bd63855ca34c4d75bc498958571fc6507a4d60a1af84df716073de6e53faa9c4f5095e1596775b2ec7b7b51e61df32510e6e76da09a78c
   languageName: node
   linkType: hard
 
@@ -9666,7 +9666,7 @@ __metadata:
     "@faker-js/faker": "npm:^9.8.0"
     "@golevelup/ts-jest": "npm:^0.7.0"
     "@human-protocol/logger": "npm:^1.1.0"
-    "@human-protocol/sdk": "npm:^5.0.0-beta.3"
+    "@human-protocol/sdk": "npm:^5.0.0"
     "@nestjs/cli": "npm:^11.0.0"
     "@nestjs/common": "npm:^11.0.1"
     "@nestjs/config": "npm:^4.0.2"

--- a/reputation-oracle/package.json
+++ b/reputation-oracle/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@human-protocol/logger": "^1.1.0",
-    "@human-protocol/sdk": "^5.0.0-beta.3",
+    "@human-protocol/sdk": "^5.0.0",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",

--- a/reputation-oracle/yarn.lock
+++ b/reputation-oracle/yarn.lock
@@ -804,12 +804,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@human-protocol/core@npm:5.0.0-beta.2":
-  version: 5.0.0-beta.2
-  resolution: "@human-protocol/core@npm:5.0.0-beta.2"
+"@human-protocol/core@npm:5.0.0":
+  version: 5.0.0
+  resolution: "@human-protocol/core@npm:5.0.0"
   peerDependencies:
     ethers: ~6.15.0
-  checksum: 10c0/22fef96bcc9ba0c840b5f336d7f0cc251da1b19ad548c3ade64fd183f9b02c10fdebff02e128972881486cce27e707f6c078065c2ee1ba087b271489c1f799ee
+  checksum: 10c0/2cfb8446fbf35dbbe9a3d453ebb915affd5cd6be4d280bb773a19a9d4363e81989ecfef8651cc8ab90103f33c5265e1f14a2d5fdb7cea5ac079b85b731491dd4
   languageName: node
   linkType: hard
 
@@ -825,11 +825,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@human-protocol/sdk@npm:^5.0.0-beta.3":
-  version: 5.0.0-beta.3
-  resolution: "@human-protocol/sdk@npm:5.0.0-beta.3"
+"@human-protocol/sdk@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@human-protocol/sdk@npm:5.0.0"
   dependencies:
-    "@human-protocol/core": "npm:5.0.0-beta.2"
+    "@human-protocol/core": "npm:5.0.0"
     axios: "npm:^1.4.0"
     ethers: "npm:~6.15.0"
     graphql: "npm:^16.8.1"
@@ -840,7 +840,7 @@ __metadata:
     secp256k1: "npm:^5.0.1"
     validator: "npm:^13.12.0"
     vitest: "npm:^3.0.9"
-  checksum: 10c0/145d1874df9c2b91ad41911b175e427aa90cce38c61c114dab65a0ced65ab95f6a1e1456b36a6d6e61bb721ae6d97b04d597ab0cb72d50701668dfb02a9c7321
+  checksum: 10c0/6341ebe1b821cdaba0bd63855ca34c4d75bc498958571fc6507a4d60a1af84df716073de6e53faa9c4f5095e1596775b2ec7b7b51e61df32510e6e76da09a78c
   languageName: node
   linkType: hard
 
@@ -7692,7 +7692,7 @@ __metadata:
     "@faker-js/faker": "npm:^9.9.0"
     "@golevelup/ts-jest": "npm:^0.7.0"
     "@human-protocol/logger": "npm:^1.1.0"
-    "@human-protocol/sdk": "npm:^5.0.0-beta.3"
+    "@human-protocol/sdk": "npm:^5.0.0"
     "@nestjs/cli": "npm:^11.0.0"
     "@nestjs/common": "npm:^11.0.1"
     "@nestjs/config": "npm:^4.0.2"


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Bumping sdk to latest in order to get updated subgraph ids for mainnet.

## How has this been tested?
- [x] run services locally

## Release plan
Together with contracts upgrade

## Potential risks; What to monitor; Rollback plan
Should be none