### PR TITLE
[Campaign Launcher Client] Allow values less than a 1 for `minimum_balance_target` field

### DIFF
--- a/campaign-launcher/client/src/components/modals/CreateCampaignModal/validation.ts
+++ b/campaign-launcher/client/src/components/modals/CreateCampaignModal/validation.ts
@@ -95,10 +95,7 @@ export const thresholdValidationSchema = yup.object({
   minimum_balance_target: yup
     .number()
     .typeError('Minimum balance target is required')
-    .min(
-      0.000001,
-      'Minimum balance target must be greater than or equal to 0.000001'
-    )
+    .min(0.001, 'Minimum balance target must be greater than or equal to 0.001')
     .required('Minimum balance target is required'),
 }) as ObjectSchema<ThresholdFormValues>;
 


### PR DESCRIPTION
## Issue tracking
<!--
  Where is the progress of this issue being tracked?
  Where can one find the requirements for this issue?
  Where did this issue originated from?

  E.g. GitHub issue, Slack message, etc.
-->
Freestyle
## Context behind the change
<!--
  What changes have you made to the code, and why?

  Describe the goal of this pull request. What does it change or fix?
  At a high level, what parts of the code did you change and why?
-->
Allow `minimum_balance_target` to be less a 0 (min 0.001) because some of the tokens has a huge price which might result in impossible target.
## How has this been tested?
<!--
  You should always test your changes.

  Describe the steps you took to make sure your PR does what it's supposed to do.
  How we ensure that adjacent code/features are still working?
  Are there any performance implications?
-->
Locally
## Release plan
<!--
  If not you, but somebody else will be deploying this, what they need to know/do to succeed?

  Add any action items that need to be done for the release (any step, before/during/after),
  e.g. running a DB migration, leaving a note about release in Slack, adding new envs, etc.
-->
N/A
## Potential risks; What to monitor; Rollback plan
<!--
  What might go wrong with deployment of this PR?
  Can it affect some other services/areas? In what way?
  What metrics/dashboards/etc. you should keep an eye on while/after deploying this?
 
  How will we handle any issues if they arise? Do we need rollback plan?
  Do we need a second pair of eyes on this?
-->
N/A