### PR TITLE
fix: use bulkTransferV3 from contract

### DIFF
--- a/reputation-oracle/src/modules/payouts/payouts.service.ts
+++ b/reputation-oracle/src/modules/payouts/payouts.service.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import fs from 'fs/promises';
 
+import EscrowABI from '@human-protocol/core/abis/Escrow.json';
 import {
   EscrowClient,
   EscrowStatus,
@@ -480,31 +481,15 @@ export class PayoutsService {
       })
     )[0];
 
-    const bulkInterfaceV3 = new ethers.Interface([
-      'event BulkTransferV3(bytes32 indexed payoutId, address[] recipients, uint256[] amounts, bool isPartial, string finalResultsUrl)',
-    ]);
+    const bulkInterfaceV3 = new ethers.Interface(EscrowABI);
     const topicV3 = bulkInterfaceV3.getEvent('BulkTransferV3')!.topicHash;
 
-    let logs = await signer.provider.getLogs({
+    const logs = await signer.provider.getLogs({
       address: escrowAddress,
       topics: [topicV3],
       fromBlock: block,
       toBlock: 'latest',
     });
-
-    if (logs.length === 0) {
-      const bulkInterfaceV2 = new ethers.Interface([
-        'event BulkTransferV2(uint256 indexed _txId, address[] _recipients, uint256[] _amounts, bool _isPartial, string finalResultsUrl)',
-      ]);
-      const topicV2 = bulkInterfaceV2.getEvent('BulkTransferV2')!.topicHash;
-
-      logs = await signer.provider.getLogs({
-        address: escrowAddress,
-        topics: [topicV2],
-        fromBlock: block,
-        toBlock: 'latest',
-      });
-    }
 
     return logs.length;
   }


### PR DESCRIPTION
## Issue tracking
#489 

## Context behind the change
Update in `BulkTransferV3` event signature was missed during new contracts update development. To fix it and avoid such situation in the future - change the approach on using ABI from contracts package instead of hardcoding it.

## How has this been tested?
- [x] run `getBulkPayoutsCount` in a separate script for real contract, make sure it returns correct logs count

## Release plan
Merge & monitor

## Potential risks; What to monitor; Rollback plan
Should be none