### PR TITLE
[Campaign Launcher UI] fix: authed queries invalidation

### DIFF
--- a/campaign-launcher/client/src/hooks/recording-oracle/campaign.ts
+++ b/campaign-launcher/client/src/hooks/recording-oracle/campaign.ts
@@ -20,13 +20,13 @@ export const useGetJoinedCampaigns = (params: JoinedCampaignsParams = {}) => {
 
   return useQuery({
     queryKey: [
-      AUTHED_QUERY_TAG,
       QUERY_KEYS.JOINED_CAMPAIGNS,
       isAuthenticated,
       !!signer,
       status,
       limit,
       skip,
+      AUTHED_QUERY_TAG,
     ],
     queryFn: () => recordingApi.getJoinedCampaigns(params),
     select: (data) => ({
@@ -68,11 +68,11 @@ export const useCheckCampaignJoinStatus = (address: EvmAddress) => {
 
   return useQuery({
     queryKey: [
-      AUTHED_QUERY_TAG,
       QUERY_KEYS.CHECK_CAMPAIGN_JOIN_STATUS,
       appChainId,
       address,
       isAuthenticated,
+      AUTHED_QUERY_TAG,
     ],
     queryFn: () => recordingApi.checkCampaignJoinStatus(appChainId, address),
     select: (data) => data.status,

--- a/campaign-launcher/client/src/hooks/recording-oracle/exchangeApiKeys.ts
+++ b/campaign-launcher/client/src/hooks/recording-oracle/exchangeApiKeys.ts
@@ -10,7 +10,7 @@ export const useGetEnrolledExchanges = () => {
   const { isConnected } = useAccount();
 
   return useQuery({
-    queryKey: [AUTHED_QUERY_TAG, QUERY_KEYS.ENROLLED_EXCHANGES],
+    queryKey: [QUERY_KEYS.ENROLLED_EXCHANGES, AUTHED_QUERY_TAG],
     queryFn: () => recordingApi.getEnrolledExchanges(),
     enabled: isAuthenticated && isConnected,
   });
@@ -21,7 +21,7 @@ export const useGetExchangesWithApiKeys = () => {
   const { isConnected } = useAccount();
 
   return useQuery({
-    queryKey: [AUTHED_QUERY_TAG, QUERY_KEYS.EXCHANGES_WITH_API_KEYS],
+    queryKey: [QUERY_KEYS.EXCHANGES_WITH_API_KEYS, AUTHED_QUERY_TAG],
     queryFn: () => recordingApi.getExchangesWithApiKeys(),
     enabled: isAuthenticated && isConnected,
   });

--- a/campaign-launcher/client/src/hooks/recording-oracle/user.ts
+++ b/campaign-launcher/client/src/hooks/recording-oracle/user.ts
@@ -9,7 +9,7 @@ export const useGetUserProgress = (address: EvmAddress) => {
   const { appChainId } = useNetwork();
 
   return useQuery({
-    queryKey: [AUTHED_QUERY_TAG, QUERY_KEYS.USER_PROGRESS, appChainId, address],
+    queryKey: [QUERY_KEYS.USER_PROGRESS, appChainId, address, AUTHED_QUERY_TAG],
     queryFn: () => recordingApi.getUserProgress(appChainId, address),
     enabled: !!appChainId && !!address,
   });

--- a/campaign-launcher/client/src/providers/Web3AuthProvider.tsx
+++ b/campaign-launcher/client/src/providers/Web3AuthProvider.tsx
@@ -51,7 +51,7 @@ export const Web3AuthProvider: FC<PropsWithChildren> = ({ children }) => {
       if (!_isAuthenticated) {
         tokenManager.clearTokens();
         queryClient.removeQueries({
-          queryKey: [AUTHED_QUERY_TAG],
+          predicate: (query) => query.queryKey.includes(AUTHED_QUERY_TAG),
         });
       }
     },


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
After recent update where we invalidate authed queries, invalidation of these queries by their name got broken because `react-query` uses exact-match for `queryKey` param. Use `predicate` matcher instead to invalidate authed queries and keep query name on the first place to keep using it in simple way.

To avoid such issues in the future, would be good to have some sort of "query key builder" methods that are used here and there.

## How has this been tested?
- [x] locally e2e: sign in as new user and make sure queries of previous user invalidated
- [x] locally e2e: login or join campaign, make sure tables and campaign info updated

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No