### PR TITLE
[Reputation Oracle] fix: zero score validation

### DIFF
--- a/reputation-oracle/src/modules/payouts/payouts.utils.ts
+++ b/reputation-oracle/src/modules/payouts/payouts.utils.ts
@@ -7,7 +7,7 @@ import { BaseCampaignManifest, IntermediateResultsData } from './types';
 
 const participantOutcome = Joi.object({
   address: Joi.string().required(),
-  score: Joi.number().strict().positive().required(),
+  score: Joi.number().strict().min(0).required(),
 });
 
 const participantsOutcomesBatchSchema = Joi.object({


### PR DESCRIPTION
## Issue tracking
N/A
Found via DD alerts

## Context behind the change
Bug introduced in https://github.com/Hu-Fi/hufi/pull/504
Score can be 0, so with `positive` validation fails. Fixed by using `min(0)`;

## How has this been tested?
- [x] unit test for this case 

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No