### PR TITLE
[Recording Oracle] feat: xt dep addr network

### DIFF
--- a/recording-oracle/src/modules/exchanges/api-client/ccxt-exchange-client.spec.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/ccxt-exchange-client.spec.ts
@@ -76,6 +76,7 @@ describe('CcxtExchangeClient', () => {
         new CcxtExchangeClient(exchangeName, {
           apiKey: faker.string.sample(),
           secret: faker.string.sample(),
+          userId: faker.string.uuid(),
         });
       } catch (error) {
         thrownError = error;
@@ -419,6 +420,7 @@ describe('CcxtExchangeClient', () => {
             mexcClient = new CcxtExchangeClient(exchangeName, {
               apiKey: faker.string.sample(),
               secret: faker.string.sample(),
+              userId: faker.string.uuid(),
             });
           });
 
@@ -458,6 +460,7 @@ describe('CcxtExchangeClient', () => {
             const exchangeClient = new CcxtExchangeClient(randomExchange, {
               apiKey: faker.string.sample(),
               secret: faker.string.sample(),
+              userId: faker.string.uuid(),
             });
 
             const nonMexcError = new Error(
@@ -559,6 +562,7 @@ describe('CcxtExchangeClient', () => {
             mexcClient = new CcxtExchangeClient(exchangeName, {
               apiKey: faker.string.sample(),
               secret: faker.string.sample(),
+              userId: faker.string.uuid(),
             });
           });
 
@@ -598,6 +602,7 @@ describe('CcxtExchangeClient', () => {
             const exchangeClient = new CcxtExchangeClient(randomExchange, {
               apiKey: faker.string.sample(),
               secret: faker.string.sample(),
+              userId: faker.string.uuid(),
             });
 
             const nonMexcError = new Error(
@@ -665,6 +670,7 @@ describe('CcxtExchangeClient', () => {
             mexcClient = new CcxtExchangeClient(exchangeName, {
               apiKey: faker.string.sample(),
               secret: faker.string.sample(),
+              userId: faker.string.uuid(),
             });
           });
 
@@ -701,6 +707,7 @@ describe('CcxtExchangeClient', () => {
             const exchangeClient = new CcxtExchangeClient(randomExchange, {
               apiKey: faker.string.sample(),
               secret: faker.string.sample(),
+              userId: faker.string.uuid(),
             });
 
             const nonMexcError = new Error(
@@ -776,6 +783,7 @@ describe('CcxtExchangeClient', () => {
             mexcClient = new CcxtExchangeClient(exchangeName, {
               apiKey: faker.string.sample(),
               secret: faker.string.sample(),
+              userId: faker.string.uuid(),
             });
           });
 
@@ -814,6 +822,7 @@ describe('CcxtExchangeClient', () => {
             const exchangeClient = new CcxtExchangeClient(randomExchange, {
               apiKey: faker.string.sample(),
               secret: faker.string.sample(),
+              userId: faker.string.uuid(),
             });
 
             const nonMexcError = new Error(
@@ -837,18 +846,19 @@ describe('CcxtExchangeClient', () => {
         });
       });
 
-      it('shold fetch deposit address info for ERC20 network on gate', async () => {
-        const CCXT_GATE_NAME = 'gate';
-        mockedCcxt[CCXT_GATE_NAME].mockReturnValueOnce(mockedExchange);
+      it('should fetch deposit address info for ERC20 network on gate', async () => {
+        const GATE_EXCHANGE_NAME = 'gate';
+        mockedCcxt[GATE_EXCHANGE_NAME].mockReturnValueOnce(mockedExchange);
 
         const mockedAddressStructure = generateDepositAddressStructure();
         mockedExchange.fetchDepositAddress.mockResolvedValueOnce(
           mockedAddressStructure,
         );
 
-        ccxtExchangeApiClient = new CcxtExchangeClient(CCXT_GATE_NAME, {
+        ccxtExchangeApiClient = new CcxtExchangeClient(GATE_EXCHANGE_NAME, {
           apiKey: faker.string.sample(),
           secret: faker.string.sample(),
+          userId: faker.string.uuid(),
         });
 
         const address = await ccxtExchangeApiClient.fetchDepositAddress(
@@ -862,6 +872,36 @@ describe('CcxtExchangeClient', () => {
           mockedAddressStructure.currency,
           {
             network: 'ERC20',
+          },
+        );
+      });
+
+      it('should fetch deposit address info for ETH network on xt', async () => {
+        const XT_EXCHANGE_NAME = 'xt';
+        mockedCcxt[XT_EXCHANGE_NAME].mockReturnValueOnce(mockedExchange);
+
+        const mockedAddressStructure = generateDepositAddressStructure();
+        mockedExchange.fetchDepositAddress.mockResolvedValueOnce(
+          mockedAddressStructure,
+        );
+
+        ccxtExchangeApiClient = new CcxtExchangeClient(XT_EXCHANGE_NAME, {
+          apiKey: faker.string.sample(),
+          secret: faker.string.sample(),
+          userId: faker.string.uuid(),
+        });
+
+        const address = await ccxtExchangeApiClient.fetchDepositAddress(
+          mockedAddressStructure.currency,
+        );
+
+        expect(address).toEqual(mockedAddressStructure.address);
+
+        expect(mockedExchange.fetchDepositAddress).toHaveBeenCalledTimes(1);
+        expect(mockedExchange.fetchDepositAddress).toHaveBeenCalledWith(
+          mockedAddressStructure.currency,
+          {
+            network: 'ETH',
           },
         );
       });

--- a/recording-oracle/src/modules/exchanges/api-client/ccxt-exchange-client.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/ccxt-exchange-client.ts
@@ -194,6 +194,7 @@ export class CcxtExchangeClient implements ExchangeApiClient {
   private ccxtClient: Exchange;
   readonly sandbox: boolean;
   readonly userId: string;
+  readonly exchangeName: SupportedExchange;
 
   protected logger: Logger;
   protected loggingConfig: ExchangeApiClientLoggingConfig = {
@@ -201,7 +202,7 @@ export class CcxtExchangeClient implements ExchangeApiClient {
   };
 
   constructor(
-    readonly exchangeName: string,
+    exchangeName: string,
     {
       apiKey,
       secret,
@@ -214,7 +215,11 @@ export class CcxtExchangeClient implements ExchangeApiClient {
     if (!(exchangeName in ccxt)) {
       throw new Error(`Exchange not supported: ${exchangeName}`);
     }
+    if (!userId) {
+      throw new Error('userId is missing');
+    }
 
+    this.exchangeName = exchangeName as SupportedExchange;
     this.userId = userId;
 
     const exchangeClass = ccxt[exchangeName];
@@ -359,6 +364,10 @@ export class CcxtExchangeClient implements ExchangeApiClient {
     switch (this.exchangeName) {
       case 'gate': {
         fetchParams.network = 'ERC20';
+        break;
+      }
+      case 'xt': {
+        fetchParams.network = 'ETH';
         break;
       }
       case 'bybit': {

--- a/recording-oracle/src/modules/exchanges/fixtures/exchange.ts
+++ b/recording-oracle/src/modules/exchanges/fixtures/exchange.ts
@@ -1,8 +1,11 @@
 import { faker } from '@faker-js/faker';
 
-import { SUPPORTED_EXCHANGE_NAMES } from '@/common/constants';
+import {
+  SUPPORTED_EXCHANGE_NAMES,
+  SupportedExchange,
+} from '@/common/constants';
 
-export function generateExchangeName() {
+export function generateExchangeName(): SupportedExchange {
   return faker.helpers.arrayElement(SUPPORTED_EXCHANGE_NAMES);
 }
 


### PR DESCRIPTION
## Issue tracking
Freestyle

## Context behind the change
Add hardcoded network param for `xt` to fetch deposit address since it's required and no default in ccxt.

## How has this been tested?
- [x] in local script
- [x] unit tests

## Release plan
Regular

## Potential risks; What to monitor; Rollback plan
No