### PR TITLE
chore: change dependabot bot config for direct deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
       - "/reputation-oracle"
     schedule:
       interval: "weekly"
+    allow:
+      - dependency-type: "direct"
     target-branch: "develop"
     # Grouping minor and patch updates to 1 PR to reduce the noise:
     # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#example-3-individual-pull-requests-for-major-updates-and-grouped-for-minorpatch-updates


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Right now dependabot is configure to update all dependencies, including `indirect`, i.e. packages/subdeps that are not mentioned in `package.json` but only in `yarn.lock`. It creates unnecessary noise and might lead to unintentional bump of packages with security issues. We should rely only on direct deps instead.

## How has this been tested?
N/A

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
N/A