### PR TITLE
chore: add config for security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     
     # Even though we use yarn, according to the documentation, value should be 'npm': 
     # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem-
+    # Regular dependency updates
   - package-ecosystem: "npm" 
     directories:
       - "/campaign-launcher/client"
@@ -31,3 +32,17 @@ updates:
           - "minor"
           - "patch"
     open-pull-requests-limit: 5 # Reasonable number to start with
+
+    # Security dependency updates
+  - package-ecosystem: npm
+    security-updates-only: true
+    directories:
+      - "/campaign-launcher/client"
+      - "/campaign-launcher/server"
+      - "/recording-oracle"
+      - "/reputation-oracle"
+    schedule:
+      interval: daily
+    allow:
+      - dependency-type: "all"
+    target-branch: "develop"


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Security-updates are targeting default repo branch, which is `main` in our case, but we would like to preserve regular flow.

## How has this been tested?
N/A

## Release plan
1. Merge this PR to main
2. Disable security updates on settings config

## Potential risks; What to monitor; Rollback plan
Config might not be optimal or not respect `target-branch` for security udpates