### PR TITLE
[Reputation Oracle] fix: use createEscrow event

### DIFF
--- a/reputation-oracle/src/modules/payouts/payouts.service.ts
+++ b/reputation-oracle/src/modules/payouts/payouts.service.ts
@@ -480,7 +480,7 @@ export class PayoutsService {
       await TransactionUtils.getTransactions({
         chainId: chainId as number,
         escrow: escrowAddress,
-        method: 'setup',
+        method: 'createEscrow',
       })
     )[0];
 


### PR DESCRIPTION
## Issue tracking
Freestyle

## Context behind the change
After we started to launch campaigns using `createFundAndSetupEscrow` method, there is no `setup` transaction recorded due to bug in HUMAN Protocol subgraph. Use `createEscrow` tx instead.

## How has this been tested?
- [x] verified that stuck campaigns have `createEscrow` tx via local toolkit call

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No