### PR TITLE
chore: ignore jest major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,13 @@ updates:
     # instead of increasing them all
     versioning-strategy: increase-if-necessary
     target-branch: "develop"
+    ignore:
+        # Ignore versions of Jest and related packages that are equal to
+        # or greater than 30.0.0 because it introduces module system change
+        # and it must be updated together with some other packages (nest, ts-jest, etc.)
+        # including some extra configuration changes
+      - dependency-name: "*jest*"
+        versions: [">=30.0.0"]
     # Grouping minor and patch updates to 1 PR to reduce the noise:
     # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#example-3-individual-pull-requests-for-major-updates-and-grouped-for-minorpatch-updates
     groups:


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Jest 30 should be adopted correctly w/ all adjacent packages and might require big refactoring on module part, so should be done separately and planned.
Rel: https://github.com/Hu-Fi/hufi/issues/638

## How has this been tested?
N/A

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No