### PR TITLE
[Recording Oracle] fix: progress cache caller name

### DIFF
--- a/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
@@ -1422,7 +1422,8 @@ describe('CampaignsService', () => {
         expect(logger.child).toHaveBeenCalledTimes(1);
         expect(logger.child).toHaveBeenCalledWith({
           action: 'checkCampaignProgressForPeriod',
-          caller: 'Object.<anonymous>',
+          caller: 'unknown',
+          debugCaller: 'Object.<anonymous>',
           campaignId: campaign.id,
           chainId: campaign.chainId,
           campaignAddress: campaign.address,
@@ -2015,7 +2016,7 @@ describe('CampaignsService', () => {
         campaign,
         expectedStartDate,
         expectedEndDate,
-        { logWarnings: true },
+        { logWarnings: true, caller: 'recordCampaignProgress' },
       );
     });
 
@@ -2032,7 +2033,7 @@ describe('CampaignsService', () => {
         campaign,
         expectedStartDate,
         expectedEndDate,
-        { logWarnings: true },
+        { logWarnings: true, caller: 'recordCampaignProgress' },
       );
     });
 
@@ -2082,7 +2083,7 @@ describe('CampaignsService', () => {
         campaign,
         expectedStartDate,
         expectedEndDate,
-        { logWarnings: true },
+        { logWarnings: true, caller: 'recordCampaignProgress' },
       );
     });
 
@@ -2116,7 +2117,7 @@ describe('CampaignsService', () => {
         campaign,
         expectedStartDate,
         expectedEndDate,
-        { logWarnings: true },
+        { logWarnings: true, caller: 'recordCampaignProgress' },
       );
     });
 
@@ -2134,7 +2135,7 @@ describe('CampaignsService', () => {
         campaign,
         campaign.startDate,
         campaign.endDate,
-        { logWarnings: true },
+        { logWarnings: true, caller: 'recordCampaignProgress' },
       );
     });
 
@@ -2153,7 +2154,7 @@ describe('CampaignsService', () => {
         campaign,
         campaign.startDate,
         cancellationRequestedAt,
-        { logWarnings: true },
+        { logWarnings: true, caller: 'recordCampaignProgress' },
       );
     });
 
@@ -3363,6 +3364,9 @@ describe('CampaignsService', () => {
           campaign,
           mockedActiveTimeframe.start,
           mockedActiveTimeframe.end,
+          {
+            caller: 'refreshInterimProgressCache',
+          },
         );
         await expect(
           campaignsCache.getInterimProgress(campaign.id),

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -605,7 +605,7 @@ export class CampaignsService implements OnModuleDestroy {
             campaign,
             startDate,
             endDate,
-            { logWarnings: true },
+            { logWarnings: true, caller: this.recordCampaignProgress.name },
           );
 
           let progressValueTarget: number;
@@ -719,15 +719,22 @@ export class CampaignsService implements OnModuleDestroy {
     campaign: CampaignEntity,
     startDate: Date,
     endDate: Date,
-    options: { logWarnings?: boolean } = {},
+    options: { logWarnings?: boolean; caller?: string } = {},
   ): Promise<CampaignProgress<CampaignProgressMeta>> {
     if (dayjs(startDate).isAfter(endDate)) {
       throw new Error('Invalid period range provided');
     }
 
+    const callerMeta: {
+      caller: string;
+      debugCaller?: string;
+    } = options.caller
+      ? { caller: options.caller }
+      : { caller: 'unknown', debugCaller: debugUtils.getCaller() };
+
     const logger = this.logger.child({
       action: 'checkCampaignProgressForPeriod',
-      caller: debugUtils.getCaller(),
+      ...callerMeta,
       campaignId: campaign.id,
       chainId: campaign.chainId,
       campaignAddress: campaign.address,
@@ -1350,6 +1357,9 @@ export class CampaignsService implements OnModuleDestroy {
                 campaign,
                 timeframe.start,
                 timeframe.end,
+                {
+                  caller: this.refreshInterimProgressCache.name,
+                },
               );
               await this.campaignsCache.setInterimProgress(
                 campaign.id,


### PR DESCRIPTION
## Issue tracking
No

## Context behind the change
We have a `caller` property logged with debug tools atm, but when you build the app and run it - anonymous functions lose their `Object.<anonymous>` caller name and defined as path to the code line. Taking into account that we are going to use progress check log for metric, having `caller` as code path not meaningful, so in order to use it as a human-readable metric dimension we change the approach a bit to explicitly pass caller name and use debug tools only if it's missing.

## How has this been tested?
- [x] unit tests
- [x] `yarn build` & `yarn start:prod` locally; make sure that `refreshInterimProgressCache` logged as caller when runs 

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No