### PR TITLE
[Campaign Launcher UI] Pop-up with information about invalid API Keys during signin

### DIFF
--- a/campaign-launcher/client/src/App.tsx
+++ b/campaign-launcher/client/src/App.tsx
@@ -25,17 +25,17 @@ const App: FC = () => {
     <WagmiProvider>
       <QueryClientProvider>
         <ThemeProvider>
-          <NotificationProvider>
-            <NetworkProvider>
-              <ActiveAccountProvider>
-                <Web3AuthProvider>
-                  <ExchangesProvider>
-                    <StakeProvider>
-                      <LocalizationProvider
-                        dateAdapter={AdapterDayjs}
-                        adapterLocale="en"
-                      >
-                        <BrowserRouter>
+          <BrowserRouter>
+            <NotificationProvider>
+              <NetworkProvider>
+                <ActiveAccountProvider>
+                  <Web3AuthProvider>
+                    <ExchangesProvider>
+                      <StakeProvider>
+                        <LocalizationProvider
+                          dateAdapter={AdapterDayjs}
+                          adapterLocale="en"
+                        >
                           <Layout>
                             <Routes>
                               <Route
@@ -56,14 +56,14 @@ const App: FC = () => {
                               />
                             </Routes>
                           </Layout>
-                        </BrowserRouter>
-                      </LocalizationProvider>
-                    </StakeProvider>
-                  </ExchangesProvider>
-                </Web3AuthProvider>
-              </ActiveAccountProvider>
-            </NetworkProvider>
-          </NotificationProvider>
+                        </LocalizationProvider>
+                      </StakeProvider>
+                    </ExchangesProvider>
+                  </Web3AuthProvider>
+                </ActiveAccountProvider>
+              </NetworkProvider>
+            </NotificationProvider>
+          </BrowserRouter>
         </ThemeProvider>
       </QueryClientProvider>
     </WagmiProvider>

--- a/campaign-launcher/client/src/hooks/recording-oracle/exchangeApiKeys.ts
+++ b/campaign-launcher/client/src/hooks/recording-oracle/exchangeApiKeys.ts
@@ -17,14 +17,14 @@ export const useGetEnrolledExchanges = () => {
   });
 };
 
-export const useGetExchangesWithApiKeys = () => {
+export const useGetExchangesWithApiKeys = ({ enabled = true } = {}) => {
   const { isAuthenticated } = useWeb3Auth();
   const { isConnected } = useConnection();
 
   return useQuery({
     queryKey: [QUERY_KEYS.EXCHANGES_WITH_API_KEYS, AUTHED_QUERY_TAG],
     queryFn: () => recordingApi.getExchangesWithApiKeys(),
-    enabled: isAuthenticated && isConnected,
+    enabled: enabled && isAuthenticated && isConnected,
   });
 };
 

--- a/campaign-launcher/client/src/hooks/useCheckApiKeysValidity.tsx
+++ b/campaign-launcher/client/src/hooks/useCheckApiKeysValidity.tsx
@@ -1,0 +1,48 @@
+import { useCallback } from 'react';
+
+import { Box, Link } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+
+import { ROUTES } from '@/constants';
+
+import { useGetExchangesWithApiKeys } from './recording-oracle';
+import { useNotification } from './useNotification';
+
+const useCheckApiKeysValidity = () => {
+  const { refetch } = useGetExchangesWithApiKeys({ enabled: false });
+  const { showError } = useNotification();
+
+  const checkApiKeysValidity = useCallback(async () => {
+    const { data: apiKeys } = await refetch();
+
+    if (!apiKeys) {
+      return;
+    }
+
+    const isInvalidKeyExist = apiKeys.some((key) => !key.is_valid);
+    if (isInvalidKeyExist) {
+      const message = (
+        <Box>
+          Some of your API keys are invalid or missing permissions.
+          <br />
+          <Link
+            component={RouterLink}
+            to={ROUTES.MANAGE_API_KEYS}
+            color="inherit"
+            sx={{ textDecoration: 'underline', fontWeight: 'bold' }}
+          >
+            Update them here
+          </Link>
+          .
+        </Box>
+      );
+      showError(message, {
+        position: { vertical: 'bottom', horizontal: 'right' },
+      });
+    }
+  }, [refetch, showError]);
+
+  return { checkApiKeysValidity };
+};
+
+export default useCheckApiKeysValidity;

--- a/campaign-launcher/client/src/hooks/useNotification.tsx
+++ b/campaign-launcher/client/src/hooks/useNotification.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { type ReactNode, useCallback } from 'react';
 
 import CloseIcon from '@mui/icons-material/Close';
 import { IconButton } from '@mui/material';
@@ -18,7 +18,11 @@ export const useNotification = () => {
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();
 
   const showNotification = useCallback(
-    (message: string, variant: VariantType, options?: NotificationOptions) => {
+    (
+      message: string | ReactNode,
+      variant: VariantType,
+      options?: NotificationOptions
+    ) => {
       const { duration, position } = options || {};
       const { vertical, horizontal } = position || {
         vertical: 'top',
@@ -44,28 +48,28 @@ export const useNotification = () => {
   );
 
   const showSuccess = useCallback(
-    (message: string, options?: NotificationOptions) => {
+    (message: string | ReactNode, options?: NotificationOptions) => {
       showNotification(message, 'success', options);
     },
     [showNotification]
   );
 
   const showError = useCallback(
-    (message: string, options?: NotificationOptions) => {
+    (message: string | ReactNode, options?: NotificationOptions) => {
       showNotification(message, 'error', options);
     },
     [showNotification]
   );
 
   const showWarning = useCallback(
-    (message: string, options?: NotificationOptions) => {
+    (message: string | ReactNode, options?: NotificationOptions) => {
       showNotification(message, 'warning', options);
     },
     [showNotification]
   );
 
   const showInfo = useCallback(
-    (message: string, options?: NotificationOptions) => {
+    (message: string | ReactNode, options?: NotificationOptions) => {
       showNotification(message, 'info', options);
     },
     [showNotification]

--- a/campaign-launcher/client/src/types/index.ts
+++ b/campaign-launcher/client/src/types/index.ts
@@ -49,6 +49,8 @@ export type ExchangeApiKeyData = {
   exchange_name: string;
   api_key: string;
   extras?: Record<string, string>;
+  is_valid: boolean;
+  missing_permissions: string[];
 };
 
 export type Campaign = {


### PR DESCRIPTION
## Issue tracking
Closes #550 

## Context behind the change
Implement a UI, that would tell users they have invalid key(s). Upon discussing the issue we decided to implement a simple toast notification instead of popup. This notification pops up right after user gets signed in and suggests navigating to the manage api keys page

## How has this been tested?
locally

## Release plan
regular

## Potential risks; What to monitor; Rollback plan
not found