### PR TITLE
[Recording Oracle] fix: network to view bigone dep addr

### DIFF
--- a/recording-oracle/src/modules/exchanges/api-client/ccxt-exchange-client.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/ccxt-exchange-client.ts
@@ -320,6 +320,10 @@ export class CcxtExchangeClient implements ExchangeApiClient {
         }
         break;
       }
+      case ExchangeName.BIGONE: {
+        fetchParams.network = 'Ethereum';
+        break;
+      }
     }
 
     const response = await this.ccxtClient.fetchDepositAddress(


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Ran permission check for BigONE and it appeared that in order to get deposit address we must provide `network` param now, so in this PR added default one.

## How has this been tested?
- [x] e2e locally by running `yarn ts-node scripts/permissions-example.ts ` with BigONE api key

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No