### PR TITLE
[Recording Oracle] fix: migration run

### DIFF
--- a/recording-oracle/typeorm-migrations-datasource.ts
+++ b/recording-oracle/typeorm-migrations-datasource.ts
@@ -2,6 +2,8 @@ import * as dotenv from 'dotenv';
 import { DataSource } from 'typeorm';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 
+import './src/setup-libs';
+
 import Environment from './src/common/utils/environment';
 
 dotenv.config({


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
After some constants added in https://github.com/Hu-Fi/hufi/pull/689, deployment started to fail due to migration command not able to run because of next error:
```
TypeError: dayjs_1.default.duration is not a function
    at Object.<anonymous> (/Users/dnechay/Documents/dev/metahuman/hufi/recording-oracle/src/modules/exchanges/api-client/pancakeswap/constants.ts:11:40)
    at Module._compile (node:internal/modules/cjs/loader:1761:14)
    at Module.m._compile (/Users/dnechay/Documents/dev/metahuman/hufi/recording-oracle/node_modules/ts-node/src/index.ts:1618:23)
```
It's because `dayjs - duration` plugin must be also initialized in migration script as well (not sure why though). Added it in this PR. 

## How has this been tested?
- [x] `NODE_ENV=local yarn migration:run` locally to finish successfully 

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No