### PR TITLE
[Recording Oracle] fix: pancake stale check

### DIFF
--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -40,6 +40,7 @@ import {
   ExchangesService,
   ExchangeApiAccessError,
   ExchangeApiKeyNotFoundError,
+  PancakeswapClient,
 } from '@/modules/exchanges';
 import { StorageService } from '@/modules/storage';
 import { Web3Service } from '@/modules/web3';
@@ -1387,6 +1388,9 @@ export class CampaignsService implements OnModuleDestroy {
     );
   }
 
+  /**
+   * Should be used only to get active timeframe for interim progress
+   */
   async getActiveTimeframe(campaign: CampaignEntity): Promise<{
     start: Date;
     end: Date;
@@ -1431,6 +1435,14 @@ export class CampaignsService implements OnModuleDestroy {
         return null;
       }
       timeframeEnd = cancellationRequestedAt;
+    } else if (campaign.exchangeName === ExchangeName.PANCAKESWAP) {
+      const client = new PancakeswapClient({
+        userId: 'system',
+        userEvmAddress: 'n/a',
+        subgraphApiKey: this.web3ConfigService.subgraphApiKey,
+      });
+      const subgraphMeta = await client.fetchSubgraphMeta();
+      timeframeEnd = new Date(subgraphMeta.block.timestamp * 1000);
     } else {
       timeframeEnd = now;
     }

--- a/recording-oracle/src/modules/exchanges/api-client/index.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/index.ts
@@ -16,3 +16,5 @@ export {
   type RequiredAccessCheckResult,
   type Trade,
 } from './types';
+
+export { PancakeswapClient } from './pancakeswap';

--- a/recording-oracle/src/modules/exchanges/api-client/pancakeswap/queries.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/pancakeswap/queries.ts
@@ -64,19 +64,24 @@ export type SubgraphSwapData = {
   tokenOut: SubgraphToken;
 };
 
-export const GET_LATEST_SWAP_QUERY = gql`
-  query getLatestSwap($timestamp: BigInt!) {
-    swaps(
-      where: { timestamp_gte: $timestamp }
-      first: 1
-      orderBy: timestamp
-      orderDirection: desc
-    ) {
-      id
-      blockNumber
-      hash
-      timestamp
-      nonce
+export type SubgraphMeta = {
+  hasIndexingErrors: boolean;
+  block: {
+    hash: string;
+    number: number;
+    timestamp: number;
+  };
+};
+
+export const GET_SUBGRAPH_META_QUERY = gql`
+  query getSubgraphMeta {
+    _meta {
+      hasIndexingErrors
+      block {
+        hash
+        timestamp
+        number
+      }
     }
   }
 `;

--- a/recording-oracle/src/modules/exchanges/index.ts
+++ b/recording-oracle/src/modules/exchanges/index.ts
@@ -1,11 +1,12 @@
 export {
-  ExchangeApiClientError,
   ExchangeApiAccessError,
+  ExchangeApiClientError,
   ExchangePermission,
-  type Trade,
-  type ExchangeApiClient,
+  PancakeswapClient,
   TakerOrMakerFlag,
   TradingSide,
+  type ExchangeApiClient,
+  type Trade,
 } from './api-client';
 
 export {


### PR DESCRIPTION
## Issue tracking
Freestyle

## Context behind the change
Atm when running interim progress check for PancakeSwap we pass `now` as `until` param and it's almost always ahead of current indexed block, hence staleness check fails. Fix it by fetching latest block meta and use it for interim progress check.

## How has this been tested?
- [x] e2e locally by using `sample` script: init client, fetch meta, fetch my trades

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No