### PR TITLE
[Recording Oracle] fix: cancelled pancake timeframe

### DIFF
--- a/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
@@ -3171,6 +3171,7 @@ describe('CampaignsService', () => {
 
     beforeEach(() => {
       campaign = generateCampaignEntity();
+      campaign.exchangeName = faker.lorem.slug(); // any exchange w/o specific logic
     });
 
     it('should return null if campaign not started', async () => {
@@ -3233,43 +3234,7 @@ describe('CampaignsService', () => {
       });
     });
 
-    it('should return correct timeframe for active pancakeswap campaign', async () => {
-      campaign.exchangeName = ExchangeName.PANCAKESWAP;
-      const mockedLastBlockTs = Math.round(
-        faker.date.recent().valueOf() / 1000,
-      );
-      mockedPancakeswapClient.prototype.fetchSubgraphMeta.mockResolvedValueOnce(
-        {
-          block: {
-            timestamp: mockedLastBlockTs,
-            hash: faker.string.hexadecimal(),
-            number: faker.number.int(),
-          },
-          hasIndexingErrors: false,
-        },
-      );
-
-      const campaignDaysPassed = faker.number.int({ min: 1, max: 3 });
-      campaign.startDate = dayjs()
-        .subtract(campaignDaysPassed, 'days')
-        .toDate();
-
-      const expectedTimeframeStart = dayjs(campaign.startDate)
-        .add(campaignDaysPassed, 'days')
-        .add(1, 'millisecond')
-        .toDate();
-
-      const result = await campaignsService.getActiveTimeframe(campaign);
-
-      expect(result).toEqual({
-        start: expectedTimeframeStart,
-        end: new Date(mockedLastBlockTs * 1000),
-      });
-    });
-
     it('should return correct timeframe for active campaign', async () => {
-      campaign.exchangeName = faker.lorem.slug(); // any exchange w/o specific logic
-
       const campaignDaysPassed = faker.number.int({ min: 1, max: 3 });
       campaign.startDate = dayjs()
         .subtract(campaignDaysPassed, 'days')
@@ -3306,6 +3271,82 @@ describe('CampaignsService', () => {
       const result = await campaignsService.getActiveTimeframe(campaign);
 
       expect(result).toBeNull();
+    });
+
+    it('should return correct timeframe for active pancakeswap campaign', async () => {
+      campaign.exchangeName = ExchangeName.PANCAKESWAP;
+      const mockedLastBlockTs = Math.round(
+        faker.date.recent().valueOf() / 1000,
+      );
+      mockedPancakeswapClient.prototype.fetchSubgraphMeta.mockResolvedValueOnce(
+        {
+          block: {
+            timestamp: mockedLastBlockTs,
+            hash: faker.string.hexadecimal(),
+            number: faker.number.int(),
+          },
+          hasIndexingErrors: false,
+        },
+      );
+
+      const campaignDaysPassed = faker.number.int({ min: 1, max: 3 });
+      campaign.startDate = dayjs()
+        .subtract(campaignDaysPassed, 'days')
+        .toDate();
+
+      const expectedTimeframeStart = dayjs(campaign.startDate)
+        .add(campaignDaysPassed, 'days')
+        .add(1, 'millisecond')
+        .toDate();
+
+      const result = await campaignsService.getActiveTimeframe(campaign);
+
+      expect(result).toEqual({
+        start: expectedTimeframeStart,
+        end: new Date(mockedLastBlockTs * 1000),
+      });
+    });
+
+    it('should return correct timeframe when cancellation requested for pancakeswap campaign', async () => {
+      campaign.status = CampaignStatus.TO_CANCEL;
+      campaign.exchangeName = ExchangeName.PANCAKESWAP;
+      const mockedLastBlockTs = Math.round(
+        faker.date.recent().valueOf() / 1000,
+      );
+      mockedPancakeswapClient.prototype.fetchSubgraphMeta.mockResolvedValueOnce(
+        {
+          block: {
+            timestamp: mockedLastBlockTs,
+            hash: faker.string.hexadecimal(),
+            number: faker.number.int(),
+          },
+          hasIndexingErrors: false,
+        },
+      );
+
+      const campaignDaysPassed = faker.number.int({ min: 1, max: 3 });
+      campaign.startDate = dayjs()
+        .subtract(campaignDaysPassed, 'days')
+        .toDate();
+
+      const expectedTimeframeStart = dayjs(campaign.startDate)
+        .add(campaignDaysPassed, 'days')
+        .add(1, 'millisecond')
+        .toDate();
+
+      const cancellationRequestedAt = dayjs(expectedTimeframeStart)
+        .add(1, 'minute')
+        .toDate();
+      spyOnGetCancellationRequestDate.mockResolvedValueOnce(
+        cancellationRequestedAt,
+      );
+
+      const result = await campaignsService.getActiveTimeframe(campaign);
+
+      expect(result).toEqual({
+        start: expectedTimeframeStart,
+        end: new Date(mockedLastBlockTs * 1000),
+      });
     });
   });
 

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -1408,16 +1408,21 @@ export class CampaignsService implements OnModuleDestroy {
         return null;
       }
       timeframeEnd = cancellationRequestedAt;
-    } else if (campaign.exchangeName === ExchangeName.PANCAKESWAP) {
+    } else {
+      timeframeEnd = now;
+    }
+
+    if (campaign.exchangeName === ExchangeName.PANCAKESWAP) {
       const client = new PancakeswapClient({
         userId: 'system',
         userEvmAddress: 'n/a',
         subgraphApiKey: this.web3ConfigService.subgraphApiKey,
       });
       const subgraphMeta = await client.fetchSubgraphMeta();
-      timeframeEnd = new Date(subgraphMeta.block.timestamp * 1000);
-    } else {
-      timeframeEnd = now;
+      const lastBlockSyncedAt = new Date(subgraphMeta.block.timestamp * 1000);
+      if (lastBlockSyncedAt.valueOf() < timeframeEnd.valueOf()) {
+        timeframeEnd = lastBlockSyncedAt;
+      }
     }
 
     return {

--- a/recording-oracle/src/modules/exchanges/api-client/pancakeswap/pancakeswap-client.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/pancakeswap/pancakeswap-client.ts
@@ -93,7 +93,12 @@ export class PancakeswapClient implements ExchangeApiClient {
     }
 
     if (subgraphMeta.block.timestamp < timestamp) {
-      throw new PancakeswapClientError('Subgraph is stale');
+      const errorMessage = 'Subgraph is stale';
+      this.logger.warn(errorMessage, {
+        subgraphMeta,
+        checkedTimestamp: timestamp,
+      });
+      throw new PancakeswapClientError(errorMessage);
     }
   }
 


### PR DESCRIPTION
## Issue tracking
Freestyle

## Context behind the change
Recently got error about stale subgraph, and taking into account that it's not clear how it could have happened (highly likely one of indexers is stale) - decided to add some logs for that.
Also found some edge case: if PancakeSwap campaign cancellation requested date is before that subgraph sync date - then active timeframe for interim results won't be correct, so fixed it here.

## How has this been tested?
- [x] unit tests
- [x] use sample script to call `fetchMyTrades` with `until` that is lower than last block timestamp and verify warn is logged

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No