### PR TITLE
[Recording Oracle] feat: add joined campaigns filters

### DIFF
--- a/recording-oracle/src/common/utils/transformer.ts
+++ b/recording-oracle/src/common/utils/transformer.ts
@@ -1,0 +1,11 @@
+export const parseQueryArray = ({
+  value,
+}: {
+  value?: string | string[];
+}): string[] | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return Array.isArray(value) ? value : [value];
+};

--- a/recording-oracle/src/modules/campaigns/campaigns.controller.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.controller.ts
@@ -107,7 +107,7 @@ export class CampaignsController {
     const campaigns = await this.participationsRepository.findByUserId(
       request.user.id,
       {
-        chaindId: query.chainId,
+        chainId: query.chainId,
         statuses,
         types: query.type,
         exchanges: query.exchange,

--- a/recording-oracle/src/modules/campaigns/campaigns.controller.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.controller.ts
@@ -109,6 +109,8 @@ export class CampaignsController {
       {
         chaindId: query.chainId,
         statuses,
+        types: query.type,
+        exchanges: query.exchange,
         limit: limit + 1,
         skip: query.skip,
       },

--- a/recording-oracle/src/modules/campaigns/campaigns.dto.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.dto.ts
@@ -17,8 +17,10 @@ import {
 import {
   ChainIds,
   DEFAULT_PAGINATION_LIMIT,
+  ExchangeName,
   type ChainId,
 } from '@/common/constants';
+import { parseQueryArray } from '@/common/utils/transformer';
 
 import {
   CampaignDetails,
@@ -149,6 +151,26 @@ export class ListJoinedCampaignsQueryDto {
   @IsOptional()
   @IsEnum(ReturnedCampaignStatus)
   status?: ReturnedCampaignStatus;
+
+  @ApiPropertyOptional({
+    description: 'Campaign types',
+    isArray: true,
+    enum: CampaignType,
+  })
+  @IsOptional()
+  @Transform(parseQueryArray)
+  @IsEnum(CampaignType, { each: true })
+  type?: CampaignType[];
+
+  @ApiPropertyOptional({
+    description: 'Exchanges',
+    isArray: true,
+    enum: ExchangeName,
+  })
+  @IsOptional()
+  @Transform(parseQueryArray)
+  @IsEnum(ExchangeName, { each: true })
+  exchange?: ExchangeName[];
 
   @ApiPropertyOptional({
     default: DEFAULT_PAGINATION_LIMIT,

--- a/recording-oracle/src/modules/campaigns/participations/participations.repository.ts
+++ b/recording-oracle/src/modules/campaigns/participations/participations.repository.ts
@@ -2,12 +2,12 @@ import { Injectable } from '@nestjs/common';
 import _ from 'lodash';
 import { DataSource, Repository } from 'typeorm';
 
-import { type ChainId } from '@/common/constants';
+import { ExchangeName, type ChainId } from '@/common/constants';
 import { isFiniteNumber } from '@/common/utils/type-guard';
 import type { UserEntity } from '@/modules/users';
 
 import { CampaignEntity } from '../campaign.entity';
-import { CampaignStatus } from '../types';
+import { CampaignStatus, CampaignType } from '../types';
 import { ParticipationEntity } from './participation.entity';
 import { MaxParticipantsError } from './participations.errors';
 import { type CampaignParticipant } from './types';
@@ -35,6 +35,8 @@ export class ParticipationsRepository extends Repository<ParticipationEntity> {
     options: {
       chaindId?: ChainId;
       statuses?: CampaignStatus[];
+      types?: CampaignType[];
+      exchanges?: ExchangeName[];
       limit?: number;
       skip?: number;
     } = {},
@@ -52,6 +54,18 @@ export class ParticipationsRepository extends Repository<ParticipationEntity> {
     if (options.statuses?.length) {
       query.andWhere('campaign.status IN (:...statuses)', {
         statuses: options.statuses,
+      });
+    }
+
+    if (options.exchanges?.length) {
+      query.andWhere('campaign.exchangeName IN (:...exchanges)', {
+        exchanges: options.exchanges,
+      });
+    }
+
+    if (options.types?.length) {
+      query.andWhere('campaign.type IN (:...types)', {
+        types: options.types,
       });
     }
 

--- a/recording-oracle/src/modules/campaigns/participations/participations.repository.ts
+++ b/recording-oracle/src/modules/campaigns/participations/participations.repository.ts
@@ -33,7 +33,7 @@ export class ParticipationsRepository extends Repository<ParticipationEntity> {
   async findByUserId(
     userId: string,
     options: {
-      chaindId?: ChainId;
+      chainId?: ChainId;
       statuses?: CampaignStatus[];
       types?: CampaignType[];
       exchanges?: ExchangeName[];
@@ -45,9 +45,9 @@ export class ParticipationsRepository extends Repository<ParticipationEntity> {
       .leftJoinAndSelect('participation.campaign', 'campaign')
       .where('participation.userId = :userId', { userId });
 
-    if (options.chaindId) {
+    if (options.chainId) {
       query.andWhere('campaign.chainId = :chainId', {
-        chainId: options.chaindId,
+        chainId: options.chainId,
       });
     }
 


### PR DESCRIPTION
## Issue tracking
Follow-up to https://github.com/Hu-Fi/hufi/issues/831

## Context behind the change
Extended joined campaigns filters to also support `types` and `exchanges` as on CL.

## How has this been tested?
- [x] e2e locally

## Release plan
Regular

## Potential risks; What to monitor; Rollback plan
No