### PR TITLE
[Recording Oracle] feat: support multiple cycles progress recording

### DIFF
--- a/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
@@ -2009,7 +2009,8 @@ describe('CampaignsService', () => {
     beforeEach(() => {
       campaign = generateCampaignEntity();
       /**
-       * Adjust campaign dates to easily manipulate full cycles passed
+       * Adjust campaign dates to be already ended 1-day campaign
+       * to easily manipulate inputs and check for expectations
        */
       campaign.endDate = dayjs().subtract(1, 'hour').toDate();
       campaign.startDate = dayjs(campaign.endDate).subtract(1, 'day').toDate();
@@ -2224,7 +2225,6 @@ describe('CampaignsService', () => {
     it('should use correct period dates for campaign with < 1d duration when no intermediate results', async () => {
       spyOnRetrieveCampaignIntermediateResults.mockResolvedValueOnce(null);
 
-      campaign.endDate = new Date(Date.now() - 1);
       campaign.startDate = dayjs(campaign.endDate)
         .subtract(faker.number.int({ min: 1, max: 23 }), 'hours')
         .toDate();
@@ -2245,8 +2245,18 @@ describe('CampaignsService', () => {
     });
 
     it('should check all passed cycles for campaign with > 1d duration when no intermediate results', async () => {
-      const nFullCycles = faker.number.int({ min: 2, max: 3 });
-      campaign.startDate = dayjs().subtract(nFullCycles, 'day').toDate();
+      const nFullCycles = faker.number.int({ min: 2, max: 5 });
+      /**
+       * Set campaign start date to be nFullCycles days and 1ms ago to make sure
+       * that only full cycles are checked, and not including last partial cycle (if any)
+       */
+      campaign.startDate = dayjs()
+        .subtract(nFullCycles, 'day')
+        .subtract(1, 'ms')
+        .toDate();
+      /**
+       * Campaign not ended yet to make sure endDate is last full cycle end
+       */
       campaign.endDate = dayjs()
         .add(faker.number.int({ min: 1, max: 100 }), 'hour')
         .toDate();
@@ -2280,13 +2290,47 @@ describe('CampaignsService', () => {
     });
 
     it('should check last cycle if it is not round but campaign ended', async () => {
-      /**
-       * TODO: revisit if need to add more edge-case tests
-       */
-      expect(1).toBe(1);
+      const nFullCycles = faker.number.int({ min: 2, max: 5 });
+      campaign.startDate = dayjs(campaign.endDate)
+        .subtract(nFullCycles, 'day')
+        .subtract(faker.number.int({ min: 1, max: 23 }), 'hour')
+        .toDate();
+
+      spyOnRetrieveCampaignIntermediateResults.mockResolvedValueOnce(null);
+      spyOnCheckCampaignProgressForPeriod.mockResolvedValue(
+        generateCampaignProgress(campaign),
+      );
+
+      await campaignsService.recordCampaignProgress(campaign);
+
+      const nTotalCycles = nFullCycles + 1;
+      expect(spyOnCheckCampaignProgressForPeriod).toHaveBeenCalledTimes(
+        nTotalCycles,
+      );
+      for (let i = 1; i <= nTotalCycles; i += 1) {
+        const expectedStartDate = dayjs(campaign.startDate)
+          .add(i - 1, 'day')
+          .toDate();
+        let expectedEndDate = dayjs(expectedStartDate).add(1, 'day').toDate();
+        if (i === nTotalCycles) {
+          expectedEndDate = campaign.endDate;
+        }
+
+        expect(spyOnCheckCampaignProgressForPeriod).toHaveBeenNthCalledWith(
+          i,
+          campaign,
+          expectedStartDate,
+          expectedEndDate,
+          {
+            excludeIneligible: expect.any(Boolean),
+            logWarnings: true,
+            caller: 'recordCampaignProgress',
+          },
+        );
+      }
     });
 
-    it('should not check progress if less than a day from last result for ongoing campaign', async () => {
+    it('should not check progress if less than a day from last intermediate result for ongoing campaign', async () => {
       const now = Date.now();
       campaign.endDate = new Date(now + 1);
       campaign.startDate = dayjs(campaign.endDate).subtract(2, 'day').toDate();
@@ -2377,6 +2421,68 @@ describe('CampaignsService', () => {
       );
     });
 
+    it('should check all passed cycles for campaign with > 1d duration and existing intermediate results', async () => {
+      const nFullCycles = faker.number.int({ min: 2, max: 5 });
+      /**
+       * Set campaign start date to be nFullCycles days and 1ms ago to make sure
+       * that only full cycles are checked, and not including last partial cycle (if any)
+       */
+      campaign.startDate = dayjs()
+        .subtract(nFullCycles, 'day')
+        .subtract(1, 'ms')
+        .toDate();
+      /**
+       * Campaign not ended yet to make sure endDate is last full cycle end
+       */
+      campaign.endDate = dayjs()
+        .add(faker.number.int({ min: 1, max: 100 }), 'hour')
+        .toDate();
+
+      const lastResultsEndDate = dayjs(campaign.startDate)
+        .add(1, 'day')
+        .toDate();
+      const intermediateResultsData = generateIntermediateResultsData({
+        results: [
+          generateIntermediateResult({
+            endDate: lastResultsEndDate,
+          }),
+        ],
+      });
+      spyOnRetrieveCampaignIntermediateResults.mockResolvedValueOnce(
+        intermediateResultsData,
+      );
+      spyOnCheckCampaignProgressForPeriod.mockResolvedValue(
+        generateCampaignProgress(campaign),
+      );
+
+      await campaignsService.recordCampaignProgress(campaign);
+
+      /**
+       * First is covered by intermediate result
+       */
+      const nNewCycles = nFullCycles - 1;
+      expect(spyOnCheckCampaignProgressForPeriod).toHaveBeenCalledTimes(
+        nNewCycles,
+      );
+      for (let i = 1; i <= nNewCycles; i += 1) {
+        const expectedStartDate = dayjs(lastResultsEndDate)
+          .add(i - 1, 'day')
+          .toDate();
+
+        expect(spyOnCheckCampaignProgressForPeriod).toHaveBeenNthCalledWith(
+          i,
+          campaign,
+          expectedStartDate,
+          dayjs(expectedStartDate).add(1, 'day').toDate(),
+          {
+            excludeIneligible: expect.any(Boolean),
+            logWarnings: true,
+            caller: 'recordCampaignProgress',
+          },
+        );
+      }
+    });
+
     it('should use campaign end date if cancellation requested after campaign end date', async () => {
       mockedGetEscrowStatus.mockResolvedValueOnce(EscrowStatus.ToCancel);
       spyOnRetrieveCampaignIntermediateResults.mockResolvedValueOnce(null);
@@ -2420,6 +2526,52 @@ describe('CampaignsService', () => {
           caller: 'recordCampaignProgress',
         },
       );
+    });
+
+    it('should check all passed cycles for campaign with > 1d duration and cancellation request', async () => {
+      mockedGetEscrowStatus.mockResolvedValueOnce(EscrowStatus.ToCancel);
+      spyOnRetrieveCampaignIntermediateResults.mockResolvedValueOnce(null);
+      const cancellationRequestedAt = new Date(campaign.endDate.valueOf() - 1);
+      spyOnGetCancellationRequestDate.mockResolvedValueOnce(
+        cancellationRequestedAt,
+      );
+
+      const nCycles = faker.number.int({ min: 2, max: 5 });
+      campaign.startDate = dayjs(campaign.endDate)
+        .subtract(nCycles, 'day')
+        .toDate();
+
+      spyOnRetrieveCampaignIntermediateResults.mockResolvedValueOnce(null);
+      spyOnCheckCampaignProgressForPeriod.mockResolvedValue(
+        generateCampaignProgress(campaign),
+      );
+
+      await campaignsService.recordCampaignProgress(campaign);
+
+      expect(spyOnCheckCampaignProgressForPeriod).toHaveBeenCalledTimes(
+        nCycles,
+      );
+      for (let i = 1; i <= nCycles; i += 1) {
+        const expectedStartDate = dayjs(campaign.startDate)
+          .add(i - 1, 'day')
+          .toDate();
+        let expectedEndDate = dayjs(expectedStartDate).add(1, 'day').toDate();
+        if (i === nCycles) {
+          expectedEndDate = cancellationRequestedAt;
+        }
+
+        expect(spyOnCheckCampaignProgressForPeriod).toHaveBeenNthCalledWith(
+          i,
+          campaign,
+          expectedStartDate,
+          expectedEndDate,
+          {
+            excludeIneligible: expect.any(Boolean),
+            logWarnings: true,
+            caller: 'recordCampaignProgress',
+          },
+        );
+      }
     });
 
     it('should record campaign progress when no results yet', async () => {

--- a/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
@@ -2874,10 +2874,9 @@ describe('CampaignsService', () => {
       expect(secondBatch.results[0]).toEqual(participantOutcomes[2]);
     });
 
-    it('should not move campaign to "pending_completion" if reached its end date but not all results calculated', async () => {
+    it('should not move campaign to "pending_completion" when not all results calculated', async () => {
       const currentDate = new Date();
       campaign.endDate = new Date(currentDate.valueOf() + 1);
-      campaign.startDate = dayjs(campaign.endDate).subtract(2, 'day').toDate();
 
       spyOnRetrieveCampaignIntermediateResults.mockResolvedValueOnce(null);
       spyOnCheckCampaignProgressForPeriod.mockResolvedValueOnce(

--- a/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
@@ -2530,7 +2530,6 @@ describe('CampaignsService', () => {
 
     it('should check all passed cycles for campaign with > 1d duration and cancellation request', async () => {
       mockedGetEscrowStatus.mockResolvedValueOnce(EscrowStatus.ToCancel);
-      spyOnRetrieveCampaignIntermediateResults.mockResolvedValueOnce(null);
       const cancellationRequestedAt = new Date(campaign.endDate.valueOf() - 1);
       spyOnGetCancellationRequestDate.mockResolvedValueOnce(
         cancellationRequestedAt,

--- a/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
@@ -1957,7 +1957,7 @@ describe('CampaignsService', () => {
     });
   });
 
-  describe('recordCampaignProgress', () => {
+  describe.only('recordCampaignProgress', () => {
     let spyOnRetrieveCampaignIntermediateResults: jest.SpyInstance;
     let spyOnCheckCampaignProgressForPeriod: jest.SpyInstance;
     let spyOnRecordCampaignIntermediateResults: jest.SpyInstance;

--- a/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
@@ -1957,7 +1957,7 @@ describe('CampaignsService', () => {
     });
   });
 
-  describe.only('recordCampaignProgress', () => {
+  describe('recordCampaignProgress', () => {
     let spyOnRetrieveCampaignIntermediateResults: jest.SpyInstance;
     let spyOnCheckCampaignProgressForPeriod: jest.SpyInstance;
     let spyOnRecordCampaignIntermediateResults: jest.SpyInstance;
@@ -2008,14 +2008,11 @@ describe('CampaignsService', () => {
 
     beforeEach(() => {
       campaign = generateCampaignEntity();
-
       /**
-       * Adjust campaign dates to easily manipulate if its "ongoing"
-       * and already recorded intermediate results
+       * Adjust campaign dates to easily manipulate full cycles passed
        */
-      const nDaysToShift = faker.number.int({ min: 3, max: 5 });
-      campaign.startDate = dayjs().subtract(nDaysToShift, 'day').toDate();
-      campaign.endDate = dayjs().add(nDaysToShift, 'day').toDate();
+      campaign.endDate = dayjs().subtract(1, 'hour').toDate();
+      campaign.startDate = dayjs(campaign.endDate).subtract(1, 'day').toDate();
 
       mockPgAdvisoryLock.withLock.mockImplementationOnce(async (_key, fn) => {
         await fn();
@@ -2208,7 +2205,9 @@ describe('CampaignsService', () => {
       spyOnRetrieveCampaignIntermediateResults.mockResolvedValueOnce(null);
 
       const now = Date.now();
-      campaign.startDate = dayjs(now)
+      campaign.endDate = new Date(now + 1);
+
+      campaign.startDate = dayjs(campaign.endDate)
         .subtract(1, 'day')
         .add(1, 'millisecond')
         .toDate();
@@ -2232,14 +2231,11 @@ describe('CampaignsService', () => {
 
       await campaignsService.recordCampaignProgress(campaign);
 
-      const expectedStartDate = new Date(campaign.startDate.valueOf());
-      const expectedEndDate = campaign.endDate;
-
       expect(spyOnCheckCampaignProgressForPeriod).toHaveBeenCalledTimes(1);
       expect(spyOnCheckCampaignProgressForPeriod).toHaveBeenCalledWith(
         campaign,
-        expectedStartDate,
-        expectedEndDate,
+        campaign.startDate,
+        campaign.endDate,
         {
           excludeIneligible: expect.any(Boolean),
           logWarnings: true,
@@ -2248,35 +2244,57 @@ describe('CampaignsService', () => {
       );
     });
 
-    it('should use correct period dates for campaign with > 1d duration when no intermediate results', async () => {
+    it('should check all passed cycles for campaign with > 1d duration when no intermediate results', async () => {
+      const nFullCycles = faker.number.int({ min: 2, max: 3 });
+      campaign.startDate = dayjs().subtract(nFullCycles, 'day').toDate();
+      campaign.endDate = dayjs()
+        .add(faker.number.int({ min: 1, max: 100 }), 'hour')
+        .toDate();
       spyOnRetrieveCampaignIntermediateResults.mockResolvedValueOnce(null);
+      spyOnCheckCampaignProgressForPeriod.mockResolvedValue(
+        generateCampaignProgress(campaign),
+      );
 
       await campaignsService.recordCampaignProgress(campaign);
 
-      const expectedStartDate = new Date(campaign.startDate.valueOf());
-      const expectedEndDate = dayjs(expectedStartDate).add(1, 'day').toDate();
-
-      expect(spyOnCheckCampaignProgressForPeriod).toHaveBeenCalledTimes(1);
-      expect(spyOnCheckCampaignProgressForPeriod).toHaveBeenCalledWith(
-        campaign,
-        expectedStartDate,
-        expectedEndDate,
-        {
-          excludeIneligible: expect.any(Boolean),
-          logWarnings: true,
-          caller: 'recordCampaignProgress',
-        },
+      expect(spyOnCheckCampaignProgressForPeriod).toHaveBeenCalledTimes(
+        nFullCycles,
       );
+      for (let i = 1; i <= nFullCycles; i += 1) {
+        const expectedStartDate = dayjs(campaign.startDate)
+          .add(i - 1, 'day')
+          .toDate();
+
+        expect(spyOnCheckCampaignProgressForPeriod).toHaveBeenNthCalledWith(
+          i,
+          campaign,
+          expectedStartDate,
+          dayjs(expectedStartDate).add(1, 'day').toDate(),
+          {
+            excludeIneligible: expect.any(Boolean),
+            logWarnings: true,
+            caller: 'recordCampaignProgress',
+          },
+        );
+      }
     });
 
-    it('should not check progress if less than a day from last results for ongoing campaign', async () => {
+    it('should check last cycle if it is not round but campaign ended', async () => {
+      /**
+       * TODO: revisit if need to add more edge-case tests
+       */
+      expect(1).toBe(1);
+    });
+
+    it('should not check progress if less than a day from last result for ongoing campaign', async () => {
       const now = Date.now();
-      const oneDayAgo = dayjs(now).subtract(1, 'day').toDate();
+      campaign.endDate = new Date(now + 1);
+      campaign.startDate = dayjs(campaign.endDate).subtract(2, 'day').toDate();
+
       const intermediateResultsData = generateIntermediateResultsData({
         results: [
           generateIntermediateResult({
-            // add one ms to imitate "almost one day ago"
-            endDate: new Date(oneDayAgo.valueOf() + 1),
+            endDate: dayjs(campaign.startDate).add(1, 'day').toDate(),
           }),
         ],
       });
@@ -2293,7 +2311,9 @@ describe('CampaignsService', () => {
       expect(spyOnCheckCampaignProgressForPeriod).toHaveBeenCalledTimes(0);
     });
 
-    it('should use start date from last intermediate results when more than a day from last results but campaign not ended', async () => {
+    it('should rely on last intermediate result when more than a day from last result and campaign not ended', async () => {
+      campaign.endDate = dayjs().add(1, 'hour').toDate();
+      campaign.startDate = dayjs(campaign.endDate).subtract(3, 'day').toDate();
       const lastResultsEndDate = dayjs(campaign.startDate)
         .add(1, 'day')
         .toDate();
@@ -2322,7 +2342,7 @@ describe('CampaignsService', () => {
       );
     });
 
-    it('should use start date from last intermediate results if less than a day from last results but campaign ended', async () => {
+    it('should rely on last intermediate result if less than a day from last result and campaign ended', async () => {
       const now = Date.now();
       campaign.endDate = new Date(now - 1);
       const lastResultsEndDate = dayjs().subtract(42, 'minutes').toDate();
@@ -2344,13 +2364,11 @@ describe('CampaignsService', () => {
 
       jest.useRealTimers();
 
-      const expectedEndDate = campaign.endDate;
-
       expect(spyOnCheckCampaignProgressForPeriod).toHaveBeenCalledTimes(1);
       expect(spyOnCheckCampaignProgressForPeriod).toHaveBeenCalledWith(
         campaign,
         lastResultsEndDate,
-        expectedEndDate,
+        campaign.endDate,
         {
           excludeIneligible: expect.any(Boolean),
           logWarnings: true,
@@ -2441,6 +2459,8 @@ describe('CampaignsService', () => {
     });
 
     it('should record campaign progress to existing results', async () => {
+      campaign.startDate = dayjs(campaign.endDate).subtract(2, 'day').toDate();
+
       const intermediateResultsData = generateIntermediateResultsData({
         results: [
           generateIntermediateResult({
@@ -2705,8 +2725,8 @@ describe('CampaignsService', () => {
 
     it('should not move campaign to "pending_completion" if reached its end date but not all results calculated', async () => {
       const currentDate = new Date();
-      campaign.endDate = new Date(currentDate.valueOf() - 1);
-      campaign.startDate = dayjs(campaign.endDate).subtract(3, 'day').toDate();
+      campaign.endDate = new Date(currentDate.valueOf() + 1);
+      campaign.startDate = dayjs(campaign.endDate).subtract(2, 'day').toDate();
 
       spyOnRetrieveCampaignIntermediateResults.mockResolvedValueOnce(null);
       spyOnCheckCampaignProgressForPeriod.mockResolvedValueOnce(

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -533,27 +533,22 @@ export class CampaignsService implements OnModuleDestroy {
               );
             endDate = cancellationRequestedAt;
           } else {
+            const cyclesToTimestamp = Math.min(
+              Date.now(),
+              campaign.endDate.valueOf(),
+            );
+            const cyclesPassed = Math.floor(
+              dayjs(cyclesToTimestamp).diff(startDate, 'day', false) /
+                CAMPAIGNS_DAILY_CYCLE,
+            );
             endDate = dayjs(startDate)
-              .add(CAMPAIGNS_DAILY_CYCLE, 'day')
+              .add(cyclesPassed * CAMPAIGNS_DAILY_CYCLE, 'days')
               .toDate();
-
-            const isOngoingCampaign = campaign.endDate.valueOf() > Date.now();
-            if (isOngoingCampaign && endDate.valueOf() > Date.now()) {
-              /**
-               * If campaign is ongoing - check results only once per period.
-               * Otherwise - let it record results immediately to reduce the wait.
-               */
-              logger.warn(
-                "Can't check progress for period that is not finished yet",
-                {
-                  startDate,
-                  endDate,
-                },
-              );
-              return;
-            }
           }
 
+          /**
+           * Just a safety belt, just in case cancellation requested after
+           */
           if (endDate > campaign.endDate) {
             endDate = campaign.endDate;
           }
@@ -596,63 +591,61 @@ export class CampaignsService implements OnModuleDestroy {
             }
           }
 
-          const progress = await this.checkCampaignProgressForPeriod(
-            campaign,
-            startDate,
-            endDate,
-            {
-              excludeIneligible:
-                isThresholdCampaign(campaign) &&
-                isFiniteNumber(campaign.details.maxParticipants),
-              logWarnings: true,
-              caller: this.recordCampaignProgress.name,
-            },
-          );
+          const newResults: IntermediateResult[] = [];
+          let totalRewardPool = new Decimal(0);
+          let nextCycleStart = startDate;
+          while (dayjs(nextCycleStart).isBefore(endDate)) {
+            const cycleProgress = await this.checkCampaignProgressForPeriod(
+              campaign,
+              nextCycleStart,
+              dayjs(nextCycleStart).add(CAMPAIGNS_DAILY_CYCLE, 'day').toDate(),
+              {
+                excludeIneligible:
+                  isThresholdCampaign(campaign) &&
+                  isFiniteNumber(campaign.details.maxParticipants),
+                logWarnings: true,
+                caller: this.recordCampaignProgress.name,
+              },
+            );
 
-          const rewardPool = rewardsUtils.calculateRewardPool(
-            campaign,
-            progress,
-          );
-          if (escrowStatus !== EscrowStatus.ToCancel) {
-            const dailyReward = rewardsUtils.calculateDailyReward(campaign);
-            if (Decimal(rewardPool).greaterThan(dailyReward)) {
-              /**
-               * Safety-belt
-               * Should not be possible for non-cancelled campaign
-               */
-              throw new Error(
-                'Calculated reward pool is greater than daily reward',
-              );
+            const rewardPool = rewardsUtils.calculateRewardPool(
+              campaign,
+              cycleProgress,
+            );
+
+            const intermediateResult: IntermediateResult = {
+              from: cycleProgress.from,
+              to: cycleProgress.to,
+              reserved_funds: rewardPool,
+              participants_outcomes_batches: [],
+              ...cycleProgress.meta,
+            };
+            for (const chunk of _.chunk(
+              cycleProgress.participants_outcomes,
+              ESCROW_BULK_PAYOUT_MAX_ITEMS,
+            )) {
+              intermediateResult.participants_outcomes_batches.push({
+                id: crypto.randomUUID(),
+                results: chunk,
+              });
             }
+
+            newResults.push(intermediateResult);
+            totalRewardPool = totalRewardPool.add(rewardPool);
+            nextCycleStart = dayjs(nextCycleStart)
+              .add(CAMPAIGNS_DAILY_CYCLE, 'day')
+              .toDate();
           }
 
-          const intermediateResult: IntermediateResult = {
-            from: progress.from,
-            to: progress.to,
-            reserved_funds: rewardPool,
-            participants_outcomes_batches: [],
-            ...progress.meta,
-          };
-          for (const chunk of _.chunk(
-            progress.participants_outcomes,
-            ESCROW_BULK_PAYOUT_MAX_ITEMS,
-          )) {
-            intermediateResult.participants_outcomes_batches.push({
-              id: crypto.randomUUID(),
-              results: chunk,
-            });
-          }
-
-          intermediateResults.results.push(intermediateResult);
           const fundsToReserve = ethers.parseUnits(
-            rewardPool.toString(),
+            totalRewardPool.toString(),
             campaign.fundTokenDecimals,
           );
 
           logger.info('Going to record campaign progress', {
-            from: progress.from,
-            to: progress.to,
-            reserved_funds: rewardPool,
+            from: startDate.toISOString(),
+            to: endDate.toISOString(),
+            reserved_funds: fundsToReserve,
           });
 
           const storedResultsMeta =
@@ -661,19 +654,26 @@ export class CampaignsService implements OnModuleDestroy {
               fundsToReserve,
             );
 
-          logger.info('Campaign progress recorded', {
-            from: progress.from,
-            to: progress.to,
-            reserved_funds: rewardPool,
-            ...progress.meta,
-            resultsUrl: storedResultsMeta.url,
-          });
+          for (const intermediateResult of newResults) {
+            logger.info(
+              'Campaign progress recorded',
+              Object.assign(
+                {
+                  resultsUrl: storedResultsMeta.url,
+                },
+                intermediateResult,
+                {
+                  participants_outcomes_batches: undefined,
+                },
+              ),
+            );
 
-          if (
-            isMarketMakingCampaign(campaign) ||
-            isCompetitiveMarketMakingCampaign(campaign)
-          ) {
-            void this.recordGeneratedVolume(campaign, intermediateResult);
+            if (
+              isMarketMakingCampaign(campaign) ||
+              isCompetitiveMarketMakingCampaign(campaign)
+            ) {
+              void this.recordGeneratedVolume(campaign, intermediateResult);
+            }
           }
 
           if (escrowStatus === EscrowStatus.ToCancel) {

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -531,7 +531,6 @@ export class CampaignsService implements OnModuleDestroy {
                 campaign.chainId,
                 campaign.address,
               );
-            endDate = cancellationRequestedAt;
             endDate = new Date(
               Math.min(
                 cancellationRequestedAt.valueOf(),
@@ -545,12 +544,6 @@ export class CampaignsService implements OnModuleDestroy {
               dayjs().diff(startDate, 'day', false) / CAMPAIGNS_DAILY_CYCLE,
             );
             if (fullCyclesPassed === 0) {
-              logger.warn(
-                "Can't check progress for period that is not finished yet",
-                {
-                  startDate,
-                },
-              );
               return;
             }
             endDate = dayjs(startDate)
@@ -647,9 +640,7 @@ export class CampaignsService implements OnModuleDestroy {
 
             newResults.push(intermediateResult);
             totalRewardPool = totalRewardPool.add(rewardPool);
-            nextCycleStart = dayjs(nextCycleStart)
-              .add(CAMPAIGNS_DAILY_CYCLE, 'day')
-              .toDate();
+            nextCycleStart = nextCycleEnd;
           } while (nextCycleStart < endDate);
 
           logger.info('Going to record campaign progress', {

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -532,25 +532,30 @@ export class CampaignsService implements OnModuleDestroy {
                 campaign.address,
               );
             endDate = cancellationRequestedAt;
-          } else {
-            const cyclesToTimestamp = Math.min(
-              Date.now(),
-              campaign.endDate.valueOf(),
+            endDate = new Date(
+              Math.min(
+                cancellationRequestedAt.valueOf(),
+                campaign.endDate.valueOf(),
+              ),
             );
-            const cyclesPassed = Math.floor(
-              dayjs(cyclesToTimestamp).diff(startDate, 'day', false) /
-                CAMPAIGNS_DAILY_CYCLE,
-            );
-            endDate = dayjs(startDate)
-              .add(cyclesPassed * CAMPAIGNS_DAILY_CYCLE, 'days')
-              .toDate();
-          }
-
-          /**
-           * Just a safety belt, just in case cancellation requested after
-           */
-          if (endDate > campaign.endDate) {
+          } else if (campaign.endDate <= new Date()) {
             endDate = campaign.endDate;
+          } else {
+            const fullCyclesPassed = Math.floor(
+              dayjs().diff(startDate, 'day', false) / CAMPAIGNS_DAILY_CYCLE,
+            );
+            if (fullCyclesPassed === 0) {
+              logger.warn(
+                "Can't check progress for period that is not finished yet",
+                {
+                  startDate,
+                },
+              );
+              return;
+            }
+            endDate = dayjs(startDate)
+              .add(fullCyclesPassed * CAMPAIGNS_DAILY_CYCLE, 'days')
+              .toDate();
           }
 
           // safety-belt
@@ -594,11 +599,21 @@ export class CampaignsService implements OnModuleDestroy {
           const newResults: IntermediateResult[] = [];
           let totalRewardPool = new Decimal(0);
           let nextCycleStart = startDate;
-          while (dayjs(nextCycleStart).isBefore(endDate)) {
+          do {
+            let nextCycleEnd = dayjs(nextCycleStart)
+              .add(CAMPAIGNS_DAILY_CYCLE, 'day')
+              .toDate();
+            if (nextCycleEnd > endDate) {
+              /**
+               * In case campaign duration is not multiple of cycle duration
+               */
+              nextCycleEnd = endDate;
+            }
+
             const cycleProgress = await this.checkCampaignProgressForPeriod(
               campaign,
               nextCycleStart,
-              dayjs(nextCycleStart).add(CAMPAIGNS_DAILY_CYCLE, 'day').toDate(),
+              nextCycleEnd,
               {
                 excludeIneligible:
                   isThresholdCampaign(campaign) &&
@@ -635,18 +650,19 @@ export class CampaignsService implements OnModuleDestroy {
             nextCycleStart = dayjs(nextCycleStart)
               .add(CAMPAIGNS_DAILY_CYCLE, 'day')
               .toDate();
-          }
+          } while (nextCycleStart < endDate);
+
+          logger.info('Going to record campaign progress', {
+            from: startDate.toISOString(),
+            to: endDate.toISOString(),
+            reserved_funds: totalRewardPool.toString(),
+          });
 
           const fundsToReserve = ethers.parseUnits(
             totalRewardPool.toString(),
             campaign.fundTokenDecimals,
           );
-
-          logger.info('Going to record campaign progress', {
-            from: startDate.toISOString(),
-            to: endDate.toISOString(),
-            reserved_funds: fundsToReserve,
-          });
+          intermediateResults.results.push(...newResults);
 
           const storedResultsMeta =
             await this.recordCampaignIntermediateResults(

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -643,22 +643,22 @@ export class CampaignsService implements OnModuleDestroy {
             nextCycleStart = nextCycleEnd;
           } while (nextCycleStart < endDate);
 
+          const fundsToReserve = rewardsUtils.formatRewardValue(
+            totalRewardPool,
+            campaign.fundTokenDecimals,
+          );
           logger.info('Going to record campaign progress', {
             from: startDate.toISOString(),
             to: endDate.toISOString(),
-            reserved_funds: totalRewardPool.toString(),
+            reserved_funds: fundsToReserve,
           });
 
-          const fundsToReserve = ethers.parseUnits(
-            totalRewardPool.toString(),
-            campaign.fundTokenDecimals,
-          );
           intermediateResults.results.push(...newResults);
 
           const storedResultsMeta =
             await this.recordCampaignIntermediateResults(
               intermediateResults,
-              fundsToReserve,
+              ethers.parseUnits(fundsToReserve, campaign.fundTokenDecimals),
             );
 
           for (const intermediateResult of newResults) {

--- a/recording-oracle/src/modules/campaigns/rewards.utils.spec.ts
+++ b/recording-oracle/src/modules/campaigns/rewards.utils.spec.ts
@@ -24,6 +24,60 @@ import {
 } from './types';
 
 describe('rewards utils', () => {
+  describe('formatRewardValue', () => {
+    it('should correctly format reward value when decimals is 0', () => {
+      const reward = faker.number
+        .float({ min: 1, max: 1000, fractionDigits: 15 })
+        .toString();
+
+      const formattedReward = rewardsUtils.formatRewardValue(
+        new Decimal(reward),
+        0,
+      );
+
+      expect(formattedReward).toBe(reward.split('.')[0]);
+    });
+
+    it('should correctly format zero reward', () => {
+      const formattedReward = rewardsUtils.formatRewardValue(
+        new Decimal('0.000000000000000000'),
+        faker.number.int({ min: 1, max: 5 }),
+      );
+
+      expect(formattedReward).toBe('0');
+    });
+
+    it('should not round up the reward value', () => {
+      const decimals = faker.number.int({ min: 3, max: 18 });
+      const wholePart = faker.number.int({ min: 1, max: 1000 });
+
+      const formattedReward = rewardsUtils.formatRewardValue(
+        new Decimal(`${wholePart}.${'9'.repeat(decimals + 1)}`),
+        decimals,
+      );
+
+      expect(formattedReward).toBe(`${wholePart}.${'9'.repeat(decimals)}`);
+    });
+
+    it('should correctly format reward value when it has less decimals than passed', () => {
+      const decimals = faker.number.int({ min: 3, max: 18 });
+      const rewardValue = faker.number
+        .float({
+          min: 1,
+          max: 1000,
+          fractionDigits: decimals - 1,
+        })
+        .toString();
+
+      const formattedReward = rewardsUtils.formatRewardValue(
+        new Decimal(rewardValue),
+        decimals,
+      );
+
+      expect(formattedReward).toBe(rewardValue);
+    });
+  });
+
   describe('calculateDailyReward', () => {
     it('should correctly calculate reward when duration is integer number of days', () => {
       const duration = faker.number.int({ min: 1, max: 15 });

--- a/recording-oracle/src/modules/campaigns/rewards.utils.ts
+++ b/recording-oracle/src/modules/campaigns/rewards.utils.ts
@@ -22,6 +22,15 @@ import type {
   ParticipantOutcome,
 } from './types';
 
+export function formatRewardValue(
+  rewardValue: Decimal,
+  fundTokenDecimals: number,
+): string {
+  return rewardValue
+    .toDecimalPlaces(fundTokenDecimals, Decimal.ROUND_DOWN)
+    .toString();
+}
+
 export function calculateDailyReward(campaign: CampaignEntity): string {
   const campaignDurationDays = Math.ceil(
     dayjs(campaign.endDate).diff(campaign.startDate, 'days', true),
@@ -31,9 +40,7 @@ export function calculateDailyReward(campaign: CampaignEntity): string {
 
   const dailyReward = fundAmount.div(campaignDurationDays);
 
-  return dailyReward
-    .toDecimalPlaces(campaign.fundTokenDecimals, Decimal.ROUND_DOWN)
-    .toString();
+  return formatRewardValue(dailyReward, campaign.fundTokenDecimals);
 }
 
 export function calculateRewardPool(
@@ -103,9 +110,7 @@ export function calculateRewardPool(
 
   const rewardPool = Decimal.mul(dailyReward, progressRatio);
 
-  return rewardPool
-    .toDecimalPlaces(campaign.fundTokenDecimals, Decimal.ROUND_DOWN)
-    .toString();
+  return formatRewardValue(rewardPool, campaign.fundTokenDecimals);
 }
 
 export function estimateRewards(
@@ -201,12 +206,13 @@ export function estimateCompetitiveRewards(
 
     const rewardPerParticipant = Decimal.mul(rewardPool, totalRewardPercent)
       .div(100)
-      .div(nTiedResults)
-      .toDecimalPlaces(campaign.fundTokenDecimals, Decimal.ROUND_DOWN);
+      .div(nTiedResults);
 
     if (rewardPerParticipant.greaterThan(0)) {
       for (const tiedResult of tiedResults) {
-        estimatedRewards[tiedResult.address] = rewardPerParticipant.toNumber();
+        estimatedRewards[tiedResult.address] = Number(
+          formatRewardValue(rewardPerParticipant, campaign.fundTokenDecimals),
+        );
       }
     }
 

--- a/recording-oracle/src/modules/campaigns/rewards.utils.ts
+++ b/recording-oracle/src/modules/campaigns/rewards.utils.ts
@@ -45,14 +45,6 @@ export function calculateRewardPool(
   );
 
   if (nRewardCycles > CAMPAIGNS_DAILY_CYCLE) {
-    /**
-     * TODO: handle "to_cancel" campaigns where cycle duration is > 1 day.
-     *
-     * Such can happend if RecO wasn't able to record results for a cycle in time
-     * and cancellation request came in after the end of that cycle.
-     * In that case we can't go cycle-by-cycly because `storeResults` can be called
-     * only once for `to_cancel` escrows, so we need to have a special handling for that case.
-     */
     throw new Error(
       `Unexpected number of reward cycles in progress period: ${nRewardCycles}`,
     );


### PR DESCRIPTION
## Issue tracking
Closes #839 

## Context behind the change
It might be that by some reason RecO is stuck and later, when comes back, it needs to record campaign progress for multiple cycles. If these multiple cycles end with cancellation request - then we have only one `storeResults` call to record results (because contract allows it that way and does refund for everything that is not reserved) and existing approach where we record results cycly-by-cycle doesn't work correctly. So in this PR we change the approach to record progress for all passed cycles.

## How has this been tested?
- [x] unit tests
- [x] e2e locally for campaigns that haven't had results recorded for a couple of days

## Release plan
Regular

## Potential risks; What to monitor; Rollback plan
Should be none