### PR TITLE
[Recording Oracle] fix: empty results leaderboard

### DIFF
--- a/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
@@ -5042,6 +5042,14 @@ describe('CampaignsService', () => {
       async (campaignStatus) => {
         campaign.status = campaignStatus;
 
+        const participants = Array.from(
+          { length: faker.number.int({ min: 3, max: 5 }) },
+          () => generateCampaignParticipant(campaign),
+        );
+        mockParticipationsRepository.findCampaignParticipants.mockResolvedValueOnce(
+          participants,
+        );
+
         const data = await campaignsService.getCampaignLeaderboard(
           campaign.chainId,
           campaign.address,
@@ -5050,8 +5058,22 @@ describe('CampaignsService', () => {
         expect(data).toEqual({
           updatedAt: now,
           total: 0,
-          entries: [],
+          entries: expect.any(Array),
         });
+        expect(data.entries).toHaveLength(participants.length);
+        const entriesByParticipant = _.keyBy(
+          data.entries,
+          (entry) => entry.address,
+        );
+        for (const { evmAddress } of participants) {
+          const entry = entriesByParticipant[evmAddress];
+          expect(entry).toEqual({
+            address: evmAddress,
+            score: 0,
+            result: 0,
+            estimatedReward: 0,
+          });
+        }
       },
     );
   });

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -1534,9 +1534,24 @@ export class CampaignsService implements OnModuleDestroy {
         );
         updatedAt = new Date(cachedInterimResults.to);
       } else {
-        resultsToInspect = [];
-        estimatedRewardPool = '0';
-        updatedAt = new Date();
+        const zeroEntries: LeaderboardEntry[] = [];
+        const participants =
+          await this.participationsRepository.findCampaignParticipants(
+            campaign.id,
+          );
+        for (const participant of participants) {
+          zeroEntries.push({
+            address: participant.evmAddress,
+            score: 0,
+            result: 0,
+            estimatedReward: 0,
+          });
+        }
+        return {
+          entries: zeroEntries,
+          total: 0,
+          updatedAt: new Date(),
+        };
       }
     }
 


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Atm when there are not interim results we return empty leaderboard. UI relies on that info to show some extra data on UI (e.g. total number of participants), so instead of returning empty leaderboard return it filled with 0 values for all participants.

## How has this been tested?
- [x] locally e2e when cache is empty
- [x] unit test

## Release plan
Regular

## Potential risks; What to monitor; Rollback plan
Endpoint with leaderboard is public and we added another DB query in it. So if load becomes an issue - we can add some in-memory caching.