### PR TITLE
[Recording Oracle] feat: cancellation requested at for joined

### DIFF
--- a/recording-oracle/src/infrastructure/database/migrations/1776854041823-add-canc-req-at.ts
+++ b/recording-oracle/src/infrastructure/database/migrations/1776854041823-add-canc-req-at.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCancReqAt1776854041823 implements MigrationInterface {
+  name = 'AddCancReqAt1776854041823';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "hu_fi"."campaigns" ADD "cancellation_requested_at" TIMESTAMP WITH TIME ZONE`,
+    );
+    /**
+     * There might be some old campaigns that were just cancelled w/o cancellation request.
+     * We can detect those and update via script or manually.
+     */
+    await queryRunner.query(`
+        UPDATE "hu_fi"."campaigns"
+        SET "cancellation_requested_at" = "results_cutoff_at"
+        WHERE "status" IN ('cancelled', 'pending_cancellation')
+            AND "cancellation_requested_at" IS NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "hu_fi"."campaigns" DROP COLUMN "cancellation_requested_at"`,
+    );
+  }
+}

--- a/recording-oracle/src/modules/campaigns/campaign.entity.ts
+++ b/recording-oracle/src/modules/campaigns/campaign.entity.ts
@@ -59,6 +59,9 @@ export class CampaignEntity {
   @Column({ type: 'timestamptz', nullable: true })
   resultsCutoffAt: Date | null;
 
+  @Column({ type: 'timestamptz', nullable: true })
+  cancellationRequestedAt: Date | null;
+
   @Column({
     type: 'enum',
     enum: CampaignStatus,

--- a/recording-oracle/src/modules/campaigns/campaigns.controller.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.controller.ts
@@ -132,6 +132,9 @@ export class CampaignsController {
           details: campaign.details,
           status: CAMPAIGN_STATUS_TO_RETURNED_STATUS[campaign.status],
           processingStatus: campaign.status,
+          cancellationRequestedAt: campaign.cancellationRequestedAt
+            ? campaign.cancellationRequestedAt.valueOf()
+            : null,
         }))
         .slice(0, limit),
     };

--- a/recording-oracle/src/modules/campaigns/campaigns.dto.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.dto.ts
@@ -75,6 +75,9 @@ class JoinedCampaignDto {
   @ApiProperty({ name: 'processing_status' })
   processingStatus: string;
 
+  @ApiProperty({ name: 'cancellation_requested_at' })
+  cancellationRequestedAt: number | null;
+
   type: CampaignType;
 
   details: CampaignDetails;

--- a/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
@@ -791,13 +791,37 @@ describe('CampaignsService', () => {
   });
 
   describe('createCampaign', () => {
+    let chainId: number;
+    let campaignAddress: string;
+    let fundAmount: number;
+    let fundTokenSymbol: string;
+    let fundTokenDecimals: number;
+
+    let commonExpectedCampaignData: Record<string, unknown>;
+
+    beforeEach(() => {
+      chainId = generateTestnetChainId();
+      campaignAddress = faker.finance.ethereumAddress();
+      fundAmount = faker.number.float();
+      fundTokenSymbol = faker.finance.currencyCode();
+      fundTokenDecimals = faker.number.int({ min: 6, max: 18 });
+
+      commonExpectedCampaignData = {
+        id: expect.any(String),
+        chainId,
+        address: ethers.getAddress(campaignAddress),
+        fundAmount: fundAmount.toString(),
+        fundToken: fundTokenSymbol,
+        fundTokenDecimals,
+        status: 'active',
+        lastResultsAt: null,
+        resultsCutoffAt: null,
+        cancellationRequestedAt: null,
+      };
+    });
+
     it('should create market making campaign with proper data', async () => {
-      const chainId = generateTestnetChainId();
-      const campaignAddress = faker.finance.ethereumAddress();
       const manifest = generateMarketMakingCampaignManifest();
-      const fundAmount = faker.number.float();
-      const fundTokenSymbol = faker.finance.currencyCode();
-      const fundTokenDecimals = faker.number.int({ min: 6, max: 18 });
 
       const campaign = await campaignsService.createCampaign(
         chainId,
@@ -807,29 +831,22 @@ describe('CampaignsService', () => {
           fundAmount,
           fundTokenSymbol,
           fundTokenDecimals,
+          cancellationRequestedAt: null,
         },
       );
 
       expect(isUuidV4(campaign.id)).toBe(true);
 
       const expectedCampaignData = {
-        id: expect.any(String),
-        chainId,
-        address: ethers.getAddress(campaignAddress),
+        ...commonExpectedCampaignData,
         type: manifest.type,
         exchangeName: manifest.exchange,
         symbol: manifest.pair,
         startDate: manifest.start_date,
         endDate: manifest.end_date,
-        fundAmount: fundAmount.toString(),
-        fundToken: fundTokenSymbol,
-        fundTokenDecimals,
         details: {
           dailyVolumeTarget: manifest.daily_volume_target,
         },
-        status: 'active',
-        lastResultsAt: null,
-        resultsCutoffAt: null,
       };
       expect(campaign).toEqual(expectedCampaignData);
 
@@ -840,12 +857,7 @@ describe('CampaignsService', () => {
     });
 
     it('should create holding campaign with proper data', async () => {
-      const chainId = generateTestnetChainId();
-      const campaignAddress = faker.finance.ethereumAddress();
       const manifest = generateHoldingCampaignManifest();
-      const fundAmount = faker.number.float();
-      const fundTokenSymbol = faker.finance.currencyCode();
-      const fundTokenDecimals = faker.number.int({ min: 6, max: 18 });
 
       const campaign = await campaignsService.createCampaign(
         chainId,
@@ -855,29 +867,22 @@ describe('CampaignsService', () => {
           fundAmount,
           fundTokenSymbol,
           fundTokenDecimals,
+          cancellationRequestedAt: null,
         },
       );
 
       expect(isUuidV4(campaign.id)).toBe(true);
 
       const expectedCampaignData = {
-        id: expect.any(String),
-        chainId,
-        address: ethers.getAddress(campaignAddress),
+        ...commonExpectedCampaignData,
         type: manifest.type,
         exchangeName: manifest.exchange,
         symbol: manifest.symbol,
         startDate: manifest.start_date,
         endDate: manifest.end_date,
-        fundAmount: fundAmount.toString(),
-        fundToken: fundTokenSymbol,
-        fundTokenDecimals,
         details: {
           dailyBalanceTarget: manifest.daily_balance_target,
         },
-        status: 'active',
-        lastResultsAt: null,
-        resultsCutoffAt: null,
       };
       expect(campaign).toEqual(expectedCampaignData);
 
@@ -888,12 +893,7 @@ describe('CampaignsService', () => {
     });
 
     it('should create competitive market making campaign with proper data', async () => {
-      const chainId = generateTestnetChainId();
-      const campaignAddress = faker.finance.ethereumAddress();
       const manifest = generateCompetitiveMarketMakingCampaignManifest();
-      const fundAmount = faker.number.float();
-      const fundTokenSymbol = faker.finance.currencyCode();
-      const fundTokenDecimals = faker.number.int({ min: 6, max: 18 });
 
       const campaign = await campaignsService.createCampaign(
         chainId,
@@ -903,30 +903,23 @@ describe('CampaignsService', () => {
           fundAmount,
           fundTokenSymbol,
           fundTokenDecimals,
+          cancellationRequestedAt: null,
         },
       );
 
       expect(isUuidV4(campaign.id)).toBe(true);
 
       const expectedCampaignData = {
-        id: expect.any(String),
-        chainId,
-        address: ethers.getAddress(campaignAddress),
+        ...commonExpectedCampaignData,
         type: manifest.type,
         exchangeName: manifest.exchange,
         symbol: manifest.pair,
         startDate: manifest.start_date,
         endDate: manifest.end_date,
-        fundAmount: fundAmount.toString(),
-        fundToken: fundTokenSymbol,
-        fundTokenDecimals,
         details: {
           minVolumeRequired: manifest.min_volume_required,
           rewardsDistribution: manifest.rewards_distribution,
         },
-        status: 'active',
-        lastResultsAt: null,
-        resultsCutoffAt: null,
       };
       expect(campaign).toEqual(expectedCampaignData);
 
@@ -937,20 +930,10 @@ describe('CampaignsService', () => {
     });
 
     describe('threshold campaign creation', () => {
-      let chainId: number;
-      let campaignAddress: string;
       let manifest: ThresholdCampaignManifest;
-      let fundAmount: number;
-      let fundTokenSymbol: string;
-      let fundTokenDecimals: number;
 
       beforeEach(() => {
-        chainId = generateTestnetChainId();
-        campaignAddress = faker.finance.ethereumAddress();
         manifest = generateThresholdampaignManifest();
-        fundAmount = faker.number.float();
-        fundTokenSymbol = faker.finance.currencyCode();
-        fundTokenDecimals = faker.number.int({ min: 6, max: 18 });
       });
 
       it('should create with proper data', async () => {
@@ -962,29 +945,22 @@ describe('CampaignsService', () => {
             fundAmount,
             fundTokenSymbol,
             fundTokenDecimals,
+            cancellationRequestedAt: null,
           },
         );
 
         expect(isUuidV4(campaign.id)).toBe(true);
 
         const expectedCampaignData = {
-          id: expect.any(String),
-          chainId,
-          address: ethers.getAddress(campaignAddress),
+          ...commonExpectedCampaignData,
           type: manifest.type,
           exchangeName: manifest.exchange,
           symbol: manifest.symbol,
           startDate: manifest.start_date,
           endDate: manifest.end_date,
-          fundAmount: fundAmount.toString(),
-          fundToken: fundTokenSymbol,
-          fundTokenDecimals,
           details: expect.objectContaining({
             minimumBalanceTarget: manifest.minimum_balance_target,
           }),
-          status: 'active',
-          lastResultsAt: null,
-          resultsCutoffAt: null,
         };
         expect(campaign).toEqual(expectedCampaignData);
 
@@ -1007,10 +983,10 @@ describe('CampaignsService', () => {
             fundAmount,
             fundTokenSymbol,
             fundTokenDecimals,
+            cancellationRequestedAt: null,
           },
         );
 
-        expect(isUuidV4(campaign.id)).toBe(true);
         expect(campaign.details).toEqual({
           minimumBalanceTarget: manifest.minimum_balance_target,
           maxParticipants: manifest.max_participants,
@@ -1031,15 +1007,52 @@ describe('CampaignsService', () => {
             fundAmount,
             fundTokenSymbol,
             fundTokenDecimals,
+            cancellationRequestedAt: null,
           },
         );
 
-        expect(isUuidV4(campaign.id)).toBe(true);
         expect(campaign.details).toEqual({
           minimumBalanceTarget: manifest.minimum_balance_target,
         });
         expect(mockCampaignsRepository.insert).toHaveBeenCalledTimes(1);
       });
+    });
+
+    it('should create to_cancel campaign with proper data', async () => {
+      const manifest = generateCampaignManifest();
+      const cancellationRequestedAt = faker.date.recent();
+
+      const campaign = await campaignsService.createCampaign(
+        chainId,
+        campaignAddress,
+        manifest,
+        {
+          fundAmount,
+          fundTokenSymbol,
+          fundTokenDecimals,
+          cancellationRequestedAt: cancellationRequestedAt.valueOf(),
+        },
+      );
+
+      expect(isUuidV4(campaign.id)).toBe(true);
+
+      const expectedCampaignData = {
+        ...commonExpectedCampaignData,
+        type: manifest.type,
+        exchangeName: manifest.exchange,
+        symbol: expect.any(String),
+        startDate: manifest.start_date,
+        endDate: manifest.end_date,
+        details: expect.any(Object),
+        status: 'to_cancel',
+        cancellationRequestedAt,
+      };
+      expect(campaign).toEqual(expect.objectContaining(expectedCampaignData));
+
+      expect(mockCampaignsRepository.insert).toHaveBeenCalledTimes(1);
+      expect(mockCampaignsRepository.insert).toHaveBeenCalledWith(
+        expect.objectContaining(expectedCampaignData),
+      );
     });
   });
 
@@ -3416,9 +3429,11 @@ describe('CampaignsService', () => {
         (c) => c.status === CampaignStatus.ACTIVE,
       );
       const activeCampaign = Object.assign({}, campaigns[activeCampaignIndex]);
+      const cancellationRequestedAt = faker.date.recent();
 
       mockedEscrowUtils.getEscrow.mockResolvedValue({
         status: EscrowStatus[EscrowStatus.ToCancel],
+        cancellationRequestedAt: cancellationRequestedAt.valueOf(),
       } as IEscrow);
 
       await campaignsService.syncCampaignStatuses();
@@ -3427,6 +3442,7 @@ describe('CampaignsService', () => {
       expect(mockCampaignsRepository.save).toHaveBeenCalledWith({
         ...activeCampaign,
         status: 'to_cancel',
+        cancellationRequestedAt,
       });
       expect(logger.info).toHaveBeenCalledWith(
         'Marking campaign as to_cancel',

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -251,9 +251,18 @@ export class CampaignsService implements OnModuleDestroy {
     newCampaign.fundToken = escrowInfo.fundTokenSymbol;
     newCampaign.fundTokenDecimals = escrowInfo.fundTokenDecimals;
     newCampaign.details = details;
-    newCampaign.status = CampaignStatus.ACTIVE;
     newCampaign.lastResultsAt = null;
     newCampaign.resultsCutoffAt = null;
+
+    if (escrowInfo.cancellationRequestedAt) {
+      newCampaign.status = CampaignStatus.TO_CANCEL;
+      newCampaign.cancellationRequestedAt = new Date(
+        escrowInfo.cancellationRequestedAt,
+      );
+    } else {
+      newCampaign.status = CampaignStatus.ACTIVE;
+      newCampaign.cancellationRequestedAt = null;
+    }
 
     await this.campaignsRepository.insert(newCampaign);
 
@@ -416,6 +425,7 @@ export class CampaignsService implements OnModuleDestroy {
         ),
         fundTokenSymbol: campaignTokenSymbol,
         fundTokenDecimals: campaignTokenDecimals,
+        cancellationRequestedAt: escrow.cancellationRequestedAt,
       },
     };
   }
@@ -1028,6 +1038,9 @@ export class CampaignsService implements OnModuleDestroy {
             campaignAddress: campaign.address,
           });
           campaign.status = CampaignStatus.TO_CANCEL;
+          campaign.cancellationRequestedAt = new Date(
+            escrow.cancellationRequestedAt!,
+          );
           await this.campaignsRepository.save(campaign);
         }
       }

--- a/recording-oracle/src/modules/campaigns/fixtures/campaign.ts
+++ b/recording-oracle/src/modules/campaigns/fixtures/campaign.ts
@@ -90,6 +90,7 @@ export function generateCampaignEntity(type?: CampaignType): CampaignEntity {
     details,
     lastResultsAt: null,
     resultsCutoffAt: null,
+    cancellationRequestedAt: null,
     status: CampaignStatus.ACTIVE,
     createdAt: faker.date.recent(),
     updatedAt: new Date(),

--- a/recording-oracle/src/modules/campaigns/types.ts
+++ b/recording-oracle/src/modules/campaigns/types.ts
@@ -92,6 +92,7 @@ export type CampaignEscrowInfo = {
   fundAmount: number;
   fundTokenSymbol: string;
   fundTokenDecimals: number;
+  cancellationRequestedAt: number | null;
 };
 
 export type ParticipantOutcome = {


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
New UI uses "cancellation_requested_at" date to display it for joined campaigns as well, so we need to add it to RecO.

## How has this been tested?
- [x] unit tests
- [x] run migration locally, make sure it's good
- [x] e2e locally: query joined campaigns via API and see new prop is returned

## Release plan
Some campaigns were cancelled in an old way (i.e. w/o cancellation request, prior to contracts update) or cancelled before start date, so no results. For these campaigns we will updated `cancellation_requested_at` prop in DB separately after migration run.

## Potential risks; What to monitor; Rollback plan
Should be none