### PR TITLE
fix: asset symbol format checks for kraken

### DIFF
--- a/campaign-launcher/server/src/modules/exchanges/api-client/exchange-api-client-factory.ts
+++ b/campaign-launcher/server/src/modules/exchanges/api-client/exchange-api-client-factory.ts
@@ -4,6 +4,7 @@ import { ExchangeName } from '@/common/constants';
 
 import { CcxtExchangeClient } from './ccxt-exchange-client';
 import type { ExchangeApiClient } from './exchange-api-client.interface';
+import { KrakenClient } from './kraken-client';
 import { PancakeSwapClient } from './pancakeswap-client';
 
 @Injectable()
@@ -16,6 +17,9 @@ export class ExchangeApiClientFactory {
       switch (exchangeName) {
         case ExchangeName.PANCAKESWAP:
           client = new PancakeSwapClient();
+          break;
+        case ExchangeName.KRAKEN:
+          client = new KrakenClient();
           break;
         default:
           client = new CcxtExchangeClient(exchangeName);

--- a/campaign-launcher/server/src/modules/exchanges/api-client/kraken-client.ts
+++ b/campaign-launcher/server/src/modules/exchanges/api-client/kraken-client.ts
@@ -40,9 +40,20 @@ export class KrakenClient extends BaseExchangeApiClient {
 
     const updatedAssets: string[] = [];
     for (const [assetSymbol, assetInfo] of Object.entries(data.result)) {
-      if (assetInfo.status === 'enabled') {
-        updatedAssets.push(assetSymbol);
+      if (assetInfo.status !== 'enabled') {
+        continue;
       }
+
+      /**
+       * https://support.kraken.com/articles/360039879471-what-is-asset-s-and-asset-m-?
+       * Technically it's possible to have "." in crypto symbol, but for simplicity
+       * filter out all assets with "." to exlcude Kraken internal assets for "Migration".
+       */
+      if (assetSymbol.indexOf('.') > -1) {
+        continue;
+      }
+
+      updatedAssets.push(assetSymbol);
     }
     this.assets = updatedAssets;
   }
@@ -60,16 +71,15 @@ export class KrakenClient extends BaseExchangeApiClient {
     }
 
     const updatedTradeableAssetPairs: string[] = [];
-    for (const [assetPair, assetPairInfo] of Object.entries(data.result)) {
-      if (assetPairInfo.status === 'online') {
-        let assetPairName: string;
-        if (assetPairInfo.wsname) {
-          assetPairName = assetPairInfo.wsname;
-        } else {
-          const quoteAltName = assetPair.slice(assetPairInfo.base.length);
-          assetPairName = `${assetPairInfo.base}/${quoteAltName}`;
-        }
-        updatedTradeableAssetPairs.push(assetPairName);
+    for (const [_assetPair, assetPairInfo] of Object.entries(data.result)) {
+      /**
+       * Assert pair name itself is in BASEQUOTE format and in order to put "/"
+       * we have to map base and quote assets correctly (e.g. XXDG -> XDG, ZUSD -> USD).
+       * To simplify this - rely on wsname field which is in BASE/QUOTE format
+       * and contains (presumably) already mapped asset names.
+       */
+      if (assetPairInfo.status === 'online' && assetPairInfo.wsname) {
+        updatedTradeableAssetPairs.push(assetPairInfo.wsname);
       }
     }
     this.tradeableAssetPairs = updatedTradeableAssetPairs;

--- a/campaign-launcher/server/src/modules/exchanges/api-client/kraken-client.ts
+++ b/campaign-launcher/server/src/modules/exchanges/api-client/kraken-client.ts
@@ -1,0 +1,89 @@
+import { ExchangeName } from '@/common/constants';
+
+import { BaseExchangeApiClient } from './base-client';
+
+const BASE_API_URL = 'https://api.kraken.com/0/public';
+
+type KrakenAsset = {
+  altname: string;
+  decimals: number;
+  display_decimals: number;
+  status: string;
+};
+
+type KrakenTradeableAssetPair = {
+  altname: string;
+  wsname: string;
+  aclass_base: string;
+  base: string;
+  aclass_quote: string;
+  quote: string;
+  status: string;
+};
+
+export class KrakenClient extends BaseExchangeApiClient {
+  private assets: string[] = [];
+  private tradeableAssetPairs: string[] = [];
+
+  constructor() {
+    super(ExchangeName.KRAKEN);
+  }
+
+  private async loadAssets(): Promise<void> {
+    const response = await fetch(`${BASE_API_URL}/Assets?aclass=currency`);
+    const data: { result?: Record<string, KrakenAsset> } =
+      await response.json();
+
+    if (!data.result) {
+      throw new Error('Failed to load assets from Kraken API');
+    }
+
+    const updatedAssets: string[] = [];
+    for (const [assetSymbol, assetInfo] of Object.entries(data.result)) {
+      if (assetInfo.status === 'enabled') {
+        updatedAssets.push(assetSymbol);
+      }
+    }
+    this.assets = updatedAssets;
+  }
+
+  private async loadTradeableAssetPairs(): Promise<void> {
+    const response = await fetch(
+      `${BASE_API_URL}/AssetPairs?aclass_base=currency`,
+    );
+    const data: {
+      result?: Record<string, KrakenTradeableAssetPair>;
+    } = await response.json();
+
+    if (!data.result) {
+      throw new Error('Failed to load tradeable asset pairs from Kraken API');
+    }
+
+    const updatedTradeableAssetPairs: string[] = [];
+    for (const [assetPair, assetPairInfo] of Object.entries(data.result)) {
+      if (assetPairInfo.status === 'online') {
+        let assetPairName: string;
+        if (assetPairInfo.wsname) {
+          assetPairName = assetPairInfo.wsname;
+        } else {
+          const quoteAltName = assetPair.slice(assetPairInfo.base.length);
+          assetPairName = `${assetPairInfo.base}/${quoteAltName}`;
+        }
+        updatedTradeableAssetPairs.push(assetPairName);
+      }
+    }
+    this.tradeableAssetPairs = updatedTradeableAssetPairs;
+  }
+
+  protected async runLoadMarkets(): Promise<void> {
+    await Promise.all([this.loadAssets(), this.loadTradeableAssetPairs()]);
+  }
+
+  protected get tradingPairs() {
+    return this.tradeableAssetPairs;
+  }
+
+  protected get currencies() {
+    return this.assets;
+  }
+}

--- a/recording-oracle/src/modules/exchanges/api-client/kraken/fixtures/index.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/kraken/fixtures/index.ts
@@ -17,10 +17,9 @@ export function generateTradeTime(date = faker.date.past()): {
 
   return {
     formatted: `${baseTime}.${msPart}`,
-    timestamp: dayjs(
-      `${baseTime}.${msPart.substring(0, 3)}Z`,
-      `${BASE_TIME_FORMAT}.SSSZ`,
-    ).valueOf(),
+    timestamp: dayjs
+      .utc(`${baseTime}.${msPart.substring(0, 3)}`, `${BASE_TIME_FORMAT}.SSS`)
+      .valueOf(),
   };
 }
 
@@ -54,7 +53,7 @@ export function generateCsvTradeLine(
       .join('-')
       .toUpperCase(),
     time: tradeTime.formatted,
-    pair: `${faker.finance.currencyCode()}-${faker.finance.currencyCode()}`,
+    pair: `${faker.finance.currencyCode()}/${faker.finance.currencyCode()}`,
     type: faker.helpers.arrayElement(['buy', 'sell'] as const),
     price: price.toString(),
     vol: amount.toString(),

--- a/recording-oracle/src/modules/exchanges/api-client/kraken/kraken-client.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/kraken/kraken-client.ts
@@ -438,19 +438,6 @@ export class KrakenClient implements ExchangeApiClient {
 
     let trades: Trade[] = [];
     for await (const csvLine of report.parsedCsvStream) {
-      if (csvLine.pair.indexOf('/') === -1) {
-        /**
-         * TradeHistory and report API have different formats for pair, e.g.:
-         * - trade history: "CCDUSD"
-         * - report: "CCD/USD"
-         *
-         * "BASE/QUOTE" is our common format for symbols, so have this safety-belt
-         * to avoid potential loss of results due to unexpected format change.
-         */
-        throw new KrakenClientError(
-          `Unexpected pair format in report: ${csvLine.pair}`,
-        );
-      }
       const trade = krakenUtils.mapReportRowToTrade(csvLine);
       if (trade.symbol !== symbol) {
         continue;

--- a/recording-oracle/src/modules/exchanges/api-client/kraken/kraken-client.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/kraken/kraken-client.ts
@@ -438,6 +438,19 @@ export class KrakenClient implements ExchangeApiClient {
 
     let trades: Trade[] = [];
     for await (const csvLine of report.parsedCsvStream) {
+      if (csvLine.pair.indexOf('/') === -1) {
+        /**
+         * TradeHistory and report API have different formats for pair, e.g.:
+         * - trade history: "CCDUSD"
+         * - report: "CCD/USD"
+         *
+         * "BASE/QUOTE" is our common format for symbols, so have this safety-belt
+         * to avoid potential loss of results due to unexpected format change.
+         */
+        throw new KrakenClientError(
+          `Unexpected pair format in report: ${csvLine.pair}`,
+        );
+      }
       const trade = krakenUtils.mapReportRowToTrade(csvLine);
       if (trade.symbol !== symbol) {
         continue;

--- a/recording-oracle/src/modules/exchanges/api-client/kraken/utils.spec.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/kraken/utils.spec.ts
@@ -67,21 +67,21 @@ describe('Kraken client utils', () => {
 
     it('should pad timestamp when no fractional digits', () => {
       expect(normalizeTimestamp(baseKrakenTimestamp)).toBe(
-        `${baseKrakenTimestamp}.000Z`,
+        `${baseKrakenTimestamp}.000`,
       );
     });
 
     it('should normalize a timestamp with more than 3 fractional digits by truncating', () => {
       const msPart = faker.number.int({ min: 1000 }).toString();
       expect(normalizeTimestamp(`${baseKrakenTimestamp}.${msPart}`)).toBe(
-        `${baseKrakenTimestamp}.${msPart.slice(0, 3)}Z`,
+        `${baseKrakenTimestamp}.${msPart.slice(0, 3)}`,
       );
     });
 
-    it('should normalize a timestamp with exactly 3 fractional digits unchanged', () => {
-      const msPart = faker.number.int({ min: 0, max: 999 }).toString();
+    it('should keep timestamp with exactly 3 fractional digits unchanged', () => {
+      const msPart = faker.number.int({ min: 100, max: 999 }).toString();
       expect(normalizeTimestamp(`${baseKrakenTimestamp}.${msPart}`)).toBe(
-        `${baseKrakenTimestamp}.${msPart}Z`,
+        `${baseKrakenTimestamp}.${msPart}`,
       );
     });
 
@@ -89,7 +89,7 @@ describe('Kraken client utils', () => {
       const msPart = faker.number.int({ min: 1, max: 99 }).toString();
 
       expect(normalizeTimestamp(`${baseKrakenTimestamp}.${msPart}`)).toBe(
-        `${baseKrakenTimestamp}.${msPart.padEnd(3, '0')}Z`,
+        `${baseKrakenTimestamp}.${msPart.padEnd(3, '0')}`,
       );
     });
   });
@@ -149,6 +149,25 @@ describe('Kraken client utils', () => {
   });
 
   describe('mapReportRowToTrade', () => {
+    it('should throw when report pair is not in BASE/QUOTE format', () => {
+      const csvTrade = generateCsvTradeLine({
+        pair: `${faker.finance.currencyCode()}${faker.finance.currencyCode()}`,
+      });
+
+      expect(() => mapReportRowToTrade(csvTrade)).toThrow(
+        `Unexpected pair format in report: ${csvTrade.pair}`,
+      );
+    });
+
+    it('should throw when report timestamp cannot be parsed', () => {
+      const csvTrade = generateCsvTradeLine();
+      csvTrade.time = new Date(csvTrade.__timestamp).toISOString();
+
+      expect(() => mapReportRowToTrade(csvTrade)).toThrow(
+        `Invalid timestamp format in report: ${csvTrade.time}`,
+      );
+    });
+
     it('should correctly map base data from csv row to trade', () => {
       const csvTrade = generateCsvTradeLine();
 

--- a/recording-oracle/src/modules/exchanges/api-client/kraken/utils.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/kraken/utils.ts
@@ -117,7 +117,7 @@ export function normalizeTimestamp(rawTs: string): string {
   const [_upToMsPart, msPart] = rawTs.split('.');
 
   if (!msPart) {
-    return rawTs + '.000Z';
+    return rawTs + '.000';
   }
 
   let normalized: string;
@@ -127,15 +127,31 @@ export function normalizeTimestamp(rawTs: string): string {
     normalized = rawTs + '0'.repeat(3 - msPart.length);
   }
 
-  return normalized + 'Z';
+  return normalized;
 }
 
 // https://support.kraken.com/articles/360001184886-how-to-interpret-trades-history-fields
 export function mapReportRowToTrade(csvTrade: ReportCsvRow): Trade {
-  const timestamp = dayjs(
+  if (csvTrade.pair.indexOf('/') === -1) {
+    /**
+     * TradeHistory and report API have different formats for pair, e.g.:
+     * - trade history: "CCDUSD"
+     * - report: "CCD/USD"
+     *
+     * "BASE/QUOTE" is our common format for symbols, so have this safety-belt
+     * to avoid potential loss of results due to unexpected format change.
+     */
+    throw new Error(`Unexpected pair format in report: ${csvTrade.pair}`);
+  }
+
+  const timestamp = dayjs.utc(
     normalizeTimestamp(csvTrade.time),
-    'YYYY-MM-DD HH:mm:ss.SSSZ',
+    'YYYY-MM-DD HH:mm:ss.SSS',
+    true,
   );
+  if (!timestamp.isValid()) {
+    throw new Error(`Invalid timestamp format in report: ${csvTrade.time}`);
+  }
 
   return {
     id: csvTrade.txid,

--- a/recording-oracle/src/setup-libs.ts
+++ b/recording-oracle/src/setup-libs.ts
@@ -2,6 +2,7 @@ import { Logger as ValkeyLogger } from '@valkey/valkey-glide';
 import dayjs from 'dayjs';
 import dayjsCustomParseFormat from 'dayjs/plugin/customParseFormat';
 import dayjsIsSameOrAfter from 'dayjs/plugin/isSameOrAfter';
+import dayjsUtc from 'dayjs/plugin/utc';
 import Decimal from 'decimal.js';
 
 /**
@@ -15,5 +16,6 @@ Decimal.set({
 
 dayjs.extend(dayjsCustomParseFormat);
 dayjs.extend(dayjsIsSameOrAfter);
+dayjs.extend(dayjsUtc);
 
 ValkeyLogger.setLoggerConfig('off');


### PR DESCRIPTION
## Issue tracking
Follow up to #866 

## Context behind the change
1. List of `currencies` returned by `ccxt` for Kraken doesn't reflect the name of symbol used to check the balance; e.g. `ZUSD` is the asset name (and same on account balance), but `ccxt` maps it to its `altname`: `USD`. So we have to handle it by fetching original list to correctly launch "holding" campaigns
2. Tradeable asset pair name is different in various places of Kraken API, so uniform it and add safety-belts.

## How has this been tested?
- [x] unit tests
- [ ] run CL locally, retrieve list of currencies and trading pairs, verify they match expectations.

## Release plan
With main PR.

## Potential risks; What to monitor; Rollback plan
TBD