### PR TITLE
[Campaign Launcher UI] Show link to the intermediate results in case campaign has ended without payouts

### DIFF
--- a/campaign-launcher/client/src/components/CampaignResultsSection/index.tsx
+++ b/campaign-launcher/client/src/components/CampaignResultsSection/index.tsx
@@ -36,12 +36,14 @@ const CampaignResultsSection: FC<Props> = ({ campaign }) => {
     CampaignStatus.COMPLETED,
   ].includes(status);
 
+  const resultUrlForFinished = final_results_url ?? intermediate_results_url;
+
   let result: ResultType[keyof ResultType];
   let resultUrl: string;
 
-  if (isFinished && final_results_url) {
+  if (isFinished && resultUrlForFinished) {
     result = RESULT.final;
-    resultUrl = final_results_url;
+    resultUrl = resultUrlForFinished;
   } else if (!isFinished && intermediate_results_url) {
     result = RESULT.intermediate;
     resultUrl = intermediate_results_url;


### PR DESCRIPTION
## Issue tracking
Closes #882 

## Context behind the change
In order to keep UI consistent we need to use intermediate_results_url as a fallback value, if a campaign is finished

## How has this been tested?
locally

## Release plan
regular

## Potential risks; What to monitor; Rollback plan
not found