### PR TITLE
fix: dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,7 @@ updates:
           - "@types/react-dom"
     open-pull-requests-limit: 5 # Reasonable number to start with
     cooldown:
-      patch-days: 3
-      minor-days: 7
-      major-days: 30
+      default-days: 3
+      semver-patch-days: 3
+      semver-minor-days: 7
+      semver-major-days: 30


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Typo in dependabot's cooldown option: it should also have `semver-` prefix.

## How has this been tested?
Double-checked via docs.

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No