### PR TITLE
[Campaign Launcher] fix: trading pairs list in sandbox env

### DIFF
--- a/campaign-launcher/server/src/modules/exchanges/api-client/ccxt-exchange-client.ts
+++ b/campaign-launcher/server/src/modules/exchanges/api-client/ccxt-exchange-client.ts
@@ -3,6 +3,7 @@ import type { Exchange } from 'ccxt';
 import _ from 'lodash';
 
 import { ExchangeName } from '@/common/constants';
+import Environment from '@/common/utils/environment';
 
 import { BaseExchangeApiClient } from './base-client';
 import { BASE_CCXT_CLIENT_OPTIONS } from './constants';
@@ -20,8 +21,9 @@ export class CcxtExchangeClient extends BaseExchangeApiClient {
     const exchangeClass = ccxt[exchangeName];
     let perExchangeClientOptions: Record<string, unknown> = {};
 
+    let useSandbox = false;
     switch (exchangeName) {
-      case ExchangeName.HYPERLIQUID:
+      case ExchangeName.HYPERLIQUID: {
         perExchangeClientOptions = {
           options: {
             fetchMarkets: {
@@ -29,12 +31,15 @@ export class CcxtExchangeClient extends BaseExchangeApiClient {
             },
           },
         };
+        useSandbox = !Environment.isProduction();
         break;
+      }
     }
 
     this.ccxtClient = new exchangeClass(
       _.merge({}, BASE_CCXT_CLIENT_OPTIONS, perExchangeClientOptions),
     );
+    this.ccxtClient.setSandboxMode(useSandbox);
   }
 
   protected get tradingPairs() {

--- a/campaign-launcher/server/src/modules/exchanges/api-client/ccxt-exchange-client.ts
+++ b/campaign-launcher/server/src/modules/exchanges/api-client/ccxt-exchange-client.ts
@@ -21,7 +21,6 @@ export class CcxtExchangeClient extends BaseExchangeApiClient {
     const exchangeClass = ccxt[exchangeName];
     let perExchangeClientOptions: Record<string, unknown> = {};
 
-    let useSandbox = false;
     switch (exchangeName) {
       case ExchangeName.HYPERLIQUID: {
         perExchangeClientOptions = {
@@ -31,7 +30,6 @@ export class CcxtExchangeClient extends BaseExchangeApiClient {
             },
           },
         };
-        useSandbox = !Environment.isProduction();
         break;
       }
     }
@@ -39,7 +37,12 @@ export class CcxtExchangeClient extends BaseExchangeApiClient {
     this.ccxtClient = new exchangeClass(
       _.merge({}, BASE_CCXT_CLIENT_OPTIONS, perExchangeClientOptions),
     );
-    this.ccxtClient.setSandboxMode(useSandbox);
+    if (
+      Environment.isProduction() === false &&
+      this.ccxtClient.has['sandbox']
+    ) {
+      this.ccxtClient.setSandboxMode(true);
+    }
   }
 
   protected get tradingPairs() {

--- a/campaign-launcher/server/types/ccxt.d.ts
+++ b/campaign-launcher/server/types/ccxt.d.ts
@@ -7,6 +7,8 @@
 
 declare module 'ccxt' {
   export interface Exchange {
+    setSandboxMode(enabled: boolean): void;
+    isSandboxModeEnabled: boolean;
     loadMarkets(reload = false): Promise<Record<string, unknown>>;
     markets: Record<string, unknown>;
     /**

--- a/campaign-launcher/server/types/ccxt.d.ts
+++ b/campaign-launcher/server/types/ccxt.d.ts
@@ -21,6 +21,7 @@ declare module 'ccxt' {
       www: string;
       logo: string;
     };
+    has: Record<string, boolean | undefined>;
     setMarketsFromExchange(sourceExchange: unknown): void;
   }
 


### PR DESCRIPTION
## Issue tracking
Freestyle

## Context behind the change
Recently found out that e.g. on Hyperliquid there are different tokens available. In order to not display invalid token pairs that can't be correctly processed later on sandbox, we will be displaying only token from sandbox if exchange has one.

## How has this been tested?
- [x] e2e locally: retrieved list of tokens for prod and non-prod for hyperliquid and other exchange

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
Should be none