### PR TITLE
[Recording Oracle] feat: use TheGraph LB for PancakeSwap instead of direct indexer URL

### DIFF
--- a/recording-oracle/src/config/exchanges-config.service.ts
+++ b/recording-oracle/src/config/exchanges-config.service.ts
@@ -72,9 +72,13 @@ export class ExchangesConfigService {
   }
 
   get pancakeswapSubgraphUrl(): string {
+    /**
+     * Direct indexer URL as possible fallback to send requests to the same node:
+     * https://gateway.thegraph.com/api/deployments/id/QmYQLE8EzY8Jw4F5y2rEcSJ4vZJny1ipiyC6EnB2cFYWyr/indexers/id/0xbdfb5ee5a2abf4fc7bb1bd1221067aef7f9de491
+     */
     return this.configService.get(
       'PANCAKESWAP_SUBGRAPH_URL',
-      'https://gateway.thegraph.com/api/deployments/id/QmYQLE8EzY8Jw4F5y2rEcSJ4vZJny1ipiyC6EnB2cFYWyr/indexers/id/0xbdfb5ee5a2abf4fc7bb1bd1221067aef7f9de491',
+      'https://gateway.thegraph.com/api/subgraphs/id/F6L7Zd1hoEc5FKATZjTMpFqwDEUNE3LRC4Z784RahMYH',
     );
   }
 }

--- a/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
@@ -42,11 +42,9 @@ import logger from '@/logger';
 import {
   ExchangeApiAccessError,
   ExchangeApiClientError,
-  ExchangeApiClientFactory,
   ExchangeApiKeyNotFoundError,
   ExchangePermission,
   ExchangesService,
-  PancakeswapClient,
 } from '@/modules/exchanges';
 import { mockExchangesConfigService } from '@/modules/exchanges/fixtures';
 import { StorageService } from '@/modules/storage';
@@ -140,7 +138,6 @@ const mockEventEmitter = createMock<EventEmitter2>();
 const mockParticipationsRepository = createMock<ParticipationsRepository>();
 const mockParticipationsService = createMock<ParticipationsService>();
 const mockVolumeStatsRepository = createMock<VolumeStatsRepository>();
-const mockExchangeApiClientFactory = createMock<ExchangeApiClientFactory>();
 const mockExchangesService = createMock<ExchangesService>();
 const mockStorageService = createMock<StorageService>();
 const mockPgAdvisoryLock = createMock<PgAdvisoryLock>();
@@ -152,8 +149,6 @@ const mockedSigner = createMock<WalletWithProvider>();
 
 const mockedEscrowClient = vi.mocked(EscrowClient);
 const mockedEscrowUtils = vi.mocked(EscrowUtils);
-
-const mockedPancakeswapClient = createMock<PancakeswapClient>();
 
 const exchangePermissions = Object.values(ExchangePermission);
 
@@ -189,10 +184,6 @@ describe('CampaignsService', () => {
         {
           provide: ExchangesConfigService,
           useValue: mockExchangesConfigService,
-        },
-        {
-          provide: ExchangeApiClientFactory,
-          useValue: mockExchangeApiClientFactory,
         },
         {
           provide: ExchangesService,
@@ -3941,65 +3932,29 @@ describe('CampaignsService', () => {
     test('should return correct timeframe for active pancakeswap campaign', async () => {
       campaign.exchangeName = ExchangeName.PANCAKESWAP;
 
-      mockExchangeApiClientFactory.createDex.mockReturnValueOnce(
-        mockedPancakeswapClient,
-      );
-      const mockedLastBlockTs = Math.round(
-        faker.date.recent().valueOf() / 1000,
-      );
-      mockedPancakeswapClient.fetchSubgraphMeta.mockResolvedValueOnce({
-        block: {
-          timestamp: mockedLastBlockTs,
-          hash: faker.string.hexadecimal(),
-          number: faker.number.int(),
-        },
-        hasIndexingErrors: false,
-      });
-
       const campaignDaysPassed = faker.number.int({ min: 1, max: 3 });
       campaign.startDate = dayjs()
         .subtract(campaignDaysPassed, 'days')
         .toDate();
 
-      const expectedTimeframeStart = dayjs(campaign.startDate)
-        .add(campaignDaysPassed, 'days')
-        .toDate();
+      const now = new Date();
+      vi.useFakeTimers({ now });
 
       const result = await campaignsService.getActiveTimeframe(campaign);
 
-      expect(result).toEqual({
-        start: expectedTimeframeStart,
-        end: new Date(mockedLastBlockTs * 1000),
-      });
+      vi.useRealTimers();
 
-      expect(mockExchangeApiClientFactory.createDex).toHaveBeenCalledTimes(1);
-      expect(mockExchangeApiClientFactory.createDex).toHaveBeenCalledWith(
-        ExchangeName.PANCAKESWAP,
-        {
-          userId: 'system',
-          userEvmAddress: 'n/a',
-        },
-      );
+      expect(result).toEqual({
+        start: dayjs(campaign.startDate)
+          .add(campaignDaysPassed, 'days')
+          .toDate(),
+        end: dayjs(now).subtract(1, 'minute').toDate(),
+      });
     });
 
     test('should return correct timeframe when cancellation requested for pancakeswap campaign', async () => {
       campaign.status = CampaignStatus.TO_CANCEL;
       campaign.exchangeName = ExchangeName.PANCAKESWAP;
-
-      mockExchangeApiClientFactory.createDex.mockReturnValueOnce(
-        mockedPancakeswapClient,
-      );
-      const mockedLastBlockTs = Math.round(
-        faker.date.recent().valueOf() / 1000,
-      );
-      mockedPancakeswapClient.fetchSubgraphMeta.mockResolvedValueOnce({
-        block: {
-          timestamp: mockedLastBlockTs,
-          hash: faker.string.hexadecimal(),
-          number: faker.number.int(),
-        },
-        hasIndexingErrors: false,
-      });
 
       const campaignDaysPassed = faker.number.int({ min: 1, max: 3 });
       campaign.startDate = dayjs()
@@ -4021,17 +3976,8 @@ describe('CampaignsService', () => {
 
       expect(result).toEqual({
         start: expectedTimeframeStart,
-        end: new Date(mockedLastBlockTs * 1000),
+        end: cancellationRequestedAt,
       });
-
-      expect(mockExchangeApiClientFactory.createDex).toHaveBeenCalledTimes(1);
-      expect(mockExchangeApiClientFactory.createDex).toHaveBeenCalledWith(
-        ExchangeName.PANCAKESWAP,
-        {
-          userId: 'system',
-          userEvmAddress: 'n/a',
-        },
-      );
     });
   });
 

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -45,10 +45,8 @@ import {
 import logger from '@/logger';
 import {
   ExchangeApiAccessError,
-  ExchangeApiClientFactory,
   ExchangeApiKeyNotFoundError,
   ExchangesService,
-  type PancakeswapClient,
 } from '@/modules/exchanges';
 import { StorageService } from '@/modules/storage';
 import { Web3Service } from '@/modules/web3';
@@ -121,7 +119,6 @@ export class CampaignsService implements OnModuleDestroy {
     private readonly campaignsConfigService: CampaignsConfigService,
     private readonly campaignsRepository: CampaignsRepository,
     private readonly eventEmitter: EventEmitter2,
-    private readonly exchangeApiClientFactory: ExchangeApiClientFactory,
     private readonly exchangesConfigService: ExchangesConfigService,
     private readonly exchangesService: ExchangesService,
     private readonly participationsRepository: ParticipationsRepository,
@@ -1354,25 +1351,13 @@ export class CampaignsService implements OnModuleDestroy {
         return null;
       }
       timeframeEnd = cancellationRequestedAt;
+    } else if (campaign.exchangeName === ExchangeName.PANCAKESWAP) {
+      /**
+       * To avoid error when subgrpaph sync might be a bit delayed.
+       */
+      timeframeEnd = dayjs(now).subtract(1, 'minute').toDate();
     } else {
       timeframeEnd = now;
-    }
-
-    if (campaign.exchangeName === ExchangeName.PANCAKESWAP) {
-      const client = this.exchangeApiClientFactory.createDex(
-        ExchangeName.PANCAKESWAP,
-        {
-          userId: 'system',
-          userEvmAddress: 'n/a',
-        },
-      ) as PancakeswapClient;
-
-      const subgraphMeta = await client.fetchSubgraphMeta();
-
-      const lastBlockSyncedAt = new Date(subgraphMeta.block.timestamp * 1000);
-      if (lastBlockSyncedAt.valueOf() < timeframeEnd.valueOf()) {
-        timeframeEnd = lastBlockSyncedAt;
-      }
     }
 
     return {

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -1353,7 +1353,7 @@ export class CampaignsService implements OnModuleDestroy {
       timeframeEnd = cancellationRequestedAt;
     } else if (campaign.exchangeName === ExchangeName.PANCAKESWAP) {
       /**
-       * To avoid error when subgrpaph sync might be a bit delayed.
+       * To avoid error when subgraph sync might be a bit delayed.
        */
       timeframeEnd = dayjs(now).subtract(1, 'minute').toDate();
     } else {

--- a/recording-oracle/src/modules/exchanges/api-client/ccxt/pagination-helpers/gate.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/ccxt/pagination-helpers/gate.ts
@@ -1,4 +1,5 @@
 import type { Trade as CcxtTrade } from 'ccxt';
+import dayjs from 'dayjs';
 
 import type { GetPaginationInputFn, HandlePaginationResponseFn } from './types';
 
@@ -40,7 +41,7 @@ export const getPaginationInput: GetPaginationInputFn<
      * so in order to get items up to "until" we need to convert it on our end
      * and later filter out using "until" in ms
      */
-    to: Math.ceil(until / 1000),
+    to: dayjs(until).unix() + 1,
     page: nextPageToken || 1,
     [UNTIL_PARAM_SYMBOL]: until,
   };

--- a/recording-oracle/src/modules/exchanges/api-client/index.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/index.ts
@@ -16,5 +16,3 @@ export {
   type RequiredAccessCheckResult,
   type Trade,
 } from './types';
-
-export { type PancakeswapClient } from './pancakeswap';

--- a/recording-oracle/src/modules/exchanges/api-client/kraken/kraken-client.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/kraken/kraken-client.ts
@@ -4,6 +4,7 @@ import { setTimeout as delay } from 'timers/promises';
 import type { AxiosInstance, AxiosRequestConfig } from 'axios';
 import axios, { AxiosError } from 'axios';
 import { parse as csvParse } from 'csv-parse';
+import dayjs from 'dayjs';
 
 import { ExchangeName } from '@/common/constants';
 import * as cryptoUtils from '@/common/utils/crypto';
@@ -324,8 +325,8 @@ export class KrakenClient implements ExchangeApiClient {
      * so use [since, until] seconds range to get all trades for boundary seconds
      * and filter out trades not within [since, until) ms range when processing report.
      */
-    const starttm = Math.floor(since.valueOf() / 1000);
-    const endtm = Math.ceil(until.valueOf() / 1000);
+    const starttm = dayjs(since).unix();
+    const endtm = dayjs(until).unix() + 1;
 
     const result = await this.makeRequest<{ id: string }>(
       'POST',

--- a/recording-oracle/src/modules/exchanges/api-client/pancakeswap/constants.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/pancakeswap/constants.ts
@@ -4,7 +4,9 @@ import ms from 'ms';
 export const MAX_PAGE_SIZE = 50;
 
 export const tokenAddressBySymbol: Record<string, string | undefined> = {
+  WBNB: '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c',
   USDT: '0x55d398326f99059fF775485246999027B3197955',
+  USDC: '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d',
   HMT: NETWORKS[ChainId.BSC_MAINNET]!.hmtAddress,
 };
 tokenAddressBySymbol.USDT0 = tokenAddressBySymbol.USDT;
@@ -18,3 +20,5 @@ tokenAddressBySymbol.USDT0 = tokenAddressBySymbol.USDT;
  * have a space for maneuver.
  */
 export const MAX_LOOKBACK_MS = ms('4 days');
+
+export const ACCEPTED_SYNC_DELAY_MS = ms('20 seconds');

--- a/recording-oracle/src/modules/exchanges/api-client/pancakeswap/fixtures/index.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/pancakeswap/fixtures/index.ts
@@ -1,4 +1,5 @@
 import { faker } from '@faker-js/faker';
+import dayjs from 'dayjs';
 import { ethers } from 'ethers';
 
 import { generateTxHash } from '~/test/fixtures/web3';
@@ -20,7 +21,7 @@ export function generateSubgraphSwapData(): SubgraphSwapData {
     id: generateSwapId(txHash),
     hash: txHash,
     nonce: faker.number.bigInt().toString(),
-    timestamp: Math.round(faker.date.recent().valueOf() / 1000).toString(),
+    timestamp: dayjs(faker.date.recent()).unix().toString(),
     amountIn: ethers
       .parseUnits(
         faker.number.float(42).toFixed(tokenInDecimals),
@@ -51,7 +52,7 @@ export function generatePancakeswapSwap(overrides?: Partial<Swap>): Swap {
     id: generateSwapId(txHash),
     hash: txHash,
     nonce: faker.number.bigInt().toString(),
-    timestamp: Math.round(faker.date.recent().valueOf() / 1000),
+    timestamp: dayjs(faker.date.recent()).unix(),
     amountIn: faker.number.float(),
     amountOut: faker.number.float(),
     tokenIn: faker.finance.ethereumAddress(),

--- a/recording-oracle/src/modules/exchanges/api-client/pancakeswap/pancakeswap-client.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/pancakeswap/pancakeswap-client.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import { setTimeout as delay } from 'timers/promises';
 
+import dayjs from 'dayjs';
 import { ethers } from 'ethers';
 import { GraphQLClient } from 'graphql-request';
 import _ from 'lodash';
@@ -83,7 +84,7 @@ export class PancakeswapClient implements ExchangeApiClient {
       const { latestSwaps } = await this.graphClient.request<{
         latestSwaps: LatestSwapData[];
       }>(GET_LATEST_SWAPS_QUERY, {
-        after: Math.ceil(afterMs / 1000),
+        after: dayjs(afterMs).unix(),
       });
 
       if (latestSwaps.length === 0) {
@@ -167,8 +168,8 @@ export class PancakeswapClient implements ExchangeApiClient {
       await delay(keepUpMs);
     }
 
-    const sinceSeconds = Math.floor(since / 1000);
-    const untilSeconds = Math.ceil(until / 1000);
+    const sinceSeconds = dayjs(since).unix();
+    const untilSeconds = dayjs(until).unix() + 1;
 
     /**
      * We must ensure that queries land to graph nodes that have data up to "until" timestamp,

--- a/recording-oracle/src/modules/exchanges/api-client/pancakeswap/pancakeswap-client.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/pancakeswap/pancakeswap-client.ts
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import { setTimeout as delay } from 'timers/promises';
 
 import { ethers } from 'ethers';
 import { GraphQLClient } from 'graphql-request';
@@ -14,16 +15,20 @@ import {
   type DexApiClientInitOptions,
   ExchangeApiClient,
 } from '../exchange-api-client.interface';
-import { type RequiredAccessCheckResult, type Trade } from '../types';
+import type { RequiredAccessCheckResult, Trade } from '../types';
 import * as apiClientUtils from '../utils';
-import { MAX_LOOKBACK_MS, tokenAddressBySymbol } from './constants';
+import {
+  ACCEPTED_SYNC_DELAY_MS,
+  MAX_LOOKBACK_MS,
+  tokenAddressBySymbol,
+} from './constants';
 import {
   GET_ACCOUNT_SWAPS_QUERY,
-  GET_SUBGRAPH_META_QUERY,
+  GET_LATEST_SWAPS_QUERY,
+  type LatestSwapData,
   type SubgraphSwapData,
-  type SubgraphMeta,
 } from './queries';
-import { type Swap } from './types';
+import type { LatestBlockData, Swap } from './types';
 import * as pancakeswapUtils from './utils';
 
 type PancakeswapClientInitOptions = DexApiClientInitOptions & {
@@ -71,33 +76,31 @@ export class PancakeswapClient implements ExchangeApiClient {
     });
   }
 
-  async fetchSubgraphMeta(): Promise<SubgraphMeta> {
+  async fetchActualBlockData(producedAfter?: number): Promise<LatestBlockData> {
     try {
-      const { _meta } = await this.graphClient.request<{
-        _meta: SubgraphMeta;
-      }>(GET_SUBGRAPH_META_QUERY);
+      const afterMs = producedAfter ?? Date.now() - ACCEPTED_SYNC_DELAY_MS;
 
-      return _meta;
+      const { latestSwaps } = await this.graphClient.request<{
+        latestSwaps: LatestSwapData[];
+      }>(GET_LATEST_SWAPS_QUERY, {
+        after: Math.ceil(afterMs / 1000),
+      });
+
+      if (latestSwaps.length === 0) {
+        throw new Error(`No swaps after ${new Date(afterMs).toISOString()}`);
+      }
+
+      const { blockNumber, timestamp } = latestSwaps[0];
+      return {
+        number: Number(blockNumber),
+        timestamp: Number(timestamp) * 1000,
+      };
     } catch (error) {
-      const message = 'Failed to fetch subgraph meta';
+      const message = 'Failed to fetch actual block data';
       this.logger.error(message, {
         error: pancakeswapUtils.formatGraphqlRequestError(error as Error),
       });
       throw new PancakeswapClientError(message);
-    }
-  }
-  /**
-   * @param timestamp value in seconds
-   */
-  private async assertSubgraphNotStale(timestamp: number): Promise<void> {
-    const subgraphMeta = await this.fetchSubgraphMeta();
-
-    if (subgraphMeta.hasIndexingErrors) {
-      throw new PancakeswapClientError('Subgraph has indexing errors');
-    }
-
-    if (subgraphMeta.block.timestamp < timestamp) {
-      throw new PancakeswapClientError('Subgraph is stale');
     }
   }
 
@@ -106,7 +109,10 @@ export class PancakeswapClient implements ExchangeApiClient {
     tokenOut: string,
     since: number,
     until: number,
-    skip: number = 0,
+    options: {
+      skip?: number;
+      blockNumber?: number;
+    },
   ): Promise<Swap[]> {
     const { swaps } = await this.graphClient.request<{
       swaps: SubgraphSwapData[];
@@ -116,7 +122,12 @@ export class PancakeswapClient implements ExchangeApiClient {
       tokenOut: tokenOut.toLowerCase(),
       since,
       until,
-      skip,
+      skip: options.skip || 0,
+      block: options.blockNumber
+        ? {
+            number_gte: options.blockNumber,
+          }
+        : undefined,
     });
 
     return swaps.map(pancakeswapUtils.mapSubgraphDataToSwap);
@@ -143,10 +154,33 @@ export class PancakeswapClient implements ExchangeApiClient {
       throw new Error('"until" must be a ms timestamp in acceptable range');
     }
 
+    const msToUntil = Date.now() - until;
+    if (msToUntil < ACCEPTED_SYNC_DELAY_MS) {
+      const keepUpMs = ACCEPTED_SYNC_DELAY_MS - msToUntil;
+      this.logger.warn(
+        `Provided "until" timestamp is too recent, adding delay to avoid errors`,
+        {
+          until,
+          keepUpMs,
+        },
+      );
+      await delay(keepUpMs);
+    }
+
     const sinceSeconds = Math.floor(since / 1000);
     const untilSeconds = Math.ceil(until / 1000);
 
-    await this.assertSubgraphNotStale(untilSeconds);
+    /**
+     * We must ensure that queries land to graph nodes that have data up to "until" timestamp,
+     * so we get the first block number produced after "until" and then use it as a reference
+     * in subsequent time-travel queries, so TheGraph LB can exlude stale indexers.
+     * Ref: https://thegraph.com/docs/en/subgraphs/querying/distributed-systems/#polling-for-updated-data
+     *
+     * Otherwise, we may end up in a situation when we query for swaps in a block
+     * that is not yet indexed by the node and get empty results, while the same
+     * query to another node would return the data.
+     */
+    const latestBlockData = await this.fetchActualBlockData(until);
 
     try {
       const [baseTokenSymbol, quoteTokenSymbol] = symbol.split('/');
@@ -176,7 +210,7 @@ export class PancakeswapClient implements ExchangeApiClient {
             baseTokenAddress,
             sinceSeconds,
             untilSeconds,
-            nBuySwaps,
+            { skip: nBuySwaps, blockNumber: latestBlockData.number },
           );
         }
 
@@ -189,7 +223,7 @@ export class PancakeswapClient implements ExchangeApiClient {
             quoteTokenAddress,
             sinceSeconds,
             untilSeconds,
-            nSellSwaps,
+            { skip: nSellSwaps, blockNumber: latestBlockData.number },
           );
         }
 

--- a/recording-oracle/src/modules/exchanges/api-client/pancakeswap/pancakeswap-client.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/pancakeswap/pancakeswap-client.ts
@@ -26,7 +26,9 @@ import {
 import {
   GET_ACCOUNT_SWAPS_QUERY,
   GET_LATEST_SWAPS_QUERY,
+  GET_SUBGRAPH_META_QUERY,
   type LatestSwapData,
+  type SubgraphMeta,
   type SubgraphSwapData,
 } from './queries';
 import type { LatestBlockData, Swap } from './types';
@@ -75,6 +77,37 @@ export class PancakeswapClient implements ExchangeApiClient {
       exchangeName: this.exchangeName,
       userId,
     });
+  }
+
+  async fetchSubgraphMeta(): Promise<SubgraphMeta> {
+    try {
+      const { _meta } = await this.graphClient.request<{
+        _meta: SubgraphMeta;
+      }>(GET_SUBGRAPH_META_QUERY);
+
+      return _meta;
+    } catch (error) {
+      const message = 'Failed to fetch subgraph meta';
+      this.logger.error(message, {
+        error: pancakeswapUtils.formatGraphqlRequestError(error as Error),
+      });
+      throw new PancakeswapClientError(message);
+    }
+  }
+
+  /**
+   * @param timestamp value in seconds
+   */
+  private async assertSubgraphNotStale(timestamp: number): Promise<void> {
+    const subgraphMeta = await this.fetchSubgraphMeta();
+
+    if (subgraphMeta.hasIndexingErrors) {
+      throw new PancakeswapClientError('Subgraph has indexing errors');
+    }
+
+    if (subgraphMeta.block.timestamp < timestamp) {
+      throw new PancakeswapClientError('Subgraph is stale');
+    }
   }
 
   async fetchActualBlockData(producedAfter?: number): Promise<LatestBlockData> {
@@ -176,11 +209,14 @@ export class PancakeswapClient implements ExchangeApiClient {
      * so we get the first block number produced after "until" and then use it as a reference
      * in subsequent time-travel queries, so TheGraph LB can exlude stale indexers.
      * Ref: https://thegraph.com/docs/en/subgraphs/querying/distributed-systems/#polling-for-updated-data
+     * Previous option: rely on subgraph meta's latest block timestamp, but use exact indexer URL,
+     * so we make sure requests land to the same node.
      *
      * Otherwise, we may end up in a situation when we query for swaps in a block
      * that is not yet indexed by the node and get empty results, while the same
      * query to another node would return the data.
      */
+    // await this.assertSubgraphNotStale(untilSeconds); // previous option
     const latestBlockData = await this.fetchActualBlockData(until);
 
     try {

--- a/recording-oracle/src/modules/exchanges/api-client/pancakeswap/pancakeswap-client.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/pancakeswap/pancakeswap-client.ts
@@ -207,7 +207,7 @@ export class PancakeswapClient implements ExchangeApiClient {
     /**
      * We must ensure that queries land to graph nodes that have data up to "until" timestamp,
      * so we get the first block number produced after "until" and then use it as a reference
-     * in subsequent time-travel queries, so TheGraph LB can exlude stale indexers.
+     * in subsequent time-travel queries, so TheGraph LB can exclude stale indexers.
      * Ref: https://thegraph.com/docs/en/subgraphs/querying/distributed-systems/#polling-for-updated-data
      * Previous option: rely on subgraph meta's latest block timestamp, but use exact indexer URL,
      * so we make sure requests land to the same node.

--- a/recording-oracle/src/modules/exchanges/api-client/pancakeswap/queries.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/pancakeswap/queries.ts
@@ -88,3 +88,25 @@ export type SubgraphSwapData = {
   tokenIn: SubgraphToken;
   tokenOut: SubgraphToken;
 };
+
+export type SubgraphMeta = {
+  hasIndexingErrors: boolean;
+  block: {
+    hash: string;
+    number: number;
+    timestamp: number;
+  };
+};
+
+export const GET_SUBGRAPH_META_QUERY = gql`
+  query getSubgraphMeta {
+    _meta {
+      hasIndexingErrors
+      block {
+        hash
+        timestamp
+        number
+      }
+    }
+  }
+`;

--- a/recording-oracle/src/modules/exchanges/api-client/pancakeswap/queries.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/pancakeswap/queries.ts
@@ -2,6 +2,29 @@ import { gql } from 'graphql-request';
 
 import { MAX_PAGE_SIZE } from './constants';
 
+export type LatestSwapData = {
+  id: string;
+  hash: string;
+  timestamp: string;
+  blockNumber: string;
+};
+
+export const GET_LATEST_SWAPS_QUERY = gql`
+  query getLatestSwaps($after: BigInt!) {
+    latestSwaps: swaps(
+      where: { timestamp_gt: $after }
+      first: 5
+      orderBy: blockNumber
+      orderDirection: desc
+    ) {
+      id
+      hash
+      timestamp
+      blockNumber
+    }
+  }
+`;
+
 const TOKEN_FRAGMENT = gql`
   fragment TokenFields on Token {
     id
@@ -22,6 +45,7 @@ export const GET_ACCOUNT_SWAPS_QUERY = gql`
     $since: BigInt!
     $until: BigInt!
     $skip: Int
+    $block: Block_height
   ) {
     swaps(
       where: {
@@ -32,6 +56,7 @@ export const GET_ACCOUNT_SWAPS_QUERY = gql`
         timestamp_lt: $until
       }
       first: ${MAX_PAGE_SIZE}
+      block: $block
       skip: $skip
       orderBy: nonce
       orderDirection: asc
@@ -63,25 +88,3 @@ export type SubgraphSwapData = {
   tokenIn: SubgraphToken;
   tokenOut: SubgraphToken;
 };
-
-export type SubgraphMeta = {
-  hasIndexingErrors: boolean;
-  block: {
-    hash: string;
-    number: number;
-    timestamp: number;
-  };
-};
-
-export const GET_SUBGRAPH_META_QUERY = gql`
-  query getSubgraphMeta {
-    _meta {
-      hasIndexingErrors
-      block {
-        hash
-        timestamp
-        number
-      }
-    }
-  }
-`;

--- a/recording-oracle/src/modules/exchanges/api-client/pancakeswap/types.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/pancakeswap/types.ts
@@ -1,3 +1,8 @@
+export type LatestBlockData = {
+  number: number;
+  timestamp: number;
+};
+
 export type Swap = {
   id: string;
   hash: string;

--- a/recording-oracle/src/modules/exchanges/index.ts
+++ b/recording-oracle/src/modules/exchanges/index.ts
@@ -3,7 +3,6 @@ export {
   ExchangeApiClientError,
   ExchangeApiClientFactory,
   ExchangePermission,
-  type PancakeswapClient,
   TakerOrMakerFlag,
   TradingSide,
   type ExchangeApiClient,


### PR DESCRIPTION
## Issue tracking
Closes #913

## Context behind the change
It's possible to rely on LB to send queries only to indexers that have data starting from specific block ([ref](https://thegraph.com/docs/en/subgraphs/querying/distributed-systems/#polling-for-updated-data)), but in order to that we need to know the block number to use - the one that produced after "until" boundary.
In order to do that we could:
1. query RPC and use binary search (overhead)
2. use specific subgraph to query that info easily (e.g. [BNB Chain Block](https://thegraph.com/explorer/subgraphs/aFYiBZ2nkQVbv1HsKTQcPpWBxCAiJY4w4pG8RXaDxge?view=Query&chain=arbitrum-one))
3. query our own subgraph with some common query; it works only in case if swaps happen all the time, otherwise it will throw on any request because thinking that subgraph is stale

Choosing between 2 and 3, it easier and simpler to rely on the latter for now assuming that swaps happen all the time (if not - highly likely we will remove PancakeSwap integration because it won't make sense anymore). If something changes and this solution becomes laggy - we can use previous "assertion" and direct indexer url, while changing to the second option with blocks subgraph.

## How has this been tested?
- [x] e2e locally via script: created instance of PancakeSwap client and queried for some random account WBNB/USDT swaps

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
Mentioned above.