### PR TITLE
[Recording Oracle] fix: net found amount as per new contracts

### DIFF
--- a/recording-oracle/src/infrastructure/database/migrations/1780412549394-add-fund-amount-net.ts
+++ b/recording-oracle/src/infrastructure/database/migrations/1780412549394-add-fund-amount-net.ts
@@ -1,4 +1,38 @@
+import { EscrowUtils } from '@human-protocol/sdk';
+import Decimal from 'decimal.js';
 import { MigrationInterface, QueryRunner } from 'typeorm';
+
+type Campaign = {
+  id: string;
+  chain_id: number;
+  address: string;
+  fund_amount: string;
+  fund_token_decimals: number;
+};
+
+async function getCampaignFundAmountNet(campaign: Campaign): Promise<string> {
+  const escrow = await EscrowUtils.getEscrow(
+    campaign.chain_id,
+    campaign.address,
+  );
+  if (!escrow) {
+    throw new Error(`Escrow not found for campaign: ${campaign.id}`);
+  }
+
+  const oraclesFeePercent =
+    escrow.exchangeOracleFee! +
+    escrow.recordingOracleFee! +
+    escrow.reputationOracleFee!;
+  const netFundsPercent = 100 - oraclesFeePercent;
+
+  const fundAmountNet = Decimal(campaign.fund_amount)
+    .mul(netFundsPercent)
+    .div(100);
+
+  return fundAmountNet
+    .toDecimalPlaces(campaign.fund_token_decimals, Decimal.ROUND_DOWN)
+    .toString();
+}
 
 export class AddFundAmountNet1780412549394 implements MigrationInterface {
   name = 'AddFundAmountNet1780412549394';
@@ -7,11 +41,29 @@ export class AddFundAmountNet1780412549394 implements MigrationInterface {
     await queryRunner.query(
       `ALTER TABLE "hu_fi"."campaigns" ADD "fund_amount_net" numeric(30,18)`,
     );
-    await queryRunner.query(`
-      UPDATE "hu_fi"."campaigns"
-      SET "fund_amount_net" = "fund_amount"
-      WHERE fund_amount_net IS NULL;
-    `);
+
+    while (true) {
+      const campaigns = await queryRunner.query(`
+        SELECT "id", "chain_id", "address", "fund_amount", "fund_token_decimals"
+        FROM "hu_fi"."campaigns"
+        WHERE "fund_amount_net" IS NULL LIMIT 50
+      `);
+      if (campaigns.length === 0) {
+        break;
+      }
+
+      for (const campaign of campaigns) {
+        const fundAmountNet = await getCampaignFundAmountNet(
+          campaign as Campaign,
+        );
+        await queryRunner.query(`
+          UPDATE "hu_fi"."campaigns"
+          SET "fund_amount_net" = '${fundAmountNet}'
+          WHERE "id" = '${campaign.id}';
+        `);
+      }
+    }
+
     await queryRunner.query(
       `ALTER TABLE "hu_fi"."campaigns" ALTER COLUMN "fund_amount_net" SET NOT NULL`,
     );

--- a/recording-oracle/src/infrastructure/database/migrations/1780412549394-add-fund-amount-net.ts
+++ b/recording-oracle/src/infrastructure/database/migrations/1780412549394-add-fund-amount-net.ts
@@ -19,10 +19,18 @@ async function getCampaignFundAmountNet(campaign: Campaign): Promise<string> {
     throw new Error(`Escrow not found for campaign: ${campaign.id}`);
   }
 
+  if (
+    !escrow.exchangeOracleFee ||
+    !escrow.recordingOracleFee ||
+    !escrow.reputationOracleFee
+  ) {
+    throw new Error(`Oracle fees not found for campaign: ${campaign.id}`);
+  }
+
   const oraclesFeePercent =
-    escrow.exchangeOracleFee! +
-    escrow.recordingOracleFee! +
-    escrow.reputationOracleFee!;
+    escrow.exchangeOracleFee +
+    escrow.recordingOracleFee +
+    escrow.reputationOracleFee;
   const netFundsPercent = 100 - oraclesFeePercent;
 
   const fundAmountNet = Decimal(campaign.fund_amount)

--- a/recording-oracle/src/infrastructure/database/migrations/1780412549394-add-fund-amount-net.ts
+++ b/recording-oracle/src/infrastructure/database/migrations/1780412549394-add-fund-amount-net.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddFundAmountNet1780412549394 implements MigrationInterface {
+  name = 'AddFundAmountNet1780412549394';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "hu_fi"."campaigns" ADD "fund_amount_net" numeric(30,18)`,
+    );
+    await queryRunner.query(`
+      UPDATE "hu_fi"."campaigns"
+      SET "fund_amount_net" = "fund_amount"
+      WHERE fund_amount_net IS NULL;
+    `);
+    await queryRunner.query(
+      `ALTER TABLE "hu_fi"."campaigns" ALTER COLUMN "fund_amount_net" SET NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "hu_fi"."campaigns" DROP COLUMN "fund_amount_net"`,
+    );
+  }
+}

--- a/recording-oracle/src/modules/campaigns/campaign.entity.ts
+++ b/recording-oracle/src/modules/campaigns/campaign.entity.ts
@@ -44,6 +44,9 @@ export class CampaignEntity {
   @Column({ type: 'decimal', precision: 30, scale: 18 })
   fundAmount: string;
 
+  @Column({ type: 'decimal', precision: 30, scale: 18 })
+  fundAmountNet: string;
+
   @Column('varchar', { length: 20 })
   fundToken: string;
 

--- a/recording-oracle/src/modules/campaigns/campaigns.controller.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.controller.ts
@@ -122,6 +122,7 @@ export class CampaignsController {
           startDate: campaign.startDate.toISOString(),
           endDate: campaign.endDate.toISOString(),
           fundAmount: Number(campaign.fundAmount),
+          fundAmountNet: Number(campaign.fundAmountNet),
           fundToken: campaign.fundToken,
           details: campaign.details,
           status: CAMPAIGN_STATUS_TO_RETURNED_STATUS[campaign.status],

--- a/recording-oracle/src/modules/campaigns/campaigns.dto.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.dto.ts
@@ -66,6 +66,9 @@ class JoinedCampaignDto {
   @ApiProperty({ name: 'fund_amount' })
   fundAmount: number;
 
+  @ApiProperty({ name: 'fund_amount_net' })
+  fundAmountNet: number;
+
   @ApiProperty({ name: 'fund_token' })
   fundToken: string;
 

--- a/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
@@ -1111,7 +1111,6 @@ describe('CampaignsService', () => {
     let chainId: number;
 
     const mockedGetEscrowStatus = vi.fn();
-    const mockedGetEscrowBalance = vi.fn();
 
     beforeEach(() => {
       campaign = generateCampaignEntity();
@@ -1120,7 +1119,6 @@ describe('CampaignsService', () => {
 
       mockedEscrowClient.build.mockResolvedValue({
         getStatus: mockedGetEscrowStatus,
-        getBalance: mockedGetEscrowBalance,
       } as unknown as EscrowClient);
     });
 
@@ -1224,10 +1222,12 @@ describe('CampaignsService', () => {
         .mockImplementation(vi.fn());
       const spyOnCreateCampaign = vi.spyOn(campaignsService, 'createCampaign');
       const campaignManifest = generateCampaignManifest();
-      const escrowInfo = {
+      const escrowInfo: CampaignEscrowInfo = {
         fundAmount: faker.number.float(),
         fundAmountNet: faker.number.float(),
         fundTokenSymbol: faker.finance.currencyCode(),
+        fundTokenDecimals: faker.helpers.arrayElement([6, 18]),
+        cancellationRequestedAt: null,
       };
       spyOnretrieveCampaignData.mockResolvedValueOnce({
         manifest: campaignManifest,
@@ -2036,7 +2036,6 @@ describe('CampaignsService', () => {
     let campaign: CampaignEntity;
 
     const mockedGetEscrowStatus = vi.fn();
-    const mockedGetEscrowBalance = vi.fn();
 
     beforeAll(() => {
       spyOnRetrieveCampaignIntermediateResults = vi.spyOn(
@@ -2092,7 +2091,6 @@ describe('CampaignsService', () => {
 
       mockedEscrowClient.build.mockResolvedValue({
         getStatus: mockedGetEscrowStatus,
-        getBalance: mockedGetEscrowBalance,
       } as unknown as EscrowClient);
     });
 

--- a/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
@@ -11,6 +11,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { Test } from '@nestjs/testing';
 import dayjs from 'dayjs';
+import Decimal from 'decimal.js';
 import { ethers } from 'ethers';
 import _ from 'lodash';
 import {
@@ -329,7 +330,6 @@ describe('CampaignsService', () => {
     const TEST_TOKEN_DECIMALS = faker.helpers.arrayElement([6, 18]);
 
     const mockedGetEscrowStatus = vi.fn();
-    const mockedGetEscrowBalance = vi.fn();
 
     let spyOnDownloadCampaignManifest: Mock;
     let spyOnAssertCorrectCampaignSetup: Mock<
@@ -363,7 +363,6 @@ describe('CampaignsService', () => {
 
       mockedEscrowClient.build.mockResolvedValue({
         getStatus: mockedGetEscrowStatus,
-        getBalance: mockedGetEscrowBalance,
       } as unknown as EscrowClient);
 
       mockWeb3Service.getTokenSymbol.mockResolvedValue(TEST_TOKEN_SYMBOL);
@@ -720,7 +719,6 @@ describe('CampaignsService', () => {
         const manifestUrl = faker.internet.url();
         const manifestHash = faker.string.hexadecimal();
         const totalFundedAmount = faker.number.bigInt({ min: 1 });
-        const mockEscrowBalance = totalFundedAmount - 3n;
 
         mockedEscrowUtils.getEscrow.mockResolvedValueOnce({
           token: faker.finance.ethereumAddress(),
@@ -728,9 +726,11 @@ describe('CampaignsService', () => {
           manifest: manifestUrl,
           manifestHash,
           recordingOracle: mockWeb3ConfigService.operatorAddress,
+          exchangeOracleFee: 2,
+          recordingOracleFee: 3,
+          reputationOracleFee: 5,
         } as IEscrow);
         mockedGetEscrowStatus.mockResolvedValueOnce(EscrowStatus.Pending);
-        mockedGetEscrowBalance.mockResolvedValueOnce(mockEscrowBalance);
 
         spyOnDownloadCampaignManifest.mockResolvedValueOnce(
           JSON.stringify(mockedManifest),
@@ -741,12 +741,17 @@ describe('CampaignsService', () => {
         ](chainId, campaignAddress);
 
         expect(manifest).toEqual(mockedManifest);
+
+        const expectedFundAmount = Number(
+          ethers.formatUnits(totalFundedAmount, TEST_TOKEN_DECIMALS),
+        );
         expect(escrowInfo).toEqual({
-          fundAmount: Number(
-            ethers.formatUnits(totalFundedAmount, TEST_TOKEN_DECIMALS),
-          ),
+          fundAmount: expectedFundAmount,
           fundAmountNet: Number(
-            ethers.formatUnits(mockEscrowBalance, TEST_TOKEN_DECIMALS),
+            rewardsUtils.formatRewardValue(
+              Decimal(expectedFundAmount).mul(0.9),
+              TEST_TOKEN_DECIMALS,
+            ),
           ),
           fundTokenSymbol: TEST_TOKEN_SYMBOL,
           fundTokenDecimals: TEST_TOKEN_DECIMALS,
@@ -771,28 +776,35 @@ describe('CampaignsService', () => {
       'should retrieve and return data (manifest json) [%#]',
       async (mockedManifest) => {
         const totalFundedAmount = faker.number.bigInt({ min: 1 });
-        const mockEscrowBalance = totalFundedAmount - 3n;
+
         mockedEscrowUtils.getEscrow.mockResolvedValueOnce({
           token: faker.finance.ethereumAddress(),
           totalFundedAmount,
           manifest: JSON.stringify(mockedManifest),
           manifestHash: faker.string.hexadecimal(),
           recordingOracle: mockWeb3ConfigService.operatorAddress,
+          exchangeOracleFee: 2,
+          recordingOracleFee: 3,
+          reputationOracleFee: 5,
         } as IEscrow);
         mockedGetEscrowStatus.mockResolvedValueOnce(EscrowStatus.Pending);
-        mockedGetEscrowBalance.mockResolvedValueOnce(mockEscrowBalance);
 
         const { manifest, escrowInfo } = await campaignsService[
           'retrieveCampaignData'
         ](chainId, campaignAddress);
 
         expect(manifest).toEqual(mockedManifest);
+
+        const expectedFundAmount = Number(
+          ethers.formatUnits(totalFundedAmount, TEST_TOKEN_DECIMALS),
+        );
         expect(escrowInfo).toEqual({
-          fundAmount: Number(
-            ethers.formatUnits(totalFundedAmount, TEST_TOKEN_DECIMALS),
-          ),
+          fundAmount: expectedFundAmount,
           fundAmountNet: Number(
-            ethers.formatUnits(mockEscrowBalance, TEST_TOKEN_DECIMALS),
+            rewardsUtils.formatRewardValue(
+              Decimal(expectedFundAmount).mul(0.9),
+              TEST_TOKEN_DECIMALS,
+            ),
           ),
           fundTokenSymbol: TEST_TOKEN_SYMBOL,
           fundTokenDecimals: TEST_TOKEN_DECIMALS,

--- a/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.spec.ts
@@ -108,7 +108,7 @@ import {
   isThresholdCampaign,
 } from './type-guards';
 import {
-  CampaignEscrowInfo,
+  type CampaignEscrowInfo,
   type CampaignProgress,
   CampaignStatus,
   type CompetitiveMarketMakingCampaignDetails,
@@ -329,6 +329,7 @@ describe('CampaignsService', () => {
     const TEST_TOKEN_DECIMALS = faker.helpers.arrayElement([6, 18]);
 
     const mockedGetEscrowStatus = vi.fn();
+    const mockedGetEscrowBalance = vi.fn();
 
     let spyOnDownloadCampaignManifest: Mock;
     let spyOnAssertCorrectCampaignSetup: Mock<
@@ -362,6 +363,7 @@ describe('CampaignsService', () => {
 
       mockedEscrowClient.build.mockResolvedValue({
         getStatus: mockedGetEscrowStatus,
+        getBalance: mockedGetEscrowBalance,
       } as unknown as EscrowClient);
 
       mockWeb3Service.getTokenSymbol.mockResolvedValue(TEST_TOKEN_SYMBOL);
@@ -718,6 +720,8 @@ describe('CampaignsService', () => {
         const manifestUrl = faker.internet.url();
         const manifestHash = faker.string.hexadecimal();
         const totalFundedAmount = faker.number.bigInt({ min: 1 });
+        const mockEscrowBalance = totalFundedAmount - 3n;
+
         mockedEscrowUtils.getEscrow.mockResolvedValueOnce({
           token: faker.finance.ethereumAddress(),
           totalFundedAmount,
@@ -726,6 +730,7 @@ describe('CampaignsService', () => {
           recordingOracle: mockWeb3ConfigService.operatorAddress,
         } as IEscrow);
         mockedGetEscrowStatus.mockResolvedValueOnce(EscrowStatus.Pending);
+        mockedGetEscrowBalance.mockResolvedValueOnce(mockEscrowBalance);
 
         spyOnDownloadCampaignManifest.mockResolvedValueOnce(
           JSON.stringify(mockedManifest),
@@ -739,6 +744,9 @@ describe('CampaignsService', () => {
         expect(escrowInfo).toEqual({
           fundAmount: Number(
             ethers.formatUnits(totalFundedAmount, TEST_TOKEN_DECIMALS),
+          ),
+          fundAmountNet: Number(
+            ethers.formatUnits(mockEscrowBalance, TEST_TOKEN_DECIMALS),
           ),
           fundTokenSymbol: TEST_TOKEN_SYMBOL,
           fundTokenDecimals: TEST_TOKEN_DECIMALS,
@@ -763,6 +771,7 @@ describe('CampaignsService', () => {
       'should retrieve and return data (manifest json) [%#]',
       async (mockedManifest) => {
         const totalFundedAmount = faker.number.bigInt({ min: 1 });
+        const mockEscrowBalance = totalFundedAmount - 3n;
         mockedEscrowUtils.getEscrow.mockResolvedValueOnce({
           token: faker.finance.ethereumAddress(),
           totalFundedAmount,
@@ -771,6 +780,7 @@ describe('CampaignsService', () => {
           recordingOracle: mockWeb3ConfigService.operatorAddress,
         } as IEscrow);
         mockedGetEscrowStatus.mockResolvedValueOnce(EscrowStatus.Pending);
+        mockedGetEscrowBalance.mockResolvedValueOnce(mockEscrowBalance);
 
         const { manifest, escrowInfo } = await campaignsService[
           'retrieveCampaignData'
@@ -780,6 +790,9 @@ describe('CampaignsService', () => {
         expect(escrowInfo).toEqual({
           fundAmount: Number(
             ethers.formatUnits(totalFundedAmount, TEST_TOKEN_DECIMALS),
+          ),
+          fundAmountNet: Number(
+            ethers.formatUnits(mockEscrowBalance, TEST_TOKEN_DECIMALS),
           ),
           fundTokenSymbol: TEST_TOKEN_SYMBOL,
           fundTokenDecimals: TEST_TOKEN_DECIMALS,
@@ -797,6 +810,7 @@ describe('CampaignsService', () => {
     let chainId: number;
     let campaignAddress: string;
     let fundAmount: number;
+    let fundAmountNet: number;
     let fundTokenSymbol: string;
     let fundTokenDecimals: number;
 
@@ -806,6 +820,7 @@ describe('CampaignsService', () => {
       chainId = generateTestnetChainId();
       campaignAddress = faker.finance.ethereumAddress();
       fundAmount = faker.number.float();
+      fundAmountNet = fundAmount * 0.97;
       fundTokenSymbol = faker.finance.currencyCode();
       fundTokenDecimals = faker.number.int({ min: 6, max: 18 });
 
@@ -814,6 +829,7 @@ describe('CampaignsService', () => {
         chainId,
         address: ethers.getAddress(campaignAddress),
         fundAmount: fundAmount.toString(),
+        fundAmountNet: fundAmountNet.toString(),
         fundToken: fundTokenSymbol,
         fundTokenDecimals,
         status: 'active',
@@ -832,6 +848,7 @@ describe('CampaignsService', () => {
         manifest,
         {
           fundAmount,
+          fundAmountNet,
           fundTokenSymbol,
           fundTokenDecimals,
           cancellationRequestedAt: null,
@@ -868,6 +885,7 @@ describe('CampaignsService', () => {
         manifest,
         {
           fundAmount,
+          fundAmountNet,
           fundTokenSymbol,
           fundTokenDecimals,
           cancellationRequestedAt: null,
@@ -904,6 +922,7 @@ describe('CampaignsService', () => {
         manifest,
         {
           fundAmount,
+          fundAmountNet,
           fundTokenSymbol,
           fundTokenDecimals,
           cancellationRequestedAt: null,
@@ -946,6 +965,7 @@ describe('CampaignsService', () => {
           manifest,
           {
             fundAmount,
+            fundAmountNet,
             fundTokenSymbol,
             fundTokenDecimals,
             cancellationRequestedAt: null,
@@ -984,6 +1004,7 @@ describe('CampaignsService', () => {
           manifest,
           {
             fundAmount,
+            fundAmountNet,
             fundTokenSymbol,
             fundTokenDecimals,
             cancellationRequestedAt: null,
@@ -1008,6 +1029,7 @@ describe('CampaignsService', () => {
           manifest,
           {
             fundAmount,
+            fundAmountNet,
             fundTokenSymbol,
             fundTokenDecimals,
             cancellationRequestedAt: null,
@@ -1031,6 +1053,7 @@ describe('CampaignsService', () => {
         manifest,
         {
           fundAmount,
+          fundAmountNet,
           fundTokenSymbol,
           fundTokenDecimals,
           cancellationRequestedAt: cancellationRequestedAt.valueOf(),
@@ -1067,6 +1090,7 @@ describe('CampaignsService', () => {
         manifest,
         {
           fundAmount,
+          fundAmountNet,
           fundTokenSymbol,
           fundTokenDecimals,
           cancellationRequestedAt: null,
@@ -1087,6 +1111,7 @@ describe('CampaignsService', () => {
     let chainId: number;
 
     const mockedGetEscrowStatus = vi.fn();
+    const mockedGetEscrowBalance = vi.fn();
 
     beforeEach(() => {
       campaign = generateCampaignEntity();
@@ -1095,6 +1120,7 @@ describe('CampaignsService', () => {
 
       mockedEscrowClient.build.mockResolvedValue({
         getStatus: mockedGetEscrowStatus,
+        getBalance: mockedGetEscrowBalance,
       } as unknown as EscrowClient);
     });
 
@@ -1200,6 +1226,7 @@ describe('CampaignsService', () => {
       const campaignManifest = generateCampaignManifest();
       const escrowInfo = {
         fundAmount: faker.number.float(),
+        fundAmountNet: faker.number.float(),
         fundTokenSymbol: faker.finance.currencyCode(),
       };
       spyOnretrieveCampaignData.mockResolvedValueOnce({
@@ -2009,6 +2036,7 @@ describe('CampaignsService', () => {
     let campaign: CampaignEntity;
 
     const mockedGetEscrowStatus = vi.fn();
+    const mockedGetEscrowBalance = vi.fn();
 
     beforeAll(() => {
       spyOnRetrieveCampaignIntermediateResults = vi.spyOn(
@@ -2064,6 +2092,7 @@ describe('CampaignsService', () => {
 
       mockedEscrowClient.build.mockResolvedValue({
         getStatus: mockedGetEscrowStatus,
+        getBalance: mockedGetEscrowBalance,
       } as unknown as EscrowClient);
     });
 
@@ -4304,8 +4333,10 @@ describe('CampaignsService', () => {
       mockedEscrowUtils.getEscrows.mockResolvedValueOnce([escrow]);
 
       const campaignManifest = generateCampaignManifest();
+      const fundAmount = faker.number.float();
       const escrowInfo: CampaignEscrowInfo = {
-        fundAmount: faker.number.float(),
+        fundAmount,
+        fundAmountNet: fundAmount * 0.97,
         fundTokenSymbol: faker.finance.currencyCode(),
         fundTokenDecimals: faker.helpers.arrayElement([6, 18]),
         cancellationRequestedAt: null,

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -249,6 +249,7 @@ export class CampaignsService implements OnModuleDestroy {
     newCampaign.startDate = manifest.start_date;
     newCampaign.endDate = manifest.end_date;
     newCampaign.fundAmount = escrowInfo.fundAmount.toString();
+    newCampaign.fundAmountNet = escrowInfo.fundAmountNet.toString();
     newCampaign.fundToken = escrowInfo.fundTokenSymbol;
     newCampaign.fundTokenDecimals = escrowInfo.fundTokenDecimals;
     newCampaign.details = details;
@@ -415,16 +416,21 @@ export class CampaignsService implements OnModuleDestroy {
       );
     }
 
-    const [campaignTokenSymbol, campaignTokenDecimals] = await Promise.all([
-      this.web3Service.getTokenSymbol(chainId, escrow.token),
-      this.web3Service.getTokenDecimals(chainId, escrow.token),
-    ]);
+    const [campaignTokenSymbol, campaignTokenDecimals, fundAmountNet] =
+      await Promise.all([
+        this.web3Service.getTokenSymbol(chainId, escrow.token),
+        this.web3Service.getTokenDecimals(chainId, escrow.token),
+        escrowClient.getBalance(campaignAddress),
+      ]);
 
     return {
       manifest,
       escrowInfo: {
         fundAmount: Number(
           ethers.formatUnits(escrow.totalFundedAmount, campaignTokenDecimals),
+        ),
+        fundAmountNet: Number(
+          ethers.formatUnits(fundAmountNet, campaignTokenDecimals),
         ),
         fundTokenSymbol: campaignTokenSymbol,
         fundTokenDecimals: campaignTokenDecimals,

--- a/recording-oracle/src/modules/campaigns/campaigns.service.ts
+++ b/recording-oracle/src/modules/campaigns/campaigns.service.ts
@@ -416,22 +416,32 @@ export class CampaignsService implements OnModuleDestroy {
       );
     }
 
-    const [campaignTokenSymbol, campaignTokenDecimals, fundAmountNet] =
-      await Promise.all([
-        this.web3Service.getTokenSymbol(chainId, escrow.token),
-        this.web3Service.getTokenDecimals(chainId, escrow.token),
-        escrowClient.getBalance(campaignAddress),
-      ]);
+    const [campaignTokenSymbol, campaignTokenDecimals] = await Promise.all([
+      this.web3Service.getTokenSymbol(chainId, escrow.token),
+      this.web3Service.getTokenDecimals(chainId, escrow.token),
+    ]);
+
+    const fundAmount = ethers.formatUnits(
+      escrow.totalFundedAmount,
+      campaignTokenDecimals,
+    );
+
+    const oraclesFeePercent =
+      escrow.exchangeOracleFee! +
+      escrow.recordingOracleFee! +
+      escrow.reputationOracleFee!;
+    const netFundsPercent = 100 - oraclesFeePercent;
+
+    const fundAmountNet = rewardsUtils.formatRewardValue(
+      Decimal(fundAmount).mul(netFundsPercent).div(100),
+      campaignTokenDecimals,
+    );
 
     return {
       manifest,
       escrowInfo: {
-        fundAmount: Number(
-          ethers.formatUnits(escrow.totalFundedAmount, campaignTokenDecimals),
-        ),
-        fundAmountNet: Number(
-          ethers.formatUnits(fundAmountNet, campaignTokenDecimals),
-        ),
+        fundAmount: Number(fundAmount),
+        fundAmountNet: Number(fundAmountNet),
         fundTokenSymbol: campaignTokenSymbol,
         fundTokenDecimals: campaignTokenDecimals,
         cancellationRequestedAt: escrow.cancellationRequestedAt,

--- a/recording-oracle/src/modules/campaigns/fixtures/campaign.ts
+++ b/recording-oracle/src/modules/campaigns/fixtures/campaign.ts
@@ -85,6 +85,7 @@ export function generateCampaignEntity(type?: CampaignType): CampaignEntity {
     .add(faker.number.int({ min: 3, max: 7 }), 'days')
     .toDate();
 
+  const fundAmount = faker.number.float({ min: 10, max: 10000 });
   const campaign: Omit<CampaignEntity, 'beforeInsert' | 'beforeUpdate'> = {
     id: faker.string.uuid(),
     chainId: generateTestnetChainId(),
@@ -94,7 +95,8 @@ export function generateCampaignEntity(type?: CampaignType): CampaignEntity {
     symbol,
     startDate,
     endDate,
-    fundAmount: faker.number.float({ min: 10, max: 10000 }).toString(),
+    fundAmount: fundAmount.toString(),
+    fundAmountNet: (fundAmount * 0.97).toString(),
     fundToken: faker.finance.currencyCode(),
     fundTokenDecimals: faker.helpers.arrayElement([6, 18]),
     details,

--- a/recording-oracle/src/modules/campaigns/rewards.utils.spec.ts
+++ b/recording-oracle/src/modules/campaigns/rewards.utils.spec.ts
@@ -90,7 +90,7 @@ describe('rewards utils', () => {
 
       const dailyReward = rewardsUtils.calculateDailyReward(campaign);
 
-      const expectedDailyReward = new Decimal(campaign.fundAmount)
+      const expectedDailyReward = new Decimal(campaign.fundAmountNet)
         .div(duration)
         .toDecimalPlaces(campaign.fundTokenDecimals, Decimal.ROUND_DOWN)
         .toString();
@@ -112,7 +112,7 @@ describe('rewards utils', () => {
 
       const dailyReward = rewardsUtils.calculateDailyReward(campaign);
 
-      const expectedDailyReward = new Decimal(campaign.fundAmount)
+      const expectedDailyReward = new Decimal(campaign.fundAmountNet)
         .div(duration)
         .toDecimalPlaces(campaign.fundTokenDecimals, Decimal.ROUND_DOWN)
         .toString();
@@ -122,7 +122,7 @@ describe('rewards utils', () => {
     test('should correctly truncate reward value', () => {
       const duration = 6;
       const campaign = generateCampaignEntity();
-      campaign.fundAmount = '10';
+      campaign.fundAmountNet = '10';
       campaign.fundTokenDecimals = 18;
       campaign.endDate = dayjs(campaign.startDate)
         .add(duration, 'days')
@@ -130,7 +130,7 @@ describe('rewards utils', () => {
 
       const dailyReward = rewardsUtils.calculateDailyReward(campaign);
 
-      const expectedDailyReward = new Decimal(campaign.fundAmount)
+      const expectedDailyReward = new Decimal(campaign.fundAmountNet)
         .div(duration)
         .toDecimalPlaces(campaign.fundTokenDecimals, Decimal.ROUND_DOWN)
         .toString();

--- a/recording-oracle/src/modules/campaigns/rewards.utils.ts
+++ b/recording-oracle/src/modules/campaigns/rewards.utils.ts
@@ -36,9 +36,9 @@ export function calculateDailyReward(campaign: CampaignEntity): string {
     dayjs(campaign.endDate).diff(campaign.startDate, 'days', true),
   );
 
-  const fundAmount = new Decimal(campaign.fundAmount);
+  const fundAmountNet = new Decimal(campaign.fundAmountNet);
 
-  const dailyReward = fundAmount.div(campaignDurationDays);
+  const dailyReward = fundAmountNet.div(campaignDurationDays);
 
   return formatRewardValue(dailyReward, campaign.fundTokenDecimals);
 }

--- a/recording-oracle/src/modules/campaigns/types.ts
+++ b/recording-oracle/src/modules/campaigns/types.ts
@@ -85,6 +85,7 @@ export type CampaignManifest =
 
 export type CampaignEscrowInfo = {
   fundAmount: number;
+  fundAmountNet: number;
   fundTokenSymbol: string;
   fundTokenDecimals: number;
   cancellationRequestedAt: number | null;

--- a/reputation-oracle/src/modules/payouts/fixtures/index.ts
+++ b/reputation-oracle/src/modules/payouts/fixtures/index.ts
@@ -193,7 +193,6 @@ export function generateCampaign(): CampaignWithResults {
     launcher: faker.finance.ethereumAddress(),
     fundTokenAddress: faker.finance.ethereumAddress(),
     fundTokenDecimals: faker.helpers.arrayElement([6, 18]),
-    fundAmount: faker.number.int({ min: 1 }),
     cancellationRequestedAt: null,
   };
 

--- a/reputation-oracle/src/modules/payouts/payouts.service.spec.ts
+++ b/reputation-oracle/src/modules/payouts/payouts.service.spec.ts
@@ -143,12 +143,6 @@ describe('PayoutsService', () => {
         intermediateResultsHash: expectedEscrow.intermediateResultsHash,
         fundTokenAddress: expectedEscrow.token,
         fundTokenDecimals: TEST_TOKEN_DECIMALS,
-        fundAmount: Number(
-          ethers.formatUnits(
-            expectedEscrow.totalFundedAmount,
-            TEST_TOKEN_DECIMALS,
-          ),
-        ),
         launcher: expectedEscrow.launcher,
         cancellationRequestedAt: null,
       });
@@ -171,12 +165,6 @@ describe('PayoutsService', () => {
         intermediateResultsHash: expectedEscrow.intermediateResultsHash,
         fundTokenAddress: expectedEscrow.token,
         fundTokenDecimals: TEST_TOKEN_DECIMALS,
-        fundAmount: Number(
-          ethers.formatUnits(
-            expectedEscrow.totalFundedAmount,
-            TEST_TOKEN_DECIMALS,
-          ),
-        ),
         launcher: expectedEscrow.launcher,
         cancellationRequestedAt: new Date(
           expectedEscrow.cancellationRequestedAt!,

--- a/reputation-oracle/src/modules/payouts/payouts.service.ts
+++ b/reputation-oracle/src/modules/payouts/payouts.service.ts
@@ -606,9 +606,6 @@ export class PayoutsService {
           intermediateResultsHash: escrow.intermediateResultsHash,
           fundTokenAddress: escrow.token,
           fundTokenDecimals,
-          fundAmount: Number(
-            ethers.formatUnits(escrow.totalFundedAmount, fundTokenDecimals),
-          ),
           cancellationRequestedAt: escrow.cancellationRequestedAt
             ? new Date(escrow.cancellationRequestedAt)
             : null,

--- a/reputation-oracle/src/modules/payouts/types.ts
+++ b/reputation-oracle/src/modules/payouts/types.ts
@@ -31,7 +31,6 @@ export type CampaignWithResults = Pick<
   manifestHash: string;
   fundTokenAddress: string;
   fundTokenDecimals: number;
-  fundAmount: number;
   cancellationRequestedAt: Date | null;
 };
 


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
After recent contracts update Recording Oracle can't correctly reserve funds when storing results, because it relies on fund amount and contracts now take "fee" into account. Fix it by adding new column that represents net value.

Instead of using `escrowClient.getBalance` we decided to calculate net amount using fee percent data, so in case we need to remove campaign record from DB and re-create it, then this operation produces the same result.

## How has this been tested?
- [x] unit tests
- [x] run migration and check that `fund_amount_net` is calculated correctly

## Release plan
Merge & deploy

## Potential risks; What to monitor; Rollback plan
TBD