### PR TITLE
[Recording Oracle] refactor: get rid of ambiguity in notif config

### DIFF
--- a/recording-oracle/src/config/notifications-config.service.ts
+++ b/recording-oracle/src/config/notifications-config.service.ts
@@ -6,12 +6,12 @@ export class NotificationsConfigService {
   constructor(private configService: ConfigService) {}
 
   get hufiTgBotUrl(): string {
-    return this.configService.get('HUFI_TG_BOT_URL') || '';
+    const url = this.configService.get('HUFI_TG_BOT_URL') || '';
+
+    return url.replace(/\/+$/, '');
   }
 
   get hufiTgBotClientId(): string {
-    const url = this.configService.getOrThrow<string>('HUFI_TG_BOT_CLIENT_ID');
-
-    return url.replace(/\/+$/, '');
+    return this.configService.getOrThrow('HUFI_TG_BOT_CLIENT_ID');
   }
 }

--- a/recording-oracle/src/config/notifications-config.service.ts
+++ b/recording-oracle/src/config/notifications-config.service.ts
@@ -10,6 +10,8 @@ export class NotificationsConfigService {
   }
 
   get hufiTgBotClientId(): string {
-    return this.configService.getOrThrow('HUFI_TG_BOT_CLIENT_ID');
+    const url = this.configService.getOrThrow<string>('HUFI_TG_BOT_CLIENT_ID');
+
+    return url.replace(/\/+$/, '');
   }
 }

--- a/recording-oracle/src/modules/notifications/notifications.service.spec.ts
+++ b/recording-oracle/src/modules/notifications/notifications.service.spec.ts
@@ -202,7 +202,7 @@ describe('NotificationsService', () => {
 
       expect(mockAxiosPost).toHaveBeenCalledTimes(1);
       expect(mockAxiosPost).toHaveBeenCalledWith(
-        mockNotificationsConfigService.hufiTgBotUrl,
+        `${mockNotificationsConfigService.hufiTgBotUrl}/recording-oracle/notifications`,
         expectedWebhookPayload,
         {
           headers: {

--- a/recording-oracle/src/modules/notifications/notifications.service.ts
+++ b/recording-oracle/src/modules/notifications/notifications.service.ts
@@ -109,13 +109,17 @@ export class NotificationsService {
         this.web3ConfigService.privateKey,
       );
 
-      await axios.post(hufiTgBotUrl, tgWebhookPayload, {
-        headers: {
-          [RECORDING_ORACLE_SIGNATURE_HEADER]: signature,
-          [RECORDING_ORACLE_ADDRESS_HEADER]:
-            this.web3ConfigService.operatorAddress,
+      await axios.post(
+        `${hufiTgBotUrl}/recording-oracle/notifications`,
+        tgWebhookPayload,
+        {
+          headers: {
+            [RECORDING_ORACLE_SIGNATURE_HEADER]: signature,
+            [RECORDING_ORACLE_ADDRESS_HEADER]:
+              this.web3ConfigService.operatorAddress,
+          },
         },
-      });
+      );
     } catch (error) {
       let formattedError = error;
       if (error instanceof AxiosError) {

--- a/recording-oracle/src/modules/users/user-preferences.service.spec.ts
+++ b/recording-oracle/src/modules/users/user-preferences.service.spec.ts
@@ -195,7 +195,7 @@ describe('UserPreferencesService', () => {
           enabled: faker.datatype.boolean(),
           exchanges: [faker.lorem.word()],
           campaignTypes: [faker.lorem.word()],
-          tokens: [faker.lorem.word()],
+          tokens: [faker.lorem.word({ length: { min: 3, max: 10 } })],
         },
       });
 


### PR DESCRIPTION
## Issue tracking
Freestyle

## Context behind the change
- fixed flaky test
- got rid of ambiguity in tg bot url config var

## How has this been tested?
- [x] unit tests

## Release plan
1. Update `HUFI_TG_BOT_URL` env variable to be base url instead of full notifications path url (w/o re-deploy)
2. Deploy

## Potential risks; What to monitor; Rollback plan
Should be none