### PR TITLE
[Campaign Launcher Server] chore: bump sdk

### DIFF
--- a/campaign-launcher/server/package.json
+++ b/campaign-launcher/server/package.json
@@ -20,7 +20,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@hu-fi/subgraph-sdk": "^4.0.0",
+    "@hu-fi/subgraph-sdk": "^5.0.0",
     "@human-protocol/logger": "^1.3.0",
     "@human-protocol/sdk": "^7.1.0",
     "@nestjs/common": "^11.1.10",

--- a/campaign-launcher/server/yarn.lock
+++ b/campaign-launcher/server/yarn.lock
@@ -708,13 +708,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hu-fi/subgraph-sdk@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@hu-fi/subgraph-sdk@npm:4.0.0"
+"@hu-fi/subgraph-sdk@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@hu-fi/subgraph-sdk@npm:5.0.0"
   dependencies:
     graphql: "npm:^16.13.1"
     graphql-request: "npm:^7.4.0"
-  checksum: 10c0/a926124b79ff172c92a7522cde384718acbe98973f6f7defe479cac5284454cb43022ed825a7b940a22fa62eadfb58b18e06556ef597f5379394159cf2e07e70
+  checksum: 10c0/8f3e45f589d4c058ce3c3e5a55c49f0b7a1e15b7eb9773342f3456ea1969ce9f8ae28d50d3841f7c58d8f915a1a893733dd2355edc0b7ccc9e1eaa7411870a55
   languageName: node
   linkType: hard
 
@@ -3676,7 +3676,7 @@ __metadata:
     "@eslint/js": "npm:^10.0.1"
     "@faker-js/faker": "npm:^10.4.0"
     "@golevelup/ts-vitest": "npm:^4.0.0"
-    "@hu-fi/subgraph-sdk": "npm:^4.0.0"
+    "@hu-fi/subgraph-sdk": "npm:^5.0.0"
     "@human-protocol/logger": "npm:^1.3.0"
     "@human-protocol/sdk": "npm:^7.1.0"
     "@nestjs/cli": "npm:^11.0.14"


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Bump sdk to get latest subgraph urls

## How has this been tested?
- [x] e2e locally

## Release plan
Regular

## Potential risks; What to monitor; Rollback plan
No