### PR TITLE
[Recording Oracle] feat: DB scripts runner

### DIFF
--- a/recording-oracle/package.json
+++ b/recording-oracle/package.json
@@ -19,6 +19,7 @@
     "migration:revert": "yarn typeorm migration:revert -d typeorm-migrations-datasource.ts",
     "migration:run": "yarn typeorm migration:run -d typeorm-migrations-datasource.ts",
     "migration:show": "yarn typeorm migration:show -d typeorm-migrations-datasource.ts",
+    "run:db-script": "ts-node src/infrastructure/database/script-runner.ts",
     "test": "vitest --dir src",
     "test:watch": "yarn test --watch --ui",
     "test:e2e": "vitest --dir test/e2e",
@@ -84,6 +85,7 @@
     "@types/passport-jwt": "^4.0.1",
     "@types/pg": "^8.16.0",
     "@types/supertest": "^7.2.0",
+    "@types/yargs": "^17.0.35",
     "@vitest/ui": "^4.1.5",
     "eslint": "^10.2.0",
     "eslint-config-prettier": "^10.1.8",
@@ -99,7 +101,8 @@
     "type-fest": "^5.6.0",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.1",
-    "vitest": "^4.1.5"
+    "vitest": "^4.1.5",
+    "yargs": "^18.0.0"
   },
   "lint-staged": {
     "*.ts": [

--- a/recording-oracle/src/infrastructure/database/migrations/1780412549394-add-fund-amount-net.ts
+++ b/recording-oracle/src/infrastructure/database/migrations/1780412549394-add-fund-amount-net.ts
@@ -12,7 +12,7 @@ type Campaign = {
 
 /**
  * !!!WARN!!!
- * This was one-time occurence where we had to perform calculations in the migration.
+ * This was one-time occurrence where we had to perform calculations in the migration.
  * This is not a good practice and should be avoided in the future.
  *
  * Further we should plan migrations to only bring schema changes

--- a/recording-oracle/src/infrastructure/database/migrations/1780412549394-add-fund-amount-net.ts
+++ b/recording-oracle/src/infrastructure/database/migrations/1780412549394-add-fund-amount-net.ts
@@ -10,6 +10,14 @@ type Campaign = {
   fund_token_decimals: number;
 };
 
+/**
+ * !!!WARN!!!
+ * This was one-time occurence where we had to perform calculations in the migration.
+ * This is not a good practice and should be avoided in the future.
+ *
+ * Further we should plan migrations to only bring schema changes
+ * and run updates/backfills via separate scripts.
+ */
 async function getCampaignFundAmountNet(campaign: Campaign): Promise<string> {
   const escrow = await EscrowUtils.getEscrow(
     campaign.chain_id,

--- a/recording-oracle/src/infrastructure/database/script-runner.ts
+++ b/recording-oracle/src/infrastructure/database/script-runner.ts
@@ -4,15 +4,27 @@ import path from 'path';
 import readline from 'readline/promises';
 import { setTimeout as delay } from 'timers/promises';
 
+import * as dotenv from 'dotenv';
 import type { Constructor } from 'type-fest';
+import { DataSource } from 'typeorm';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 import '@/setup-libs';
 
+import Environment from '@/common/utils/environment';
 import logger from '@/logger';
 
+import { CustomNamingStrategy } from './naming-strategy';
 import type { DbScript } from './scripts/base';
+
+dotenv.config({
+  quiet: true,
+  /**
+   * First value wins if "override" option is not set
+   */
+  path: [`.env.${Environment.name}`, '.env'],
+});
 
 /**
  * NOTE: ts-node can't use dynamic imports that contain ts-paths,
@@ -116,6 +128,48 @@ async function getUserConfirmation(message: string): Promise<boolean> {
   }
 }
 
+async function createDependencies(scriptName: string) {
+  runnerLogger.debug('Initializing dependencies');
+
+  const connectionUrl = process.env.POSTGRES_URL;
+  if (!connectionUrl && !process.env.POSTGRES_HOST) {
+    runnerLogger.error(
+      'Database connection details are not provided. Please check your NODE_ENV or/and .env files',
+    );
+    process.exit(1);
+  }
+
+  const dataSource = new DataSource({
+    type: 'postgres',
+    useUTC: true,
+    ...(connectionUrl
+      ? {
+          url: connectionUrl,
+        }
+      : {
+          host: process.env.POSTGRES_HOST,
+          port: Number(process.env.POSTGRES_PORT),
+          username: process.env.POSTGRES_USER,
+          password: process.env.POSTGRES_PASSWORD,
+          database: process.env.POSTGRES_DATABASE,
+        }),
+    ssl: process.env.POSTGRES_SSL?.toLowerCase() === 'true',
+    namingStrategy: new CustomNamingStrategy(),
+  });
+
+  try {
+    await dataSource.initialize();
+  } catch (error) {
+    runnerLogger.error('Error while initializing data source', { error });
+    process.exit(1);
+  }
+
+  return {
+    scriptLogger: runnerLogger.child({ scriptName }),
+    queryRunner: dataSource.createQueryRunner(),
+  };
+}
+
 /**
  * yarn ts-node src/infrastructure/database/script-runner.ts
  */
@@ -134,42 +188,42 @@ void (async () => {
     scriptName,
     ...argsOptions,
   });
-  /**
-   * To get the log message above before confirmation prompt
-   */
-  await delay(1000);
 
-  if (argsOptions.dryRun) {
-    runnerLogger.warn(
-      'Running in "dry-run" mode, no actual changes should be applied',
-    );
-  } else {
-    const confirmed = await getUserConfirmation(`
-      You are going to run "${scriptName}" script in live mode,
-      actual changes will be applied. Do you want to continue?
-    `);
-    if (confirmed) {
-      runnerLogger.debug('"Live" mode confirmed, continuing');
-      await delay(2500);
-    } else {
-      runnerLogger.debug('Script execution cancelled');
-      process.exit(0);
-    }
+  const { scriptLogger, ...scriptDependencies } =
+    await createDependencies(scriptName);
+
+  let scriptCtor: Constructor<DbScript>;
+  try {
+    scriptLogger.debug('Loading script');
+    scriptCtor = await loadScriptCtor(scriptName);
+  } catch (error) {
+    scriptLogger.error('Error while loading script', { error });
+    process.exit(1);
   }
 
-  const scriptLogger = runnerLogger.child({ scriptName });
   try {
-    scriptLogger.debug('Loading script', {
-      options: argsOptions,
-    });
-    const scriptCtor = await loadScriptCtor(scriptName);
-
-    scriptLogger.info('Script executor loaded, initializing');
-
-    const script = new scriptCtor(scriptLogger);
+    const script = new scriptCtor(scriptLogger, scriptDependencies.queryRunner);
     await script.init();
 
     scriptLogger.info('Script executor initialized, going to run');
+
+    if (argsOptions.dryRun) {
+      runnerLogger.warn(
+        'Running in "dry-run" mode, no actual changes should be applied',
+      );
+    } else {
+      await delay(1000);
+      const confirmed = await getUserConfirmation(
+        `You are going to run "${scriptName}" script in live mode, actual changes will be applied. Do you want to continue?`,
+      );
+      if (confirmed) {
+        runnerLogger.debug('"Live" mode confirmed, continuing');
+        await delay(1000);
+      } else {
+        runnerLogger.debug('Script execution cancelled');
+        process.exit(0);
+      }
+    }
 
     const { revert, ...scriptOptions } = argsOptions;
     if (revert) {
@@ -180,7 +234,7 @@ void (async () => {
 
     process.exit(0);
   } catch (error) {
-    scriptLogger.error('Error while running script', { error });
+    scriptLogger.error('Error while running script', { scriptName, error });
     process.exit(1);
   }
 })();

--- a/recording-oracle/src/infrastructure/database/script-runner.ts
+++ b/recording-oracle/src/infrastructure/database/script-runner.ts
@@ -1,0 +1,186 @@
+import fs from 'fs/promises';
+import { createRequire } from 'module';
+import path from 'path';
+import readline from 'readline/promises';
+import { setTimeout as delay } from 'timers/promises';
+
+import type { Constructor } from 'type-fest';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+import '@/setup-libs';
+
+import logger from '@/logger';
+
+import type { DbScript } from './scripts/base';
+
+/**
+ * NOTE: ts-node can't use dynamic imports, so have to use this
+ */
+const __require = createRequire(__filename);
+
+const runnerLogger = logger.child({ context: 'ScriptRunner' });
+
+const DEFAULT_SCRIPT_NAME = 'ping';
+
+type ArgsOptions = {
+  dryRun: boolean;
+  revert: boolean;
+};
+
+async function parseOptions(): Promise<{ scriptName: string } & ArgsOptions> {
+  const argv = await yargs(hideBin(process.argv))
+    .version(false)
+    .scriptName('yarn run:db-script')
+    .usage('$0 [options]')
+    .option('script', {
+      type: 'string',
+      default: DEFAULT_SCRIPT_NAME,
+      describe: 'Name of script to run',
+    })
+    .option('dry-run', {
+      type: 'boolean',
+      default: true,
+      describe: 'Run without applying changes',
+    })
+    .option('revert', {
+      type: 'boolean',
+      default: false,
+      describe: 'Run "revert" version of the script',
+    })
+    .help()
+    .parserConfiguration({
+      'camel-case-expansion': true,
+    })
+    .parseAsync();
+
+  return {
+    scriptName: argv.script,
+    dryRun: argv.dryRun,
+    revert: argv.revert,
+  };
+}
+
+async function resolveScriptPath(scriptName: string): Promise<string> {
+  const scriptPath = path.resolve(__dirname, 'scripts', `${scriptName}.ts`);
+
+  try {
+    await fs.access(scriptPath);
+  } catch {
+    throw new Error(`Script "${scriptName}" not found at ${scriptPath}`);
+  }
+
+  return `./${path.relative(__dirname, scriptPath)}`;
+}
+
+async function loadScriptCtor(
+  scriptName: string,
+): Promise<Constructor<DbScript>> {
+  const scriptPath = await resolveScriptPath(scriptName);
+
+  const { default: ScriptCtor } = __require(scriptPath);
+
+  const isCorrectImplementation = ['init', 'execute', 'revert'].every(
+    (method) => typeof ScriptCtor.prototype[method] === 'function',
+  );
+  if (!isCorrectImplementation) {
+    throw new Error('Incorrect DbScript implementation');
+  }
+
+  return ScriptCtor;
+}
+
+async function getUserConfirmation(message: string): Promise<boolean> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  try {
+    const answerInput = await rl.question(
+      `${message} Type "y" or "yes" to continue: `,
+    );
+    /**
+     * Empty line after confirmation input
+     */
+    process.stdout.write('\n');
+
+    if (['y', 'yes'].includes(answerInput.trim().toLowerCase())) {
+      return true;
+    } else {
+      return false;
+    }
+  } catch {
+    return false;
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * yarn ts-node src/infrastructure/database/script-runner.ts
+ */
+void (async () => {
+  let scriptName: string;
+  let argsOptions: ArgsOptions;
+
+  try {
+    ({ scriptName, ...argsOptions } = await parseOptions());
+  } catch (error) {
+    runnerLogger.error('Error while parsing options', { error });
+    process.exit(1);
+  }
+
+  runnerLogger.debug('Parsed options', {
+    scriptName,
+    ...argsOptions,
+  });
+  /**
+   * To get this log before confirmation prompt
+   */
+  await delay(1000);
+
+  if (argsOptions.dryRun) {
+    runnerLogger.warn(
+      'Running in "dry-run" mode, no actual changes should be applied',
+    );
+  } else {
+    const confirmed = await getUserConfirmation(
+      `\nYou are going to run "${scriptName}" script in live mode, actual changes will be applied. Do you want to continue?`,
+    );
+    if (confirmed) {
+      runnerLogger.debug('"Live" mode confirmed, continuing');
+      await delay(2500);
+    } else {
+      runnerLogger.debug('Script execution cancelled');
+      process.exit(0);
+    }
+  }
+
+  const scriptLogger = runnerLogger.child({ scriptName });
+  try {
+    scriptLogger.debug('Loading script', {
+      options: argsOptions,
+    });
+    const scriptCtor = await loadScriptCtor(scriptName);
+
+    scriptLogger.info('Script executor loaded, initializing');
+
+    const script = new scriptCtor(scriptLogger);
+    await script.init();
+
+    scriptLogger.info('Script executor initialized, going to run');
+
+    const { revert, ...scriptOptions } = argsOptions;
+    if (revert) {
+      await script.revert(scriptOptions);
+    } else {
+      await script.execute(scriptOptions);
+    }
+
+    process.exit(0);
+  } catch (error) {
+    scriptLogger.error('Error while running script', { error });
+    process.exit(1);
+  }
+})();

--- a/recording-oracle/src/infrastructure/database/script-runner.ts
+++ b/recording-oracle/src/infrastructure/database/script-runner.ts
@@ -114,7 +114,6 @@ async function getUserConfirmation(message: string): Promise<boolean> {
     const answerInput = await rl.question(
       `${message} Type "y" or "yes" to continue: `,
     );
-    process.stdout.write('\n');
 
     if (['y', 'yes'].includes(answerInput.trim().toLowerCase())) {
       return true;
@@ -124,10 +123,12 @@ async function getUserConfirmation(message: string): Promise<boolean> {
   } catch {
     return false;
   } finally {
+    process.stdout.write('\n\n');
     rl.close();
   }
 }
 
+let dataSource: DataSource;
 async function createDependencies(scriptName: string) {
   runnerLogger.debug('Initializing dependencies');
 
@@ -136,10 +137,10 @@ async function createDependencies(scriptName: string) {
     runnerLogger.error(
       'Database connection details are not provided. Please check your NODE_ENV or/and .env files',
     );
-    process.exit(1);
+    throw new Error('Invalid DB connection details');
   }
 
-  const dataSource = new DataSource({
+  dataSource = new DataSource({
     type: 'postgres',
     useUTC: true,
     ...(connectionUrl
@@ -160,8 +161,9 @@ async function createDependencies(scriptName: string) {
   try {
     await dataSource.initialize();
   } catch (error) {
-    runnerLogger.error('Error while initializing data source', { error });
-    process.exit(1);
+    const errorMessage = 'Failed to initialize data source';
+    runnerLogger.error(errorMessage, { error });
+    throw new Error(errorMessage);
   }
 
   return {
@@ -170,71 +172,118 @@ async function createDependencies(scriptName: string) {
   };
 }
 
-/**
- * yarn ts-node src/infrastructure/database/script-runner.ts
- */
-void (async () => {
-  let scriptName: string;
-  let argsOptions: ArgsOptions;
+async function cleanupDependencies() {
+  runnerLogger.debug('Cleaning up dependencies');
+  await dataSource?.destroy();
+  runnerLogger.debug('Dependencies cleaned up');
+}
 
-  try {
-    ({ scriptName, ...argsOptions } = await parseOptions());
-  } catch (error) {
-    runnerLogger.error('Error while parsing options', { error });
-    process.exit(1);
+let shutdownInProgress = false;
+let cleanupTimeout: NodeJS.Timeout | undefined;
+async function shutdown(signal?: string) {
+  if (shutdownInProgress) {
+    return;
   }
+  shutdownInProgress = true;
 
-  runnerLogger.debug('Parsed options', {
-    scriptName,
-    ...argsOptions,
-  });
+  runnerLogger.info(`Received ${signal}, shutting down...`);
 
-  const { scriptLogger, ...scriptDependencies } =
-    await createDependencies(scriptName);
-
-  let scriptCtor: Constructor<DbScript>;
-  try {
-    scriptLogger.debug('Loading script');
-    scriptCtor = await loadScriptCtor(scriptName);
-  } catch (error) {
-    scriptLogger.error('Error while loading script', { error });
+  cleanupTimeout = setTimeout(() => {
+    runnerLogger.error('Cleanup timeout, forcing exit');
     process.exit(1);
-  }
+  }, 10 * 1000);
 
   try {
-    const script = new scriptCtor(scriptLogger, scriptDependencies.queryRunner);
-    await script.init();
+    await cleanupDependencies();
 
-    scriptLogger.info('Script executor initialized, going to run');
-
-    if (argsOptions.dryRun) {
-      runnerLogger.warn(
-        'Running in "dry-run" mode, no actual changes should be applied',
-      );
-    } else {
-      await delay(1000);
-      const confirmed = await getUserConfirmation(
-        `You are going to run "${scriptName}" script in live mode, actual changes will be applied. Do you want to continue?`,
-      );
-      if (confirmed) {
-        runnerLogger.debug('"Live" mode confirmed, continuing');
-        await delay(1000);
-      } else {
-        runnerLogger.debug('Script execution cancelled');
-        process.exit(0);
-      }
-    }
-
-    const { revert, ...scriptOptions } = argsOptions;
-    if (revert) {
-      await script.revert(scriptOptions);
-    } else {
-      await script.execute(scriptOptions);
+    if (cleanupTimeout) {
+      clearTimeout(cleanupTimeout);
     }
 
     process.exit(0);
   } catch (error) {
-    scriptLogger.error('Error while running script', { scriptName, error });
+    runnerLogger.error('Error during shutdown', error);
+
+    if (cleanupTimeout) {
+      clearTimeout(cleanupTimeout);
+    }
+
     process.exit(1);
+  }
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+
+/**
+ * yarn ts-node src/infrastructure/database/script-runner.ts
+ */
+void (async () => {
+  try {
+    let scriptName: string;
+    let argsOptions: ArgsOptions;
+
+    try {
+      ({ scriptName, ...argsOptions } = await parseOptions());
+    } catch (error) {
+      runnerLogger.error('Error while parsing options', { error });
+      return;
+    }
+
+    runnerLogger.debug('Parsed options', {
+      scriptName,
+      ...argsOptions,
+    });
+
+    const { scriptLogger, ...scriptDependencies } =
+      await createDependencies(scriptName);
+
+    let scriptCtor: Constructor<DbScript>;
+    try {
+      scriptLogger.debug('Loading script');
+      scriptCtor = await loadScriptCtor(scriptName);
+    } catch (error) {
+      scriptLogger.error('Error while loading script', { error });
+      return;
+    }
+
+    try {
+      const script = new scriptCtor(
+        scriptLogger,
+        scriptDependencies.queryRunner,
+      );
+      await script.init();
+
+      scriptLogger.info('Script executor initialized, going to run');
+
+      if (argsOptions.dryRun) {
+        runnerLogger.warn(
+          'Running in "dry-run" mode, no actual changes should be applied',
+        );
+      } else {
+        await delay(1000);
+        const confirmed = await getUserConfirmation(
+          `You are going to run "${scriptName}" script in live mode, actual changes will be applied. Do you want to continue?`,
+        );
+        if (confirmed) {
+          runnerLogger.debug('"Live" mode confirmed, continuing');
+          await delay(1000);
+        } else {
+          runnerLogger.debug('Script execution cancelled');
+          return;
+        }
+      }
+
+      const { revert, ...scriptOptions } = argsOptions;
+      if (revert) {
+        await script.revert(scriptOptions);
+      } else {
+        await script.execute(scriptOptions);
+      }
+    } catch (error) {
+      scriptLogger.error('Error while running script', { scriptName, error });
+    }
+  } finally {
+    await cleanupDependencies();
   }
 })();

--- a/recording-oracle/src/infrastructure/database/script-runner.ts
+++ b/recording-oracle/src/infrastructure/database/script-runner.ts
@@ -15,13 +15,12 @@ import logger from '@/logger';
 import type { DbScript } from './scripts/base';
 
 /**
- * NOTE: ts-node can't use dynamic imports, so have to use this
+ * NOTE: ts-node can't use dynamic imports that contain ts-paths,
+ * so have to use this as a workaround to load scripts dynamically
  */
 const __require = createRequire(__filename);
 
 const runnerLogger = logger.child({ context: 'ScriptRunner' });
-
-const DEFAULT_SCRIPT_NAME = 'ping';
 
 type ArgsOptions = {
   dryRun: boolean;
@@ -32,12 +31,13 @@ async function parseOptions(): Promise<{ scriptName: string } & ArgsOptions> {
   const argv = await yargs(hideBin(process.argv))
     .version(false)
     .scriptName('yarn run:db-script')
-    .usage('$0 [options]')
-    .option('script', {
-      type: 'string',
-      default: DEFAULT_SCRIPT_NAME,
-      describe: 'Name of script to run',
-    })
+    .usage('$0 <script-name> [options]')
+    .command('$0 <script-name>', 'Run a database script', (yargs) =>
+      yargs.positional('script-name', {
+        type: 'string',
+        describe: 'Script name to run',
+      }),
+    )
     .option('dry-run', {
       type: 'boolean',
       default: true,
@@ -49,13 +49,14 @@ async function parseOptions(): Promise<{ scriptName: string } & ArgsOptions> {
       describe: 'Run "revert" version of the script',
     })
     .help()
+    .example('$0 ping', 'Ping DB connection')
     .parserConfiguration({
       'camel-case-expansion': true,
     })
     .parseAsync();
 
   return {
-    scriptName: argv.script,
+    scriptName: argv['script-name'] as string,
     dryRun: argv.dryRun,
     revert: argv.revert,
   };
@@ -97,12 +98,10 @@ async function getUserConfirmation(message: string): Promise<boolean> {
   });
 
   try {
+    process.stdout.write('\n');
     const answerInput = await rl.question(
       `${message} Type "y" or "yes" to continue: `,
     );
-    /**
-     * Empty line after confirmation input
-     */
     process.stdout.write('\n');
 
     if (['y', 'yes'].includes(answerInput.trim().toLowerCase())) {
@@ -136,7 +135,7 @@ void (async () => {
     ...argsOptions,
   });
   /**
-   * To get this log before confirmation prompt
+   * To get the log message above before confirmation prompt
    */
   await delay(1000);
 
@@ -145,9 +144,10 @@ void (async () => {
       'Running in "dry-run" mode, no actual changes should be applied',
     );
   } else {
-    const confirmed = await getUserConfirmation(
-      `\nYou are going to run "${scriptName}" script in live mode, actual changes will be applied. Do you want to continue?`,
-    );
+    const confirmed = await getUserConfirmation(`
+      You are going to run "${scriptName}" script in live mode,
+      actual changes will be applied. Do you want to continue?
+    `);
     if (confirmed) {
       runnerLogger.debug('"Live" mode confirmed, continuing');
       await delay(2500);

--- a/recording-oracle/src/infrastructure/database/scripts/base.ts
+++ b/recording-oracle/src/infrastructure/database/scripts/base.ts
@@ -1,0 +1,17 @@
+import { Logger } from '@/logger';
+
+export type DbScriptOptions = {
+  dryRun: boolean;
+};
+
+export abstract class DbScript {
+  constructor(protected readonly logger: Logger) {}
+
+  async init(): Promise<void> {
+    this.logger.info('No initialization step for this script');
+  }
+
+  abstract execute(options: DbScriptOptions): Promise<void>;
+
+  abstract revert(options: DbScriptOptions): Promise<void>;
+}

--- a/recording-oracle/src/infrastructure/database/scripts/base.ts
+++ b/recording-oracle/src/infrastructure/database/scripts/base.ts
@@ -1,3 +1,5 @@
+import type { QueryRunner } from 'typeorm';
+
 import { Logger } from '@/logger';
 
 export type DbScriptOptions = {
@@ -5,7 +7,10 @@ export type DbScriptOptions = {
 };
 
 export abstract class DbScript {
-  constructor(protected readonly logger: Logger) {}
+  constructor(
+    protected readonly logger: Logger,
+    protected readonly queryRunner: QueryRunner,
+  ) {}
 
   async init(): Promise<void> {
     this.logger.info('No initialization step for this script');

--- a/recording-oracle/src/infrastructure/database/scripts/ping.ts
+++ b/recording-oracle/src/infrastructure/database/scripts/ping.ts
@@ -1,0 +1,17 @@
+import { setTimeout as delay } from 'timers/promises';
+
+import { MethodNotImplementedError } from '@/common/errors/base';
+
+import { DbScript } from './base';
+
+export default class PingDbScript extends DbScript {
+  async execute(): Promise<void> {
+    this.logger.info('Ping!');
+    await delay(2500);
+    this.logger.info('Pong!');
+  }
+
+  async revert(): Promise<void> {
+    throw new MethodNotImplementedError();
+  }
+}

--- a/recording-oracle/src/infrastructure/database/scripts/ping.ts
+++ b/recording-oracle/src/infrastructure/database/scripts/ping.ts
@@ -1,14 +1,20 @@
-import { setTimeout as delay } from 'timers/promises';
-
 import { MethodNotImplementedError } from '@/common/errors/base';
 
 import { DbScript } from './base';
 
 export default class PingDbScript extends DbScript {
   async execute(): Promise<void> {
-    this.logger.info('Ping!');
-    await delay(2500);
-    this.logger.info('Pong!');
+    try {
+      const [dbInfo] = await this.queryRunner.query(`
+        SELECT 
+          current_database() as database,
+          current_user as user
+      `);
+
+      this.logger.info('DB ping OK', { dbInfo });
+    } catch (error) {
+      this.logger.info('DB ping error', { error });
+    }
   }
 
   async revert(): Promise<void> {

--- a/recording-oracle/src/logger/index.ts
+++ b/recording-oracle/src/logger/index.ts
@@ -38,8 +38,6 @@ export const nestLoggerOverride = new NestLogger(
   defaultLogger.child({ name: 'NestLogger' }),
 );
 
-export const backfillsLogger = defaultLogger.child({ name: 'BackfillsLogger' });
-
 export type { Logger };
 
 export default defaultLogger;

--- a/recording-oracle/src/logger/index.ts
+++ b/recording-oracle/src/logger/index.ts
@@ -38,6 +38,8 @@ export const nestLoggerOverride = new NestLogger(
   defaultLogger.child({ name: 'NestLogger' }),
 );
 
+export const backfillsLogger = defaultLogger.child({ name: 'BackfillsLogger' });
+
 export type { Logger };
 
 export default defaultLogger;

--- a/recording-oracle/src/modules/users/user-preferences.service.spec.ts
+++ b/recording-oracle/src/modules/users/user-preferences.service.spec.ts
@@ -146,7 +146,7 @@ describe('UserPreferencesService', () => {
           enabled: faker.datatype.boolean(),
           exchanges: Array.from({ length: 2 }, () => faker.lorem.word()),
           campaignTypes: Array.from({ length: 2 }, () => faker.lorem.word()),
-          tokens: Array.from({ length: 2 }, () => faker.lorem.word()),
+          tokens: Array.from({ length: 2 }, () => faker.finance.currencyCode()),
         },
         telegramUserId: faker.number.int().toString(),
         notifications: {
@@ -161,7 +161,7 @@ describe('UserPreferencesService', () => {
 
       const newExchange = faker.lorem.word();
       const newCampaignType = faker.lorem.word();
-      const newToken = faker.lorem.word();
+      const newToken = faker.finance.currencyCode();
 
       const result = await userPreferencesService.update(user.id, {
         campaignsAutojoin: {
@@ -195,7 +195,7 @@ describe('UserPreferencesService', () => {
           enabled: faker.datatype.boolean(),
           exchanges: [faker.lorem.word()],
           campaignTypes: [faker.lorem.word()],
-          tokens: [faker.lorem.word({ length: { min: 3, max: 10 } })],
+          tokens: [faker.finance.currencyCode()],
         },
       });
 

--- a/recording-oracle/typeorm-migrations-datasource.ts
+++ b/recording-oracle/typeorm-migrations-datasource.ts
@@ -7,6 +7,7 @@ import Environment from '@/common/utils/environment';
 import { CustomNamingStrategy } from '@/infrastructure/database/naming-strategy';
 
 dotenv.config({
+  quiet: true,
   /**
    * First value wins if "override" option is not set
    */

--- a/recording-oracle/typeorm-migrations-datasource.ts
+++ b/recording-oracle/typeorm-migrations-datasource.ts
@@ -32,6 +32,7 @@ export default new DataSource({
   ssl: process.env.POSTGRES_SSL?.toLowerCase() === 'true',
   synchronize: false,
   migrationsRun: true,
+  migrationsTransactionMode: 'each',
   migrations: ['src/infrastructure/database/migrations/*.ts'],
   migrationsTableName: 'migrations_typeorm',
   namingStrategy: new CustomNamingStrategy(),

--- a/recording-oracle/yarn.lock
+++ b/recording-oracle/yarn.lock
@@ -2547,6 +2547,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/yargs-parser@npm:*":
+  version: 21.0.3
+  resolution: "@types/yargs-parser@npm:21.0.3"
+  checksum: 10c0/e71c3bd9d0b73ca82e10bee2064c384ab70f61034bbfb78e74f5206283fc16a6d85267b606b5c22cb2a3338373586786fed595b2009825d6a9115afba36560a0
+  languageName: node
+  linkType: hard
+
+"@types/yargs@npm:^17.0.35":
+  version: 17.0.35
+  resolution: "@types/yargs@npm:17.0.35"
+  dependencies:
+    "@types/yargs-parser": "npm:*"
+  checksum: 10c0/609557826a6b85e73ccf587923f6429850d6dc70e420b455bab4601b670bfadf684b09ae288bccedab042c48ba65f1666133cf375814204b544009f57d6eef63
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/eslint-plugin@npm:8.60.0":
   version: 8.60.0
   resolution: "@typescript-eslint/eslint-plugin@npm:8.60.0"
@@ -7571,6 +7587,7 @@ __metadata:
     "@types/passport-jwt": "npm:^4.0.1"
     "@types/pg": "npm:^8.16.0"
     "@types/supertest": "npm:^7.2.0"
+    "@types/yargs": "npm:^17.0.35"
     "@valkey/valkey-glide": "npm:^2.2.1"
     "@vitest/ui": "npm:^4.1.5"
     alchemy-sdk: "npm:^3.6.5"
@@ -7614,6 +7631,7 @@ __metadata:
     typescript: "npm:^6.0.2"
     typescript-eslint: "npm:^8.58.1"
     vitest: "npm:^4.1.5"
+    yargs: "npm:^18.0.0"
     yauzl: "npm:^3.3.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Issue tracking
Freestyle

## Context behind the change
Recently we had to run a DB migration that contained not only schema changes, but also needed to run some backfill by querying third-party (Subgraph). Taking into account that migration scripts run in transaction and they are either success or fail, it was tricky to get it working because of subgraph errors. Another potential issue relates to long-running/heavy backfills: typeorm txs hold table locks for extended periods, blocking application read/write operations.

So decided to split the approach and:
- keep "migrations" only for schema changes and "light" updates that can quickly run during "pre-deploy" script
- keep heavy "backfills" and anything that needs to go to 3rd-party to separate "scripts" with help of "script-runner"

## How has this been tested?
- [x] `NODE_ENV=local yarn run:db-script ping --dry-run=false` locally, make sure db info logged
- [x] run `ping` script with different combination of params to check for error-cases

## Release plan
Regular

## Potential risks; What to monitor; Rollback plan
No