### PR TITLE
chore: bump human-protocol-sdk

### DIFF
--- a/campaign-launcher/server/package.json
+++ b/campaign-launcher/server/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@hu-fi/subgraph-sdk": "^5.0.0",
     "@human-protocol/logger": "^1.3.0",
-    "@human-protocol/sdk": "^7.1.0",
+    "@human-protocol/sdk": "^7.3.0",
     "@nestjs/common": "^11.1.10",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.10",

--- a/campaign-launcher/server/yarn.lock
+++ b/campaign-launcher/server/yarn.lock
@@ -718,12 +718,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@human-protocol/core@npm:6.0.0":
-  version: 6.0.0
-  resolution: "@human-protocol/core@npm:6.0.0"
+"@human-protocol/core@npm:7.0.0":
+  version: 7.0.0
+  resolution: "@human-protocol/core@npm:7.0.0"
   peerDependencies:
-    ethers: ~6.15.0
-  checksum: 10c0/10316b23ed6987c75ca1276de85145200bd1190ac8116e5ce6dfad5c427b1b509db63457ba5849fb9c16477264fc521b6737af48cf4700edc968153e1f8e28f2
+    ethers: ~6.16.0
+  checksum: 10c0/b8083fca9b7fab0bca450b7a520cf9f0e8b3af29f4b90fc36ab1d3f24b2ff76aa53f3c3e160f7c40e7079aad6f32ebc67f5abaf8ad75eb77eee808fee7fd3955
   languageName: node
   linkType: hard
 
@@ -739,11 +739,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@human-protocol/sdk@npm:^7.1.0":
-  version: 7.2.0
-  resolution: "@human-protocol/sdk@npm:7.2.0"
+"@human-protocol/sdk@npm:^7.3.0":
+  version: 7.3.0
+  resolution: "@human-protocol/sdk@npm:7.3.0"
   dependencies:
-    "@human-protocol/core": "npm:6.0.0"
+    "@human-protocol/core": "npm:7.0.0"
     axios: "npm:^1.4.0"
     ethers: "npm:~6.16.0"
     graphql: "npm:^16.8.1"
@@ -753,7 +753,7 @@ __metadata:
     secp256k1: "npm:^5.0.1"
     validator: "npm:^13.12.0"
     vitest: "npm:^4.0.18"
-  checksum: 10c0/7feac300575a4429f86b9602fd028edd543853d81198377d7a6b921548ba76b3fcb4b8a1f3611783a753b3b30620adcb94f53a8631dd060442eb20a5e382206d
+  checksum: 10c0/5835ce09161ab554483c6f9239f9985296491810b28a2f19adb090602c4436732b6787acb875ef2cf3fa9a6ca04ddecc620c52d5829f13a3cec1fd4dc85f1785
   languageName: node
   linkType: hard
 
@@ -3678,7 +3678,7 @@ __metadata:
     "@golevelup/ts-vitest": "npm:^4.0.0"
     "@hu-fi/subgraph-sdk": "npm:^5.0.0"
     "@human-protocol/logger": "npm:^1.3.0"
-    "@human-protocol/sdk": "npm:^7.1.0"
+    "@human-protocol/sdk": "npm:^7.3.0"
     "@nestjs/cli": "npm:^11.0.14"
     "@nestjs/common": "npm:^11.1.10"
     "@nestjs/config": "npm:^4.0.2"

--- a/recording-oracle/package.json
+++ b/recording-oracle/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@human-protocol/logger": "^1.3.0",
-    "@human-protocol/sdk": "^7.1.0",
+    "@human-protocol/sdk": "^7.3.0",
     "@nestjs/common": "^11.1.10",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.10",

--- a/recording-oracle/yarn.lock
+++ b/recording-oracle/yarn.lock
@@ -708,12 +708,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@human-protocol/core@npm:6.0.0":
-  version: 6.0.0
-  resolution: "@human-protocol/core@npm:6.0.0"
+"@human-protocol/core@npm:7.0.0":
+  version: 7.0.0
+  resolution: "@human-protocol/core@npm:7.0.0"
   peerDependencies:
-    ethers: ~6.15.0
-  checksum: 10c0/10316b23ed6987c75ca1276de85145200bd1190ac8116e5ce6dfad5c427b1b509db63457ba5849fb9c16477264fc521b6737af48cf4700edc968153e1f8e28f2
+    ethers: ~6.16.0
+  checksum: 10c0/b8083fca9b7fab0bca450b7a520cf9f0e8b3af29f4b90fc36ab1d3f24b2ff76aa53f3c3e160f7c40e7079aad6f32ebc67f5abaf8ad75eb77eee808fee7fd3955
   languageName: node
   linkType: hard
 
@@ -729,11 +729,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@human-protocol/sdk@npm:^7.1.0":
-  version: 7.2.0
-  resolution: "@human-protocol/sdk@npm:7.2.0"
+"@human-protocol/sdk@npm:^7.3.0":
+  version: 7.3.0
+  resolution: "@human-protocol/sdk@npm:7.3.0"
   dependencies:
-    "@human-protocol/core": "npm:6.0.0"
+    "@human-protocol/core": "npm:7.0.0"
     axios: "npm:^1.4.0"
     ethers: "npm:~6.16.0"
     graphql: "npm:^16.8.1"
@@ -743,7 +743,7 @@ __metadata:
     secp256k1: "npm:^5.0.1"
     validator: "npm:^13.12.0"
     vitest: "npm:^4.0.18"
-  checksum: 10c0/7feac300575a4429f86b9602fd028edd543853d81198377d7a6b921548ba76b3fcb4b8a1f3611783a753b3b30620adcb94f53a8631dd060442eb20a5e382206d
+  checksum: 10c0/5835ce09161ab554483c6f9239f9985296491810b28a2f19adb090602c4436732b6787acb875ef2cf3fa9a6ca04ddecc620c52d5829f13a3cec1fd4dc85f1785
   languageName: node
   linkType: hard
 
@@ -7563,7 +7563,7 @@ __metadata:
     "@faker-js/faker": "npm:^10.4.0"
     "@golevelup/ts-vitest": "npm:^4.0.0"
     "@human-protocol/logger": "npm:^1.3.0"
-    "@human-protocol/sdk": "npm:^7.1.0"
+    "@human-protocol/sdk": "npm:^7.3.0"
     "@nestjs/cli": "npm:^11.0.14"
     "@nestjs/common": "npm:^11.1.10"
     "@nestjs/config": "npm:^4.0.2"

--- a/reputation-oracle/package.json
+++ b/reputation-oracle/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@human-protocol/core": "^6.0.0",
     "@human-protocol/logger": "^1.3.0",
-    "@human-protocol/sdk": "^7.1.0",
+    "@human-protocol/sdk": "^7.3.0",
     "@nestjs/common": "^11.1.10",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.10",

--- a/reputation-oracle/package.json
+++ b/reputation-oracle/package.json
@@ -19,7 +19,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@human-protocol/core": "^6.0.0",
+    "@human-protocol/core": "^7.0.0",
     "@human-protocol/logger": "^1.3.0",
     "@human-protocol/sdk": "^7.3.0",
     "@nestjs/common": "^11.1.10",

--- a/reputation-oracle/yarn.lock
+++ b/reputation-oracle/yarn.lock
@@ -313,7 +313,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@human-protocol/core@npm:6.0.0, @human-protocol/core@npm:^6.0.0":
+"@human-protocol/core@npm:7.0.0":
+  version: 7.0.0
+  resolution: "@human-protocol/core@npm:7.0.0"
+  peerDependencies:
+    ethers: ~6.16.0
+  checksum: 10c0/b8083fca9b7fab0bca450b7a520cf9f0e8b3af29f4b90fc36ab1d3f24b2ff76aa53f3c3e160f7c40e7079aad6f32ebc67f5abaf8ad75eb77eee808fee7fd3955
+  languageName: node
+  linkType: hard
+
+"@human-protocol/core@npm:^6.0.0":
   version: 6.0.0
   resolution: "@human-protocol/core@npm:6.0.0"
   peerDependencies:
@@ -334,11 +343,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@human-protocol/sdk@npm:^7.1.0":
-  version: 7.2.0
-  resolution: "@human-protocol/sdk@npm:7.2.0"
+"@human-protocol/sdk@npm:^7.3.0":
+  version: 7.3.0
+  resolution: "@human-protocol/sdk@npm:7.3.0"
   dependencies:
-    "@human-protocol/core": "npm:6.0.0"
+    "@human-protocol/core": "npm:7.0.0"
     axios: "npm:^1.4.0"
     ethers: "npm:~6.16.0"
     graphql: "npm:^16.8.1"
@@ -348,7 +357,7 @@ __metadata:
     secp256k1: "npm:^5.0.1"
     validator: "npm:^13.12.0"
     vitest: "npm:^4.0.18"
-  checksum: 10c0/7feac300575a4429f86b9602fd028edd543853d81198377d7a6b921548ba76b3fcb4b8a1f3611783a753b3b30620adcb94f53a8631dd060442eb20a5e382206d
+  checksum: 10c0/5835ce09161ab554483c6f9239f9985296491810b28a2f19adb090602c4436732b6787acb875ef2cf3fa9a6ca04ddecc620c52d5829f13a3cec1fd4dc85f1785
   languageName: node
   linkType: hard
 
@@ -5151,7 +5160,7 @@ __metadata:
     "@golevelup/ts-vitest": "npm:^4.0.0"
     "@human-protocol/core": "npm:^6.0.0"
     "@human-protocol/logger": "npm:^1.3.0"
-    "@human-protocol/sdk": "npm:^7.1.0"
+    "@human-protocol/sdk": "npm:^7.3.0"
     "@nestjs/cli": "npm:^11.0.14"
     "@nestjs/common": "npm:^11.1.10"
     "@nestjs/config": "npm:^4.0.2"

--- a/reputation-oracle/yarn.lock
+++ b/reputation-oracle/yarn.lock
@@ -313,21 +313,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@human-protocol/core@npm:7.0.0":
+"@human-protocol/core@npm:7.0.0, @human-protocol/core@npm:^7.0.0":
   version: 7.0.0
   resolution: "@human-protocol/core@npm:7.0.0"
   peerDependencies:
     ethers: ~6.16.0
   checksum: 10c0/b8083fca9b7fab0bca450b7a520cf9f0e8b3af29f4b90fc36ab1d3f24b2ff76aa53f3c3e160f7c40e7079aad6f32ebc67f5abaf8ad75eb77eee808fee7fd3955
-  languageName: node
-  linkType: hard
-
-"@human-protocol/core@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "@human-protocol/core@npm:6.0.0"
-  peerDependencies:
-    ethers: ~6.15.0
-  checksum: 10c0/10316b23ed6987c75ca1276de85145200bd1190ac8116e5ce6dfad5c427b1b509db63457ba5849fb9c16477264fc521b6737af48cf4700edc968153e1f8e28f2
   languageName: node
   linkType: hard
 
@@ -5158,7 +5149,7 @@ __metadata:
     "@eslint/js": "npm:^10.0.1"
     "@faker-js/faker": "npm:^10.4.0"
     "@golevelup/ts-vitest": "npm:^4.0.0"
-    "@human-protocol/core": "npm:^6.0.0"
+    "@human-protocol/core": "npm:^7.0.0"
     "@human-protocol/logger": "npm:^1.3.0"
     "@human-protocol/sdk": "npm:^7.3.0"
     "@nestjs/cli": "npm:^11.0.14"


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Bumping HUMAN Protocol SDK in order to get latest subgraph URLs and avoid "bad indexers" errors that come from older versions.

## How has this been tested?
- [x] `yarn start` locally

## Release plan
Regular

## Potential risks; What to monitor; Rollback plan
No