### PR TITLE
[Campaign Launcher] feat: excluded non-spot markets

### DIFF
--- a/campaign-launcher/server/src/modules/exchanges/api-client/ccxt-exchange-client.ts
+++ b/campaign-launcher/server/src/modules/exchanges/api-client/ccxt-exchange-client.ts
@@ -78,9 +78,9 @@ export class CcxtExchangeClient extends BaseExchangeApiClient {
   protected get tradingPairs() {
     const spotTradingPairs: string[] = [];
 
-    for (const marketInfo of Object.values(this.ccxtClient.markets)) {
+    for (const marketInfo of Object.values(this.ccxtClient.markets || {})) {
       if (marketInfo.type === 'spot') {
-        spotTradingPairs.push(marketInfo.symbol as string);
+        spotTradingPairs.push(marketInfo.symbol);
       }
     }
 

--- a/campaign-launcher/server/src/modules/exchanges/api-client/ccxt-exchange-client.ts
+++ b/campaign-launcher/server/src/modules/exchanges/api-client/ccxt-exchange-client.ts
@@ -48,24 +48,9 @@ export class CcxtExchangeClient extends BaseExchangeApiClient {
         };
         break;
       }
-      case ExchangeName.MEXC: {
-        perExchangeClientOptions = {
-          options: {
-            fetchMarkets: {
-              types: {
-                spot: true,
-                swap: {
-                  linear: false,
-                  inverse: false,
-                },
-              },
-            },
-          },
-        };
-        break;
-      }
       case ExchangeName.BIGONE:
       case ExchangeName.BITMART:
+      case ExchangeName.MEXC:
       case ExchangeName.XT:
       default: {
         /**

--- a/campaign-launcher/server/src/modules/exchanges/api-client/ccxt-exchange-client.ts
+++ b/campaign-launcher/server/src/modules/exchanges/api-client/ccxt-exchange-client.ts
@@ -22,6 +22,8 @@ export class CcxtExchangeClient extends BaseExchangeApiClient {
     let perExchangeClientOptions: Record<string, unknown> = {};
 
     switch (exchangeName) {
+      case ExchangeName.BYBIT:
+      case ExchangeName.GATE:
       case ExchangeName.HYPERLIQUID: {
         perExchangeClientOptions = {
           options: {
@@ -30,6 +32,49 @@ export class CcxtExchangeClient extends BaseExchangeApiClient {
             },
           },
         };
+        break;
+      }
+      case ExchangeName.HTX: {
+        perExchangeClientOptions = {
+          options: {
+            fetchMarkets: {
+              types: {
+                spot: true,
+                linear: false,
+                inverse: false,
+              },
+            },
+          },
+        };
+        break;
+      }
+      case ExchangeName.MEXC: {
+        perExchangeClientOptions = {
+          options: {
+            fetchMarkets: {
+              types: {
+                spot: true,
+                swap: {
+                  linear: false,
+                  inverse: false,
+                },
+              },
+            },
+          },
+        };
+        break;
+      }
+      case ExchangeName.BIGONE:
+      case ExchangeName.BITMART:
+      case ExchangeName.XT:
+      default: {
+        /**
+         * Not possible to configure markets via options for some exchanges,
+         * so will have to filter them out after fetching.
+         *
+         * Even though we filter out later, keep config for those exchanges that support it
+         * to reduce the amount of data fetched from the exchange and also fetch correct currencies.
+         */
         break;
       }
     }
@@ -46,7 +91,15 @@ export class CcxtExchangeClient extends BaseExchangeApiClient {
   }
 
   protected get tradingPairs() {
-    return this.ccxtClient.symbols;
+    const spotTradingPairs: string[] = [];
+
+    for (const marketInfo of Object.values(this.ccxtClient.markets)) {
+      if (marketInfo.type === 'spot') {
+        spotTradingPairs.push(marketInfo.symbol as string);
+      }
+    }
+
+    return spotTradingPairs;
   }
 
   protected get currencies() {

--- a/campaign-launcher/server/types/ccxt.d.ts
+++ b/campaign-launcher/server/types/ccxt.d.ts
@@ -6,11 +6,17 @@
  */
 
 declare module 'ccxt' {
+  type MarketInfo = {
+    type: string | undefined;
+    symbol: string;
+    [x: string]: unknown;
+  };
+
   export interface Exchange {
     setSandboxMode(enabled: boolean): void;
     isSandboxModeEnabled: boolean;
     loadMarkets(reload = false): Promise<Record<string, unknown>>;
-    markets: Record<string, unknown>;
+    markets: Record<string, MarketInfo>;
     /**
      * 'undefined' until successfull call of 'loadMarkets'
      */


### PR DESCRIPTION
## Issue tracking
Freestyle

## Context behind the change
Under the hood of `loadMarkets` call also `swap`, `futures` and other markets types are loaded. We don't want to allow launching campaigns for those so exclude them.

## How has this been tested?
- [x] fetch markets for every enabled exchange and verify only spot markets displayed where possible

## Release plan
Merge & deploy, clear CL cache.

## Potential risks; What to monitor; Rollback plan
None.