### PR TITLE
[Campaign Launcher] fix: api keys schema validation

### DIFF
--- a/campaign-launcher/client/src/components/AddApiKeyDialog/index.tsx
+++ b/campaign-launcher/client/src/components/AddApiKeyDialog/index.tsx
@@ -56,11 +56,11 @@ export const validationSchema: yup.ObjectSchema<APIKeyFormValues> = yup.object({
     .string()
     .when('exchange', {
       is: 'kucoin',
-      then: (schema) => schema.required('Required'),
+      then: (schema) =>
+        schema.required('Required') && schema.min(7, 'Min 7 characters'),
       otherwise: (schema) => schema.optional(),
     })
     .trim()
-    .min(7, 'Min 7 characters')
     .max(32, 'Max 32 characters')
     .matches(/^\S*$/, 'No spaces allowed'),
   exchange: yup.string().required('Required'),

--- a/campaign-launcher/client/src/components/AddApiKeyDialog/index.tsx
+++ b/campaign-launcher/client/src/components/AddApiKeyDialog/index.tsx
@@ -56,8 +56,7 @@ export const validationSchema: yup.ObjectSchema<APIKeyFormValues> = yup.object({
     .string()
     .when('exchange', {
       is: 'kucoin',
-      then: (schema) =>
-        schema.required('Required') && schema.min(7, 'Min 7 characters'),
+      then: (schema) => schema.required('Required').min(7, 'Min 7 characters'),
       otherwise: (schema) => schema.optional(),
     })
     .trim()


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Bug introduced in https://github.com/Hu-Fi/hufi/pull/953/changes/09bb8be311f24a0f55a456697c567cfc778ba68c. 
When exchange is not `kucoin` the rule with `min` for `passphrase` is enforced anyway, not allowing to save/edit other keys, so in order to fix it we must enforce "min" and "required" validation only when `kucoin`.

## How has this been tested?
- [x] e2e locally: add kucoin keys, make sure validation is correct
- [x] e2e locally: add/edit bybit keys, make sure validation is correct and key can be added/edited

## Release plan
Together w/ PR where bug was introduced.

## Potential risks; What to monitor; Rollback plan
No