### PR TITLE
[Recording Oracle] fix: bitmart deposit address fetch

### DIFF
--- a/recording-oracle/src/modules/exchanges/api-client/ccxt/ccxt-exchange-client.spec.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/ccxt/ccxt-exchange-client.spec.ts
@@ -857,6 +857,39 @@ describe('CcxtExchangeClient', () => {
           },
         );
       });
+
+      test('should fetch deposit address info for ETH network on bitmart', async () => {
+        mockedCcxt[ExchangeName.BITMART] = vi.fn(
+          function MockedCcxtExchangeCtor() {
+            return mockedExchange;
+          },
+        );
+
+        const mockedAddressStructure = generateCcxtDepositAddressStructure();
+        mockedExchange.fetchDepositAddress.mockResolvedValueOnce(
+          mockedAddressStructure,
+        );
+
+        ccxtExchangeApiClient = new CcxtExchangeClient(ExchangeName.BITMART, {
+          apiKey: faker.string.sample(),
+          secret: faker.string.sample(),
+          userId: faker.string.uuid(),
+        });
+
+        const address = await ccxtExchangeApiClient.fetchDepositAddress(
+          mockedAddressStructure.currency,
+        );
+
+        expect(address).toEqual(mockedAddressStructure.address);
+
+        expect(mockedExchange.fetchDepositAddress).toHaveBeenCalledTimes(1);
+        expect(mockedExchange.fetchDepositAddress).toHaveBeenCalledWith(
+          mockedAddressStructure.currency,
+          {
+            network: 'ETH',
+          },
+        );
+      });
     });
   });
 });

--- a/recording-oracle/src/modules/exchanges/api-client/ccxt/ccxt-exchange-client.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/ccxt/ccxt-exchange-client.ts
@@ -322,6 +322,10 @@ export class CcxtExchangeClient implements ExchangeApiClient {
         fetchParams.network = 'Ethereum';
         break;
       }
+      case ExchangeName.BITMART: {
+        fetchParams.network = 'ETH';
+        break;
+      }
     }
 
     const response = await this.ccxtClient.fetchDepositAddress(

--- a/recording-oracle/src/modules/exchanges/api-client/ccxt/ccxt-exchange-client.ts
+++ b/recording-oracle/src/modules/exchanges/api-client/ccxt/ccxt-exchange-client.ts
@@ -318,10 +318,6 @@ export class CcxtExchangeClient implements ExchangeApiClient {
         }
         break;
       }
-      case ExchangeName.BIGONE: {
-        fetchParams.network = 'Ethereum';
-        break;
-      }
       case ExchangeName.BITMART: {
         fetchParams.network = 'ETH';
         break;


### PR DESCRIPTION
## Issue tracking
N/A

## Context behind the change
Recently found out that we can't get deposit address for `bitmart` anymore due to api error. After digging found out that it's related to `ccxt` version update: seems like now it uses `defaultNetworks` from exchange object if no network param provided and for `bitmart` it fails, so apply correct network param to fix the issue.

## How has this been tested?
- [x] added api key for `bitmart` locally via UI to make sure things work as expected

## Release plan
Just merge

## Potential risks; What to monitor; Rollback plan
No